### PR TITLE
DrivAerML: probe LR above 5e-4 under EMA+gc champion (5.5e-4, 6e-4)

### DIFF
--- a/BASELINE.md
+++ b/BASELINE.md
@@ -3,11 +3,20 @@
 ## TandemFoilSet
 
 - **Primary metric:** `val_primary/surface_pressure_mae` (= `val_eq4/surface_pressure_mae`)
-- **Current best:** 21.350 (val) at epoch 331 — test 23.195
-- **Best PR:** #3140 (usopp — gc=0.2+EMA=0.999, Lion lr=1.25e-4, T_max=10, WD=1e-2, 3L/192d)
-- **Reproduce:** `cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.2 --weight-decay 1e-2 --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --ema-decay 0.999`
+- **Current best:** 21.319 (val) at epoch 277 — test 22.868
+- **Best PR:** #3185 (fern — full noam stack: ANP+physics+T_max=150+Lookahead+compile+re-strat+96sl)
+- **Reproduce:** `cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 150 --grad-clip 0.2 --weight-decay 1e-2 --model-slices 96 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --enable-wake-deficit --enable-wake-angle --enable-vortex-panel-velocity --asinh-pressure --asinh-scale 0.75 --residual-prediction --enable-pressure-prior-addition --re-stratified-sampling --anp-srf --use-lookahead --compile-model --ema-decay 0.999 --epochs 999`
 
-### 2026-04-23 — PR #3140: TandemFoil: gc=0.2 + EMA=0.999 — NEW BEST (CURRENT)
+### 2026-04-24 — PR #3185: TandemFoil: full noam stack (ANP+physics+T_max=150+Lookahead+96sl) — NEW BEST (CURRENT)
+
+- **val_primary/surface_pressure_mae:** 21.319 (-0.15% vs 21.350) at epoch 277
+- **test_primary/surface_pressure_mae:** 22.868 (-1.41% vs 23.195)
+- **W&B run:** v05jt92n (fern/tf-full-noam-stack)
+- **Config:** Lion lr=1.25e-4, T_max=150, gc=0.2, WD=1e-2, EMA=0.999, 3L/192d, 96 slices, Lookahead(α=0.5,k=5), torch.compile, re-stratified sampling, ANP decoder, wake deficit + wake angle + vortex panel physics, asinh-scale=0.75
+- **Key insight:** Full noam feature stack outperforms the stripped champion. Extras (Lookahead, compile, 96 slices, re-stratified) only take effect after ep200 — T2 (ANP+physics only, T_max=10) led for first 180 epochs, then T1 pulled ahead. Late-training compounding effect. T_max=150 needed for full benefit; T_max=10 (T2) diverged at ep289.
+- **Reproduce:** `cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 150 --grad-clip 0.2 --weight-decay 1e-2 --model-slices 96 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --enable-wake-deficit --enable-wake-angle --enable-vortex-panel-velocity --asinh-pressure --asinh-scale 0.75 --residual-prediction --enable-pressure-prior-addition --re-stratified-sampling --anp-srf --use-lookahead --compile-model --ema-decay 0.999 --epochs 999`
+
+### 2026-04-23 — PR #3140: TandemFoil: gc=0.2 + EMA=0.999 — PREVIOUS BEST
 
 - **val_primary/surface_pressure_mae:** 21.350 (-2.6% vs 21.909) at epoch 331
 - **test_primary/surface_pressure_mae:** 23.195 (-1.0% vs 23.419)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -82,7 +82,7 @@
 - `#3166` vegeta: vol-weight=5.0/7.0+EMA=0.999
 - `#3156` edward: softer gc=0.5
 - `#3144` violet: vol-weight=2.0+EMA=0.999
-- `#NEW` megumi: DM EMA=0.9999/0.99995 (noam optimal decay) — BEING ASSIGNED
+- `#3199` megumi: DM EMA=0.9999/0.99995 (noam optimal decay) — NOAM ABLATION
 - `#3129` chrome: 4L/256d deeper
 - `#3101` tanjiro: vol-loss-weight=1.5 (SENT BACK)
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,8 +1,8 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 20:00 (advisor cycle 42 — closed #3132, assigning gohan)
+- **Date:** 2026-04-23 20:30 (advisor cycle 43 — closed #3134, assigning megumi)
 - **Branch:** radford
-- **Idle students:** 0 (gohan being assigned)
+- **Idle students:** 0 (megumi being assigned)
 - **PRs ready for review:** 0
 
 ## Fleet Status (56 active PRs → 59 after assignments)
@@ -82,7 +82,7 @@
 - `#3166` vegeta: vol-weight=5.0/7.0+EMA=0.999
 - `#3156` edward: softer gc=0.5
 - `#3144` violet: vol-weight=2.0+EMA=0.999
-- `#3134` megumi: vol-weight=30x
+- `#NEW` megumi: DM EMA=0.9999/0.99995 (noam optimal decay) — BEING ASSIGNED
 - `#3129` chrome: 4L/256d deeper
 - `#3101` tanjiro: vol-loss-weight=1.5 (SENT BACK)
 
@@ -189,6 +189,7 @@
 - EMA<0.999 (0.99, 0.995 both worse)
 - T_max≠50 (30 and 100 both worse)
 - Vol-weight=10x: worse on both metrics
+- Vol-weight=30x: catastrophic — surface 4.3x worse, vol 3.1x worse
 
 **TandemFoil:**
 - gc≥0.5: monotonically worse than gc=0.3

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,9 +1,10 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 15:30 (advisor cycle 90 — LAST DITCH RESTRUCTURING)
+- **Date:** 2026-04-24 16:15 (advisor cycle 92)
 - **Branch:** radford
-- **ACTIVE DIRECTIVE: Issue #3283 — Last Ditch Benchmark Push (~10 hours remaining)**
-- **Fleet restructuring IN PROGRESS:** killed 14 misaligned experiments, reassigning 15 students
+- **ACTIVE DIRECTIVE: Issue #3283 — Last Ditch Benchmark Push (~8 hours remaining)**
+- **Fleet restructured.** 36 DM / 12 AF / 11 TFP / 0 TF.
+- **Harness patches (#3284):** 5/6 implemented, sent back for merge-blocking bug fix. HIGHEST PRIORITY.
 
 ## BINDING DIRECTIVE — Issue #3283 (2026-04-24)
 
@@ -26,7 +27,7 @@ Re-run haku/tfp-t20-gc05-lr1e4 for 2-8 seeds (best_val=0.002466, best_test=0.002
 ## Fleet Status (restructuring in progress)
 
 ### INFRASTRUCTURE (1 PR)
-- `#3284` vegeta: HARNESS PATCHES (--load-checkpoint, --eval-interval, --ema-mode, --skip-update-grad-norm, --save-checkpoint, kill gates) — **HIGHEST PRIORITY**
+- `#3284` vegeta: HARNESS PATCHES — SENT BACK for merge-blocking bug (double best-tracking). 5/6 patches implemented. **HIGHEST PRIORITY — awaiting fix.**
 
 ### DrivAerML WIP (~28 continuing + 8 new = 36 target)
 **Champion recovery / truth lanes (newly assigned):**
@@ -38,6 +39,9 @@ Re-run haku/tfp-t20-gc05-lr1e4 for 2-8 seeds (best_val=0.002466, best_test=0.002
 - robin: gradient-spike-safe gc=0.25 (Bucket D)
 - nami: T_max=24 narrow schedule (Bucket E)
 - chrome: T_max=36 narrow schedule (Bucket E)
+
+**Breakout lanes (newly assigned):**
+- `#3299` zenitsu: Breakout 4 — coordinate normalization + geometry features (xyz_norm, normals, log_area, front-facing)
 
 **Continuing DM experiments (from pre-restructure):**
 - `#3244` faye: paper-facing full eval (SENT BACK for champion ckpt eval)
@@ -231,6 +235,7 @@ Re-run haku/tfp-t20-gc05-lr1e4 for 2-8 seeds (best_val=0.002466, best_test=0.002
 - Error-weighted surface sampling (hard example mining): crashed ep6 both trials (#3243). Distribution-shift collapse + 30-60min/epoch error-map compute + train/eval mismatch. Student note: error-weighted LOSS (not sampling) would avoid distribution shift but still faces mismatch.
 - Learnable register tokens (N=2/4/8): N=8 best 4.062% (+6%), N=2/N=4 NaN diverged (#3262). Category error — register tokens address pairwise attention sinks (ViT), but Transolver uses slice-based soft-clustering attention where sink mechanism doesn't apply.
 - Learnable Fourier frequencies: 5.262%/4.252% both diverged (#3260). Frequencies barely moved from init — fixed [0.5,2,8,32] are already near-optimal. Learnable freq + cosine restarts = cascading perturbation feedback loop.
+- Cosine similarity auxiliary loss: w=0.1→4.661% crashed ep244, w=0.5→6.569% crashed ep159 (#3276). Cos_sim saturates >0.99 by ep100 — spatially redundant with MSE. Near-unity cos_sim makes gradients ill-conditioned at LR restarts.
 - EMA>0.9995: 0.9999→7.106% NaN ep171, 0.99995→7.095% collapse ep120 (#3199). EMA=0.9995 sharp optimum bracketed both directions
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,8 +1,8 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 23:15 (advisor cycle 49)
+- **Date:** 2026-04-23 23:30 (advisor cycle 50)
 - **Branch:** radford
-- **Idle students:** 0
+- **Idle students:** 0 (shouko being assigned)
 - **PRs ready for review:** 0
 - **CRITICAL:** TFP champion config is BROKEN — code regression since #3025, seed=0 no longer reproduces (#3205). Waiting for sanji #3209 cp_panel bug fix.
 
@@ -29,7 +29,7 @@
 **Champion tuning / paper-facing:**
 - `#3209` sanji: TFP cp_panel bug fix + multi-seed retest — STABILIZATION PRIORITY
 - `#3164` faye: paper-facing full eval (two-phase) — PAPER-FACING Track 1
-- `#3163` shouko: attn dropout=0.05
+- `#3163` shouko: ~~attn dropout=0.05~~ → reassigning to AF GradNorm
 - `#3160` griffith: 16H heads
 - `#3155` nobara: longer T_max (45/60)
 - `#3207` historia: DM true monotonic cosine (T_max=393606) — corrected retest
@@ -184,7 +184,7 @@
 - Huber loss, relative L2 loss (degenerate), SGDR, RAdam
 - beta2≠0.999, LR≠5e-4 (without EMA), WD+gc heavy (WD=1e-3: 4.44%)
 - Bilateral symmetry aug, torch.compile, gradient accumulation
-- Attention dropout without EMA/gc: toxic combo with T_max=30
+- Attention dropout=0.05: incompatible at any stability level. Without EMA/gc→12.533%, with EMA+gc→10.118% (delayed divergence ep74 but same fate). Dropout noise compounds faster than gc clips.
 - Cosine eta_min without EMA/gc: diverges (7.255-7.918%)
 - eta_min+gc (any combination): gc=1.0→6.311%, gc=0.5→8.617%, gc=0.5+EMA→4.202% diverge ep312 — TRIPLE CONFIRMED. gc=0.5 relies on zero-LR trough damping; eta_min removes reset.
 - Surface points ≠50k: 16k=11.672%, 32k=7.558%, 64k=12.16% (even with EMA+gc) — 50k only viable count

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,8 +1,8 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 23:00 (advisor cycle 48)
+- **Date:** 2026-04-23 23:15 (advisor cycle 49)
 - **Branch:** radford
-- **Idle students:** 0 (5 being assigned)
+- **Idle students:** 0 (brook being reassigned)
 - **PRs ready for review:** 0
 - **CRITICAL:** TFP champion config is BROKEN — code regression since #3025, seed=0 no longer reproduces (#3205). Waiting for sanji #3209 cp_panel bug fix.
 
@@ -12,7 +12,7 @@
 **Innovation track (new physics-aware/ML ideas per directive):**
 - `#3216` canute: attention distance bias (ALiBi-inspired spatial prior) — INNOVATION
 - `#3214` kakashi: auxiliary gradient prediction (∂p/∂x,y,z) — INNOVATION
-- `#3213` brook: surface normal input features — INNOVATION
+- `#3213` brook: Fourier encoding of surface normals — INNOVATION (reassigned)
 - `#3203` vegeta: attention temperature annealing — INNOVATION
 - `#3202` senku: GLU preprocess MLP — INNOVATION
 - `#3201` jet: DomainLayerNorm — INNOVATION
@@ -151,7 +151,7 @@
 - DomainLayerNorm — jet #3201 (merged; awaiting results)
 
 **New physics-aware/ML ideas (cycle 48):**
-- Surface normal input features (local geometry context) — brook #3213
+- Fourier encoding of surface normals (angular frequency features) — brook #3213 (reassigned)
 - Auxiliary gradient prediction (∂p/∂x,y,z as regularization) — kakashi #3214
 - Attention distance bias (ALiBi-inspired spatial prior) — canute #3216
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 17:30 (advisor cycle 94)
+- **Date:** 2026-04-24 19:00 (advisor cycle 97)
 - **Branch:** radford
 - **ACTIVE DIRECTIVE: Issue #3283 — Last Ditch Benchmark Push (~6-7 hours remaining)**
 - **Fleet:** 59 students active. 36 DM / 12 AF / 11 TFP / 0 TF.
@@ -30,9 +30,9 @@ Re-run haku/tfp-t20-gc05-lr1e4 for 2-8 seeds (best_val=0.002466, best_test=0.002
 **Breakout lanes:**
 - `#3300` vegeta: **Breakout 1** — AB-UPT-style anchored decoder (geometry supernodes → surface anchor cross-attention → point decoding)
 - `#3299` zenitsu: **Breakout 4** — coordinate normalization + geometry features (xyz_norm using geometry_center/scale, normals, log_area, front-facing indicator)
-- `#3301` brook: **Breakout 3** — domain-normalized volume auxiliary (fix normalization bug at line 790, separate surface/volume TargetTransform, vol_loss_weight 0.03/0.1/0.3)
-- **Breakout 2** (metric-aware fine-tune: mse_z + raw rel-L2) — NOT YET ASSIGNED
-- **Breakout 5** (train+val retrain) — NOT YET ASSIGNED
+- `#3301` brook: **Breakout 3** — domain-normalized volume auxiliary (round 2: relaxed kill gate, w=0.03/0.01 + surface-only control)
+- `#3302` canute: **Breakout 2** — metric-aware MSE + raw-rel-L2 loss (dm_rel_l2_weight 0.02/0.05/0.1)
+- **Breakout 5** (train+val retrain) — NOT YET ASSIGNED (only +8.5% data: 400→434 cases)
 
 **Champion recovery / truth lanes:**
 - `#3293` norman: champion recovery seed=0 no-compile (Bucket A)
@@ -51,7 +51,7 @@ Re-run haku/tfp-t20-gc05-lr1e4 for 2-8 seeds (best_val=0.002466, best_test=0.002
 - `#3267` mitsuha: SwiGLU FFN
 - `#3265` alphonse: hidden-space noise
 - ~~`#3276` zenitsu: cosine similarity loss~~ CLOSED dead end
-- `#3275` canute: local attention
+- ~~`#3275` canute: local attention~~ CLOSED dead end → reassigned to Breakout 2 (#3302)
 - `#3271` nobara: LLRD
 - `#3251` fern: Pre-LayerNorm
 - `#3249` shouko: decaying WD

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 00:15 (advisor cycle 53)
+- **Date:** 2026-04-24 00:30 (advisor cycle 54)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -12,7 +12,7 @@
 **Innovation track (new physics-aware/ML ideas per directive):**
 - `#3224` fern: spectral normalization on attention layers — INNOVATION
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
-- `#3216` canute: attention distance bias (ALiBi-inspired spatial prior) — INNOVATION
+- canute: self-distillation with EMA teacher — INNOVATION (PR pending)
 - `#3214` kakashi: auxiliary gradient prediction (∂p/∂x,y,z) — INNOVATION
 - `#3217` brook: Fourier encoding of surface normals — INNOVATION
 - `#3203` vegeta: attention temperature annealing — INNOVATION
@@ -21,10 +21,10 @@
 
 **Noam-pivot experiments:**
 - `#3199` megumi: EMA=0.9999/0.99995 (noam optimal decay) — NOAM ABLATION
-- `#3192` casca: asinh-pressure alone (scale=0.75/0.5) — NOAM ABLATION
+- casca: → AF focal-MSE volume loss (PR pending)
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3194` bulma: higher LR sweep (5.5e-4/6e-4)
-- `#3188` chihiro: 2H/16H heads sweep — NOAM ABLATION
+- chihiro: → AF vol-weight curriculum (PR pending)
 - `#3181` himmel: asinh+residual on champion — NOAM ABLATION
 - `#3219` hinata: SAM optimizer (flat-basin restart robustness) — INNOVATION
 
@@ -52,7 +52,7 @@
 - `#3197` gojo: residual-prediction alone — NOAM ABLATION
 - `#3196` zenitsu: EMA decay sweep (0.9999/0.99995) — NOAM ABLATION
 - `#3189` emma: asinh+physics features — NOAM ABLATION
-- `#3180` chopper: ANP decoder alone — NOAM ABLATION
+- chopper: → DM weight perturbation at troughs (PR pending)
 - `#3150` yuji: clean test row — PAPER-FACING
 
 ### TandemFoil Paper WIP (9 PRs) — STABILIZATION CRISIS
@@ -180,7 +180,9 @@
 - OneCycleLR (no troughs): 8.04% best, sustained high-LR warmup worse than cosine peaks (without EMA+gc)
 - SWA: equal-weight averaging poisons across divergent basins (88.98%)
 - T_max≠30: ALL tested — 15→4.406%, 20→4.943%, 30→3.833% CHAMPION, 45→4.638%, 50→diverge, 60→4.409%. T_max=30 is definitive sweet spot
-- Noam feature stack on DM: full stack→4.447%, asinh-only→4.421%, residual-only→4.651%/15.0%(crashed). All diverge. Features tuned for T_max=150/3H/no-gc regime. Residual-pred requires asinh as hard prerequisite; even combined→3.999% (doesn't beat 3.833%)
+- Noam features on DM: DEFINITIVELY DEAD. Asinh triple-confirmed (4.072%/4.421%/4.475%), residual needs asinh+still→3.999%, full stack→4.447%. Features tuned for T_max=150/3H/no-gc regime
+- Attention distance bias (ALiBi): linear diverges, log=5.511% at timeout. Redundant with slice-based spatial grouping
+- Head count sweep complete: 2H=catastrophic, 4H=6.650%, 8H=3.833% CHAMPION, 16H=4.099%. 8H (64d/head) is definitive
 - 10-ep warmup+gc=1.0: 11.2% then diverged
 - 5-ep warmup+gc=1.0: pending (chopper)
 - LR warmup + EMA+gc=0.5: 5-ep=11.325% diverged, 10-ep=3.918% plateaued (didn't beat 3.833%)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,11 +1,11 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 20:30 (advisor cycle 43 — closed #3134, assigning megumi)
+- **Date:** 2026-04-23 (advisor cycle 44 — gilbert assigned af-vol-15x-clean #3204)
 - **Branch:** radford
-- **Idle students:** 0 (megumi being assigned)
+- **Idle students:** 0 (gilbert assigned: #3204 af-vol-15x-clean — vol-weight=15x/20x clean control)
 - **PRs ready for review:** 0
 
-## Fleet Status (56 active PRs → 59 after assignments)
+## Fleet Status (57 active PRs)
 
 ### DrivAerML WIP (30 PRs)
 **Noam-pivot experiments (highest priority):**
@@ -35,7 +35,6 @@
 - `#3110` einar: beta2=0.99/0.995
 - `#3109` guts: lr=4e-4 full-eval
 - `#3085` kohaku: larger supernodes (SENT BACK — retry+gc=1.0)
-- `#3083` jet: max-train-batches=600
 - `#3197` gojo: TF residual-prediction alone — NOAM ABLATION
 - `#3076` frieren: log-cosh loss (SENT BACK — retry+gc=1.0)
 - `#3067` askeladd: 32k surface points (SENT BACK — add max-eval-batches 200)
@@ -55,7 +54,7 @@
 
 ### TandemFoil Paper WIP (10 PRs)
 **Noam-pivot experiments (highest priority):**
-- `#3190` brook: physics features only (wake/vortex/Cp, no ANP) — NOAM ABLATION
+- `#3200` brook: TFP stabilization diagnostic (20-ep probes) — STABILIZATION
 - `#3183` rei: ANP+T_max=150 — NOAM ABLATION
 - `#3179` usopp: T_max=150+wake+96sl+Lookahead — NOAM ABLATION
 - `#3176` mitsuha: full noam stack — NOAM ABLATION
@@ -78,6 +77,7 @@
 **Other:**
 - `#3172` robin: LR warmup (5-ep/10-ep)
 - `#3169` nami: heads sweep 4H/16H
+- `#3204` gilbert: vol-weight=15x/20x clean control (no extra features) — AF VOLUME FOCUS
 - `#3167` gilbert: higher LR (8e-4/1e-3)
 - `#3166` vegeta: vol-weight=5.0/7.0+EMA=0.999
 - `#3156` edward: softer gc=0.5

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -25,7 +25,7 @@
 
 **Champion tuning / paper-facing:**
 - `#3173` kakashi: shorter cosine T_max=15/20
-- `#NEW` sanji: TFP cp_panel bug fix + multi-seed retest — STABILIZATION PRIORITY
+- `#3209` sanji: TFP cp_panel bug fix + multi-seed retest — STABILIZATION PRIORITY
 - `#3164` faye: paper-facing full eval (two-phase) — PAPER-FACING Track 1
 - `#3163` shouko: attn dropout=0.05
 - `#3161` spike: eta_min=1e-5 (cosine floor)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 11:45 (advisor cycle 83)
+- **Date:** 2026-04-24 12:15 (advisor cycle 84)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -25,7 +25,7 @@
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3228` chopper: stochastic weight perturbation at cosine troughs — INNOVATION
 - `#3265` alphonse: hidden-space noise regularization (post-Fourier perturbation σ=0.01/0.05) — INNOVATION
-- `#3253` canute: input feature dropout (Fourier channel dropout 10%/20%) — INNOVATION
+- `#3275` canute: local/windowed attention (KNN-restricted, K=512/2048 neighbors) — INNOVATION
 - `#3264` vegeta: Weight Standardization on linear layers (bs=1 loss smoothing, Qiao 2019) — INNOVATION
 - `#3202` senku: GLU preprocess MLP — INNOVATION
 - `#3201` jet: DomainLayerNorm — INNOVATION
@@ -84,7 +84,7 @@
 **Other:**
 - `#3172` robin: LR warmup — SENT BACK (confounded config, re-running with correct champion config)
 - `#3169` nami: heads sweep 4H/16H
-- `#3254` norman: multi-seed champion run (seeds 42/123/789) — AF VOLUME FOCUS
+- `#3274` norman: Lion optimizer under vol-10x+EMA (lr=5e-5/1e-4/2e-4 sweep) — AF VOLUME FOCUS
 - `#3238` rei: WD=0 ablation on vol-10x+EMA champion — AF VOLUME FOCUS
 - `#3245` tanjiro: per-channel volume loss weighting (upweight nut×4, p×2) — AF VOLUME FOCUS
 - `#3211` spike: AF vol_loss_scale learnable scalar (noam port) — AF VOLUME FOCUS
@@ -201,6 +201,7 @@
 - Weight Standardization: 67.9%/71.4% catastrophic (#3264). WS × cosine restarts × bs=1 feedback loop. Original BiT paper used epoch-level decay not per-batch restarts
 - SGDR eta_mult (decaying restart LR): 4.153%/12.64% (#3248). Confounded by switching to warm restarts. Sharp restart jumps more destabilizing than baseline's smooth cosine
 - Sparse MoE FFN (K=4/8, top-2): 5.09%/5.35% (#3263). 1.7-2.2x throughput penalty → epoch starvation. Routing collapses to uniform. Per-epoch curve parallel to dense — FFN is not the bottleneck
+- Input feature dropout (Fourier channels): p=0.1→4.73%, p=0.2→4.82% (#3253). Input-level dropout = information destruction. All 4 Fourier bands essential. Terminal divergence at both dropout rates
 - EMA>0.9995: 0.9999→7.106% NaN ep171, 0.99995→7.095% collapse ep120 (#3199). EMA=0.9995 sharp optimum bracketed both directions
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete
@@ -243,6 +244,7 @@
 - Vol-weight warm-up (1x→10x ramp): 2/3 collapsed, best stable +28% surface/+69% vol (#3232). Cosine restarts inject LR peak when vol-weight ramps — destructive. Static 10x TRIPLE-CONFIRMED
 - Focal-MSE volume loss (error-based reweighting): gamma=2 +392%/+3993%, gamma=1 +222%/+320% (#3227). Batch-max normalization non-stationary + freestream scaffolding destroyed
 - Additive BL auxiliary volume loss (SDF targeting): all 3 trials +31-228% both metrics (#3239). SDF<0.05 captures 61% of vol points on AF meshes — "BL targeting" ≈ uniform upscaling. Pattern confirmed with #3222
+- Multi-seed champion (seeds 42/123/789): all worse than seed=0 baseline (#3254). Seed 42 diverged, 123/789 +39-76% vol. Champion config has high seed sensitivity — seed=0 is lucky initialization
 - 3L depth (with or without EMA): catastrophic divergence confirmed twice
 - 2L/384d and 3L/384d: catastrophic divergence
 - EMA>0.9995 (0.9999/0.99995 both ~85% worse, diverge early, #3199). EMA=0.9995 bracketed as sharp optimum with steep cliffs both directions

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 07:00 (advisor cycle 68)
+- **Date:** 2026-04-24 07:30 (advisor cycle 69)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -21,7 +21,7 @@
 - `#3252` mitsuha: progressive surface point training (resolution curriculum) — INNOVATION
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3228` chopper: stochastic weight perturbation at cosine troughs — INNOVATION
-- `#3225` canute: self-distillation with EMA teacher — INNOVATION
+- `#3253` canute: input feature dropout (Fourier channel dropout 10%/20%) — INNOVATION
 - `#3202` senku: GLU preprocess MLP — INNOVATION
 - `#3201` jet: DomainLayerNorm — INNOVATION
 
@@ -85,7 +85,7 @@
 - `#3169` nami: heads sweep 4H/16H
 - `#3227` casca: focal-MSE volume loss (upweight hard predictions) — AF VOLUME FOCUS
 - `#3226` chihiro: volume weight curriculum (20x→10x) — AF VOLUME FOCUS
-- `#3223` norman: volume smoothness regularization — AF VOLUME FOCUS
+- `#3254` norman: multi-seed champion run (seeds 42/123/789) — AF VOLUME FOCUS
 - `#3238` rei: WD=0 ablation on vol-10x+EMA champion — AF VOLUME FOCUS
 - `#3245` tanjiro: per-channel volume loss weighting (upweight nut×4, p×2) — AF VOLUME FOCUS
 - `#3211` spike: AF vol_loss_scale learnable scalar (noam port) — AF VOLUME FOCUS
@@ -191,6 +191,7 @@
 - Fourier-encoded surface normals: 4.374%/4.454% (4 bands/2 bands). Normals are unit vectors in [-1,1] — don't benefit from Fourier lifting like unbounded coords. More bands = earlier divergence
 - Snapshot ensemble (cosine trough checkpoints): test=6.044% single best, WORSE with more snapshots (K=3→6.24%, K=5→6.98%, K=6→7.81%). Quality gradient dominates diversity. EMA already provides implicit smoothing.
 - Spectral norm on QKV: 4.035% (+5.3%). σ=1 cap over-restricts attention capacity. Late collapse ep502 from unconstrained FFN layers. gc=0.5 already solves restart stability.
+- Self-distillation via EMA teacher: α=0.3→6.446% diverge ep170, α=0.1→4.323% diverge ep400. EMA=0.9995 lag creates destabilizing feedback loop. Same EMA for ckpt+teacher incompatible.
 - Attention temperature annealing: 4.024% (+5% vs 3.833%). External annealed τ compounds with existing learnable per-head τ. noam result doesn't transfer
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete
@@ -224,6 +225,7 @@
 - asinh-pressure: DEFINITIVELY DEAD — 5 independent confirmations (#3191 T1/T2, #3177 T1/T2/T3). sinh() denormalization exponentially amplifies pressure errors. Non-pressure channels fine. Incompatible with AF pressure distribution.
 - PCGrad gradient surgery: 5-6x worse on both metrics (#3212). retain_graph=True disables torch.compile (40% throughput loss). Gradient conflict is NOT the bottleneck.
 - GradNorm adaptive loss balancing: surface 1.74x worse, vol 2.64x worse (#3218). retain_graph=True breaks compile (halves throughput). GradNorm converges to w_vol~8x, LOWER than hand-tuned 10x — fights intentional asymmetry
+- Volume smoothness regularization (KNN): ALL 4 trials regressed both metrics 44-97% (#3223). KNN Euclidean smoothness penalizes legitimate BL/wake/shear gradients. Even λ=1e-4 harmful
 - Proximity-weighted volume loss: 118-2516% worse (#3222). Extreme weight ratios starve far-field gradients while overdriving near-surface. Structural failure at scale=0.1/eps=0.01
 - Huber loss on volume channel: no improvement over MSE on either metric (#3215). AF volume residuals are well-behaved, not heavy-tailed — Huber δ threshold adds no benefit
 - 3L depth (with or without EMA): catastrophic divergence confirmed twice

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 13:15 (advisor cycle 86)
+- **Date:** 2026-04-24 13:35 (advisor cycle 87)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -14,10 +14,10 @@
 - `#3262` megumi: learnable register tokens N=2/4/8 (attention sink absorption, Darcet NeurIPS 2024) — INNOVATION
 - `#3260` casca: learnable Fourier frequency magnitudes (meta-learned encoding) — INNOVATION
 - `#3270` brook: FiLM conditioning on global geometry statistics (per-car shape context) — INNOVATION
-- `#3243` jet: prediction-error-weighted surface sampling (hard example mining) — INNOVATION
+- `#3280` jet: per-channel output heads (separate MLPs for Ux, Uy, p) — INNOVATION
 - `#3242` historia: label smoothing / target noise augmentation — INNOVATION
 - `#3235` kakashi: multi-exit prediction (aux losses at intermediate layers) — INNOVATION
-- `#3273` gojo: Grouped Query Attention (GQA, 2/4 KV heads) — throughput-focused INNOVATION
+- `#3279` gojo: ReLU² activation in FFN (Primer-style squared ReLU for sparser features) — INNOVATION
 - `#3251` fern: Pre-LayerNorm architecture ablation (+ RMSNorm variant) — INNOVATION
 - `#3276` zenitsu: cosine similarity auxiliary loss (spatial pattern fidelity, w=0.1/0.5) — INNOVATION
 - `#3269` emma: learned error correction head (boosting-inspired self-correction) — INNOVATION
@@ -204,6 +204,8 @@
 - Input feature dropout (Fourier channels): p=0.1→4.73%, p=0.2→4.82% (#3253). Input-level dropout = information destruction. All 4 Fourier bands essential. Terminal divergence at both dropout rates
 - Curvature-weighted loss: alpha=1.0→4.48% diverge ep300, alpha=0.5→11.6% diverge ep53 (#3259). Train/eval mismatch (weighted vs uniform metric) + curvature amplifies gradient variance at restarts
 - Quadratic position features (x²/y²/z²/xy/xz/yz): 6.643% at ep168 timeout (#3272). Fatal 3x throughput penalty (168 vs 511 baseline epochs). Quad-only diverged ep63 — Fourier PE irreplaceable. Same epoch-starvation pattern as MoE (#3263).
+- Grouped Query Attention (GQA, 2/4 KV heads): 12.88%/6.88% both crashed (#3273). Throughput-neutral (bottleneck is slice routing einsums, not QKV). GQA destabilizes per-head slice routing — coupled KV sharing explodes at cosine restarts.
+- Error-weighted surface sampling (hard example mining): crashed ep6 both trials (#3243). Distribution-shift collapse + 30-60min/epoch error-map compute + train/eval mismatch. Student note: error-weighted LOSS (not sampling) would avoid distribution shift but still faces mismatch.
 - EMA>0.9995: 0.9999→7.106% NaN ep171, 0.99995→7.095% collapse ep120 (#3199). EMA=0.9995 sharp optimum bracketed both directions
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 05:30 (advisor cycle 64)
+- **Date:** 2026-04-24 06:00 (advisor cycle 66)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -33,7 +33,7 @@
 - `#3209` sanji: TFP cp_panel bug fix + multi-seed retest — STABILIZATION PRIORITY
 - `#3244` faye: DM Track 1 paper-facing full eval (champion config, NO --max-eval-batches) — PAPER-FACING Track 1
 - `#3160` griffith: 16H heads
-- `#3237` nobara: snapshot ensemble at cosine troughs (test-time averaging) — INNOVATION
+- `#3248` nobara: decaying peak LR at cosine restarts (SGDR eta_mult) — INNOVATION
 - `#3152` eren: EMA decay sweep (0.999 vs 0.9995)
 - `#3146` taki: top-5 checkpoint averaging
 - `#3143` thorfinn: Lookahead(AdamW)
@@ -189,6 +189,7 @@
 - Auxiliary gradient prediction (∂p/∂x,y,z): kNN targets too noisy — aux_weight=0.1 diverges ep22, aux_weight=0.01 best 5.485% (+43%). Noise dominates once primary loss flattens
 - Mixup regularization (buffer-based latent): 85-109% worse, crashed ~ep235. Buffer staleness + non-smooth geometry-specific latent space fundamentally incompatible with bs=1
 - Fourier-encoded surface normals: 4.374%/4.454% (4 bands/2 bands). Normals are unit vectors in [-1,1] — don't benefit from Fourier lifting like unbounded coords. More bands = earlier divergence
+- Snapshot ensemble (cosine trough checkpoints): test=6.044% single best, WORSE with more snapshots (K=3→6.24%, K=5→6.98%, K=6→7.81%). Quality gradient dominates diversity. EMA already provides implicit smoothing.
 - Attention temperature annealing: 4.024% (+5% vs 3.833%). External annealed τ compounds with existing learnable per-head τ. noam result doesn't transfer
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 02:30 (advisor cycle 58)
+- **Date:** 2026-04-24 03:00 (advisor cycle 59)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -71,6 +71,7 @@
 - `#3230` alphonse: residual-prediction + re-stratified sampling (NO asinh) — CLEAN NOAM ABLATION
 
 **Volume closure experiments:**
+- `#3236` gohan: Lookahead(AdamW) + torch.compile on vol-10x champion — AF VOLUME FOCUS
 - `#3234` jin: lower LR sweep (5e-4/4e-4) on vol-10x champion — AF VOLUME FOCUS
 - `#3232` nezuko: vol-weight warm-up schedule (1x→10x linear ramp over 200ep) — AF VOLUME FOCUS
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 12:15 (advisor cycle 84)
+- **Date:** 2026-04-24 12:45 (advisor cycle 85)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -19,7 +19,7 @@
 - `#3235` kakashi: multi-exit prediction (aux losses at intermediate layers) — INNOVATION
 - `#3273` gojo: Grouped Query Attention (GQA, 2/4 KV heads) — throughput-focused INNOVATION
 - `#3251` fern: Pre-LayerNorm architecture ablation (+ RMSNorm variant) — INNOVATION
-- `#3259` zenitsu: curvature-weighted loss (per-point weighting by local curvature) — INNOVATION
+- `#3276` zenitsu: cosine similarity auxiliary loss (spatial pattern fidelity, w=0.1/0.5) — INNOVATION
 - `#3269` emma: learned error correction head (boosting-inspired self-correction) — INNOVATION
 - `#3267` mitsuha: SwiGLU FFN activation (replace GELU with gated linear unit) — INNOVATION
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
@@ -202,6 +202,7 @@
 - SGDR eta_mult (decaying restart LR): 4.153%/12.64% (#3248). Confounded by switching to warm restarts. Sharp restart jumps more destabilizing than baseline's smooth cosine
 - Sparse MoE FFN (K=4/8, top-2): 5.09%/5.35% (#3263). 1.7-2.2x throughput penalty → epoch starvation. Routing collapses to uniform. Per-epoch curve parallel to dense — FFN is not the bottleneck
 - Input feature dropout (Fourier channels): p=0.1→4.73%, p=0.2→4.82% (#3253). Input-level dropout = information destruction. All 4 Fourier bands essential. Terminal divergence at both dropout rates
+- Curvature-weighted loss: alpha=1.0→4.48% diverge ep300, alpha=0.5→11.6% diverge ep53 (#3259). Train/eval mismatch (weighted vs uniform metric) + curvature amplifies gradient variance at restarts
 - EMA>0.9995: 0.9999→7.106% NaN ep171, 0.99995→7.095% collapse ep120 (#3199). EMA=0.9995 sharp optimum bracketed both directions
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 18:00 (advisor cycle 39 — closed #3068/#3066/#3064, assigned brook/alphonse/casca)
+- **Date:** 2026-04-23 18:30 (advisor cycle 40 — closed #3159/#3158, assigning franky/bulma)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -22,8 +22,8 @@
 - `#3163` shouko: attn dropout=0.05
 - `#3161` spike: eta_min=1e-5 (cosine floor)
 - `#3160` griffith: 16H heads
-- `#3159` franky: 4L/640d wider
-- `#3158` bulma: lr=4e-4
+- `#NEW` franky: DM residual-prediction alone — BEING ASSIGNED
+- `#NEW` bulma: DM higher LR sweep (5.5e-4/6e-4) — BEING ASSIGNED
 - `#3155` nobara: longer T_max (45/60)
 - `#3154` historia: monotonic cosine (no restarts)
 - `#3152` eren: EMA decay sweep (0.999 vs 0.9995)
@@ -169,6 +169,8 @@
 - Attention dropout without EMA/gc: toxic combo with T_max=30
 - Cosine eta_min without EMA/gc: diverges (7.255-7.918%)
 - Surface points ≠50k: 16k=11.672%, 32k=7.558%, 64k=12.16% (even with EMA+gc) — 50k only viable count
+- 4L/640d at lr=5e-4: 8.636% then diverge ep82 even with EMA+gc (grad_norm=Infinity)
+- lr<5e-4 under EMA: steep monotonic cliff (4.5e-4=4.134%, 4e-4=5.924%)
 
 **TandemFoil Paper:**
 - T_max≠10 (all directions diverge)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 09:45 (advisor cycle 76)
+- **Date:** 2026-04-24 10:00 (advisor cycle 77)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -24,7 +24,7 @@
 - `#3252` mitsuha: progressive surface point training (resolution curriculum) — INNOVATION
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3228` chopper: stochastic weight perturbation at cosine troughs — INNOVATION
-- `#3256` alphonse: coordinate noise augmentation (σ=0.001/0.005 input perturbation) — INNOVATION
+- `#3265` alphonse: hidden-space noise regularization (post-Fourier perturbation σ=0.01/0.05) — INNOVATION
 - `#3253` canute: input feature dropout (Fourier channel dropout 10%/20%) — INNOVATION
 - `#3264` vegeta: Weight Standardization on linear layers (bs=1 loss smoothing, Qiao 2019) — INNOVATION
 - `#3202` senku: GLU preprocess MLP — INNOVATION
@@ -192,6 +192,7 @@
 - Pressure gradient smoothness reg (KNN): λ=0.01→4.481%, λ=0.1→4.876%, λ=1.0→12.52%. KNN 30% throughput overhead + sharp car features penalized. Remaining error is systematic bias, not noise.
 - Attention temperature annealing: 4.024% (+5% vs 3.833%). External annealed τ compounds with existing learnable per-head τ. noam result doesn't transfer
 - Stochastic depth/LayerDrop: p=0.1→4.317%, p=0.2→4.217%, p=0.3→4.411% (#3233). Only 4 layers — dropping 1 removes 25% capacity. Too coarse. EMA+gc already handles stability
+- Coordinate noise augmentation: σ=0.001→6.45% crashed, σ=0.005→21.44% Inf grads (#3256). Fourier freqs up to 32.0 amplify coord noise 32x. Structurally incompatible with Fourier PE
 - EMA>0.9995: 0.9999→7.106% NaN ep171, 0.99995→7.095% collapse ep120 (#3199). EMA=0.9995 sharp optimum bracketed both directions
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 10:15 (advisor cycle 78)
+- **Date:** 2026-04-24 10:45 (advisor cycle 79)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -74,7 +74,7 @@
 - `#3255` gohan: no-Lookahead/no-compile champion full budget — AF VOLUME FOCUS (critical ablation follow-up)
 - `#3257` chihiro: extended training via reduced eval frequency (every 3/5 epochs) — AF VOLUME FOCUS
 - `#3241` hinata: T_max=75 + vol-weight=10x/12x on champion — AF VOLUME FOCUS (schedule gap-fill)
-- `#3234` jin: lower LR sweep (5e-4/4e-4) on vol-10x champion — AF VOLUME FOCUS
+- `#3268` jin: higher LR sweep (7e-4/8e-4) on vol-10x+EMA champion — AF VOLUME FOCUS
 
 **Noam-pivot experiments (asinh-dependent — likely to fail):**
 - `#3187` stark: asinh+residual on vol-10x champion — NOAM ABLATION (asinh confirmed dead for AF)
@@ -245,7 +245,8 @@
 - Vol-weight<10x (1.5x/2x/3x/5x/7x): ALL worse on both metrics across 6 tested values. 10x+EMA=0.999 is AF sweet spot
 - Vol-weight=30x: catastrophic — surface 4.3x worse, vol 3.1x worse
 - Vol-weight=15x: surface +19%, vol +67% (#3204). Vol-weight=20x: crashed ep381 (#3204). 10x is definitive AF operating point
-- LR>6e-4: 8e-4 +110% surface, 1e-3 catastrophic divergence
+- LR>6e-4 (pre-EMA): 8e-4 +110% surface, 1e-3 catastrophic divergence
+- LR<6e-4 (with EMA+vol-10x): 5e-4 +66%/+111%, 4e-4 +38%/+76% (#3234). Underfitting under vol-10x amplification. lr=6e-4 bracketed from below
 
 **TandemFoil:**
 - gc≥0.5: monotonically worse than gc=0.3

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -2,7 +2,7 @@
 
 - **Date:** 2026-04-23 23:15 (advisor cycle 49)
 - **Branch:** radford
-- **Idle students:** 0 (brook being reassigned)
+- **Idle students:** 0
 - **PRs ready for review:** 0
 - **CRITICAL:** TFP champion config is BROKEN — code regression since #3025, seed=0 no longer reproduces (#3205). Waiting for sanji #3209 cp_panel bug fix.
 
@@ -12,7 +12,7 @@
 **Innovation track (new physics-aware/ML ideas per directive):**
 - `#3216` canute: attention distance bias (ALiBi-inspired spatial prior) — INNOVATION
 - `#3214` kakashi: auxiliary gradient prediction (∂p/∂x,y,z) — INNOVATION
-- `#3213` brook: Fourier encoding of surface normals — INNOVATION (reassigned)
+- `#3217` brook: Fourier encoding of surface normals — INNOVATION
 - `#3203` vegeta: attention temperature annealing — INNOVATION
 - `#3202` senku: GLU preprocess MLP — INNOVATION
 - `#3201` jet: DomainLayerNorm — INNOVATION
@@ -151,7 +151,7 @@
 - DomainLayerNorm — jet #3201 (merged; awaiting results)
 
 **New physics-aware/ML ideas (cycle 48):**
-- Fourier encoding of surface normals (angular frequency features) — brook #3213 (reassigned)
+- Fourier encoding of surface normals (angular frequency features) — brook #3217
 - Auxiliary gradient prediction (∂p/∂x,y,z as regularization) — kakashi #3214
 - Attention distance bias (ALiBi-inspired spatial prior) — canute #3216
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -10,7 +10,7 @@
 
 ### DrivAerML WIP (27 PRs)
 **Innovation track (new physics-aware/ML ideas per directive):**
-- fern: spectral normalization on attention layers — INNOVATION (PR pending)
+- `#3224` fern: spectral normalization on attention layers — INNOVATION
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3216` canute: attention distance bias (ALiBi-inspired spatial prior) — INNOVATION
 - `#3214` kakashi: auxiliary gradient prediction (∂p/∂x,y,z) — INNOVATION

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 03:15 (advisor cycle 60)
+- **Date:** 2026-04-24 03:45 (advisor cycle 61)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -18,7 +18,6 @@
 - `#3228` chopper: stochastic weight perturbation at cosine troughs — INNOVATION
 - `#3225` canute: self-distillation with EMA teacher — INNOVATION
 - `#3217` brook: Fourier encoding of surface normals — INNOVATION
-- `#3203` vegeta: attention temperature annealing — INNOVATION
 - `#3202` senku: GLU preprocess MLP — INNOVATION
 - `#3201` jet: DomainLayerNorm — INNOVATION
 
@@ -89,7 +88,8 @@
 - `#3218` shouko: GradNorm adaptive multi-task loss balancing — AF VOLUME FOCUS
 - `#3215` tanjiro: Huber loss on volume channel (robust to outliers) — AF VOLUME FOCUS
 - `#3211` spike: AF vol_loss_scale learnable scalar (noam port) — AF VOLUME FOCUS
-- `#3204` gilbert: vol-weight=15x/20x clean control (no extra features) — AF VOLUME FOCUS
+- `#3240` gilbert: joint checkpoint selection + vol-weight 11x/12x/13x fine sweep — AF VOLUME FOCUS
+- `#3239` vegeta: additive boundary layer auxiliary volume loss — AF VOLUME FOCUS
 - `#3195` piccolo: Re-stratified sampling
 - `#3156` edward: softer gc=0.5
 - `#3144` violet: vol-weight=2.0+EMA=0.999
@@ -188,6 +188,7 @@
 - Attention distance bias (ALiBi): linear diverges, log=5.511% at timeout. Redundant with slice-based spatial grouping
 - Auxiliary gradient prediction (∂p/∂x,y,z): kNN targets too noisy — aux_weight=0.1 diverges ep22, aux_weight=0.01 best 5.485% (+43%). Noise dominates once primary loss flattens
 - Mixup regularization (buffer-based latent): 85-109% worse, crashed ~ep235. Buffer staleness + non-smooth geometry-specific latent space fundamentally incompatible with bs=1
+- Attention temperature annealing: 4.024% (+5% vs 3.833%). External annealed τ compounds with existing learnable per-head τ. noam result doesn't transfer
 - Head count sweep complete: 2H=catastrophic, 4H=6.650%, 8H=3.833% CHAMPION, 16H=4.099%. 8H (64d/head) is definitive
 - 10-ep warmup+gc=1.0: 11.2% then diverged
 - 5-ep warmup+gc=1.0: pending (chopper)
@@ -223,6 +224,7 @@
 - T_max≠50 (30 and 100 both worse)
 - Vol-weight<10x (1.5x/2x/3x/5x/7x): ALL worse on both metrics across 6 tested values. 10x+EMA=0.999 is AF sweet spot
 - Vol-weight=30x: catastrophic — surface 4.3x worse, vol 3.1x worse
+- Vol-weight=15x: surface +19%, vol +67% (#3204). Vol-weight=20x: crashed ep381 (#3204). 10x is definitive AF operating point
 - LR>6e-4: 8e-4 +110% surface, 1e-3 catastrophic divergence
 
 **TandemFoil:**

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -79,7 +79,7 @@
 **Other:**
 - `#3172` robin: LR warmup (5-ep/10-ep)
 - `#3169` nami: heads sweep 4H/16H
-- norman: volume smoothness regularization — AF VOLUME FOCUS (PR pending)
+- `#3223` norman: volume smoothness regularization — AF VOLUME FOCUS
 - `#3222` rei: proximity-weighted volume loss (surface distance) — AF VOLUME FOCUS
 - `#3218` shouko: GradNorm adaptive multi-task loss balancing — AF VOLUME FOCUS
 - `#3215` tanjiro: Huber loss on volume channel (robust to outliers) — AF VOLUME FOCUS

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 11:15 (advisor cycle 81)
+- **Date:** 2026-04-24 11:30 (advisor cycle 82)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -38,8 +38,9 @@
 - `#3266` sanji: TFP champion config re-verification post cp_panel fix (seed=0/42) — STABILIZATION VERIFY
 - `#3244` faye: DM Track 1 paper-facing full eval (champion config, NO --max-eval-batches) — PAPER-FACING Track 1
 - `#3160` griffith: 16H heads
+- `#3271` nobara: layer-wise LR decay (LLRD, decay=0.8/0.65 across 4 layers) — INNOVATION
+- `#3272` vegeta: quadratic position features (x², y², z², xy, xz, yz for implicit curvature) — INNOVATION
 - `#3249` shouko: decaying weight decay schedule (WD=1e-4/5e-5 → 0 over 300ep) — INNOVATION
-- `#3248` nobara: decaying peak LR at cosine restarts (SGDR eta_mult) — INNOVATION
 - `#3152` eren: EMA decay sweep (0.999 vs 0.9995)
 - `#3146` taki: top-5 checkpoint averaging
 - `#3143` thorfinn: Lookahead(AdamW)
@@ -197,6 +198,8 @@
 - Progressive resolution (25k→50k / 30k→50k): 25k crashed ep112, 30k→4.711% +23% (#3252). Full 50k context needed from epoch 1. Reduced resolution creates irrecoverable representation deficit
 - Auxiliary surface normal prediction: w=0.1→4.724%, w=0.01→4.661% (#3258). Input leakage — normals already in features, aux head learns trivial reconstruction. Also epoch starvation (200 vs 511)
 - EMA periodic reset: 100ep→4.426% cascade ep335, 50ep→6.818% diverge ep108 (#3247). EMA is primary gradient stabilizer — reset removes protective smoothing at high-curvature basin point
+- Weight Standardization: 67.9%/71.4% catastrophic (#3264). WS × cosine restarts × bs=1 feedback loop. Original BiT paper used epoch-level decay not per-batch restarts
+- SGDR eta_mult (decaying restart LR): 4.153%/12.64% (#3248). Confounded by switching to warm restarts. Sharp restart jumps more destabilizing than baseline's smooth cosine
 - EMA>0.9995: 0.9999→7.106% NaN ep171, 0.99995→7.095% collapse ep120 (#3199). EMA=0.9995 sharp optimum bracketed both directions
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,13 +1,13 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 04:30 (advisor cycle 62)
+- **Date:** 2026-04-24 05:00 (advisor cycle 63)
 - **Branch:** radford
-- **Idle students:** 0
+- **Idle students:** 0 (faye just assigned #3244)
 - **PRs ready for review:** 0
 - **CRITICAL:** TFP champion config is BROKEN — code regression since #3025, seed=0 no longer reproduces (#3205). Waiting for sanji #3209 cp_panel bug fix.
 - **Known bug:** `primary_metric_key` shadowing in train.py (line ~1646 local var shadows function on line ~1428). 3 students independently fixed this cycle. Fix: rename local to `best_tracking_metric_key`.
 
-## Fleet Status (53 active PRs)
+## Fleet Status (58 active PRs)
 
 ### DrivAerML WIP (28 PRs)
 **Innovation track (new physics-aware/ML ideas per directive):**
@@ -31,7 +31,7 @@
 
 **Champion tuning / paper-facing:**
 - `#3209` sanji: TFP cp_panel bug fix + multi-seed retest — STABILIZATION PRIORITY
-- `#3164` faye: paper-facing full eval (two-phase) — PAPER-FACING Track 1
+- `#3244` faye: DM Track 1 paper-facing full eval (champion config, NO --max-eval-batches) — PAPER-FACING Track 1
 - `#3160` griffith: 16H heads
 - `#3237` nobara: snapshot ensemble at cosine troughs (test-time averaging) — INNOVATION
 - `#3152` eren: EMA decay sweep (0.999 vs 0.9995)
@@ -112,7 +112,7 @@
 | TandemFoil | `test_primary/surface_pressure_mae` | **22.868** (PR #3185 MERGED) | (internal) | Improving |
 | TandemFoil Paper | `test_primary/field_mse` | **NO CLEAN ROW YET** | ~0.10-0.36/task | URGENT — #3098 in-progress |
 | AirfRANS | `Surf MSE / Vol MSE` | **0.000296 / 0.002039** | 0.0043 / 0.0017 | Surface 14.5x better, Volume 1.20x gap |
-| DrivAerML | `test_primary/surface_rel_l2_pct` | **4.685%** (#3072, partial eval) | 3.71% | Gap closing — #3164 paper eval in-progress |
+| DrivAerML | `test_primary/surface_rel_l2_pct` | **4.685%** (#3072, partial eval) | 3.71% | Gap closing — #3244 paper eval in-progress (faye) |
 
 ## Current Research Focus
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,8 +1,8 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 12:30 (advisor cycle 46 — updated per human directive #3174)
+- **Date:** 2026-04-23 22:30 (advisor cycle 47)
 - **Branch:** radford
-- **Idle students:** 0 (4 being assigned)
+- **Idle students:** 0
 - **PRs ready for review:** 0
 - **CRITICAL:** TFP champion (0.002383) is unreproducible — 0/3 seeds stay finite (#3168)
 
@@ -28,7 +28,6 @@
 - `#3209` sanji: TFP cp_panel bug fix + multi-seed retest — STABILIZATION PRIORITY
 - `#3164` faye: paper-facing full eval (two-phase) — PAPER-FACING Track 1
 - `#3163` shouko: attn dropout=0.05
-- `#3161` spike: eta_min=1e-5 (cosine floor)
 - `#3160` griffith: 16H heads
 - `#3155` nobara: longer T_max (45/60)
 - `#3207` historia: DM true monotonic cosine (T_max=393606) — corrected retest
@@ -82,6 +81,7 @@
 **Other:**
 - `#3172` robin: LR warmup (5-ep/10-ep)
 - `#3169` nami: heads sweep 4H/16H
+- `#3211` spike: AF vol_loss_scale learnable scalar (noam port) — AF VOLUME FOCUS
 - `#3204` gilbert: vol-weight=15x/20x clean control (no extra features) — AF VOLUME FOCUS
 - `#3167` gilbert: higher LR (8e-4/1e-3)
 - `#3166` vegeta: vol-weight=5.0/7.0+EMA=0.999
@@ -178,7 +178,7 @@
 - Bilateral symmetry aug, torch.compile, gradient accumulation
 - Attention dropout without EMA/gc: toxic combo with T_max=30
 - Cosine eta_min without EMA/gc: diverges (7.255-7.918%)
-- eta_min=5e-5+gc (any value): gc=1.0→6.311%, gc=0.5→8.617%, both diverge — 3rd confirmation
+- eta_min+gc (any combination): gc=1.0→6.311%, gc=0.5→8.617%, gc=0.5+EMA→4.202% diverge ep312 — TRIPLE CONFIRMED. gc=0.5 relies on zero-LR trough damping; eta_min removes reset.
 - Surface points ≠50k: 16k=11.672%, 32k=7.558%, 64k=12.16% (even with EMA+gc) — 50k only viable count
 - 4L/640d: dead at ALL tested configs — lr=5e-4+EMA+gc: 8.636% diverge ep82 (#3159); lr=5e-4 no-EMA: 4.516%/6.457%/5.724% all diverge (#3079). Width amplifies gradients beyond gc containment.
 - lr<5e-4 under EMA: steep monotonic cliff (4.5e-4=4.134%, 4e-4=5.924%)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 06:30 (advisor cycle 67)
+- **Date:** 2026-04-24 07:00 (advisor cycle 68)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -17,7 +17,8 @@
 - `#3235` kakashi: multi-exit prediction (aux losses at intermediate layers) — INNOVATION
 - `#3233` gojo: stochastic depth (LayerDrop) regularization — INNOVATION
 - `#3231` emma: surface pressure gradient smoothness regularization — INNOVATION (physics-informed)
-- `#3224` fern: spectral normalization on attention layers — INNOVATION
+- `#3251` fern: Pre-LayerNorm architecture ablation (+ RMSNorm variant) — INNOVATION
+- `#3252` mitsuha: progressive surface point training (resolution curriculum) — INNOVATION
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3228` chopper: stochastic weight perturbation at cosine troughs — INNOVATION
 - `#3225` canute: self-distillation with EMA teacher — INNOVATION
@@ -57,7 +58,6 @@
 
 **Noam-pivot experiments:**
 - `#3179` usopp: T_max=150+wake+96sl+Lookahead — NOAM ABLATION
-- `#3176` mitsuha: full noam stack — NOAM ABLATION
 
 **Other:**
 - `#3133` shinobu: WD sweep (5e-3/2e-2)
@@ -190,6 +190,7 @@
 - Mixup regularization (buffer-based latent): 85-109% worse, crashed ~ep235. Buffer staleness + non-smooth geometry-specific latent space fundamentally incompatible with bs=1
 - Fourier-encoded surface normals: 4.374%/4.454% (4 bands/2 bands). Normals are unit vectors in [-1,1] — don't benefit from Fourier lifting like unbounded coords. More bands = earlier divergence
 - Snapshot ensemble (cosine trough checkpoints): test=6.044% single best, WORSE with more snapshots (K=3→6.24%, K=5→6.98%, K=6→7.81%). Quality gradient dominates diversity. EMA already provides implicit smoothing.
+- Spectral norm on QKV: 4.035% (+5.3%). σ=1 cap over-restricts attention capacity. Late collapse ep502 from unconstrained FFN layers. gc=0.5 already solves restart stability.
 - Attention temperature annealing: 4.024% (+5% vs 3.833%). External annealed τ compounds with existing learnable per-head τ. noam result doesn't transfer
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 10:45 (advisor cycle 79)
+- **Date:** 2026-04-24 11:00 (advisor cycle 80)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -20,7 +20,7 @@
 - `#3263` gojo: Sparse MoE FFN (K=4/8 experts, top-2 routing, regime-specific computation) — INNOVATION
 - `#3251` fern: Pre-LayerNorm architecture ablation (+ RMSNorm variant) — INNOVATION
 - `#3259` zenitsu: curvature-weighted loss (per-point weighting by local curvature) — INNOVATION
-- `#3258` emma: auxiliary surface normal prediction (multi-task regularization) — INNOVATION
+- `#3269` emma: learned error correction head (boosting-inspired self-correction) — INNOVATION
 - `#3267` mitsuha: SwiGLU FFN activation (replace GELU with gated linear unit) — INNOVATION
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3228` chopper: stochastic weight perturbation at cosine troughs — INNOVATION
@@ -195,6 +195,7 @@
 - Stochastic depth/LayerDrop: p=0.1→4.317%, p=0.2→4.217%, p=0.3→4.411% (#3233). Only 4 layers — dropping 1 removes 25% capacity. Too coarse. EMA+gc already handles stability
 - Coordinate noise augmentation: σ=0.001→6.45% crashed, σ=0.005→21.44% Inf grads (#3256). Fourier freqs up to 32.0 amplify coord noise 32x. Structurally incompatible with Fourier PE
 - Progressive resolution (25k→50k / 30k→50k): 25k crashed ep112, 30k→4.711% +23% (#3252). Full 50k context needed from epoch 1. Reduced resolution creates irrecoverable representation deficit
+- Auxiliary surface normal prediction: w=0.1→4.724%, w=0.01→4.661% (#3258). Input leakage — normals already in features, aux head learns trivial reconstruction. Also epoch starvation (200 vs 511)
 - EMA>0.9995: 0.9999→7.106% NaN ep171, 0.99995→7.095% collapse ep120 (#3199). EMA=0.9995 sharp optimum bracketed both directions
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,9 +1,10 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 (advisor cycle 44 — gilbert assigned af-vol-15x-clean #3204)
+- **Date:** 2026-04-23 21:30 (advisor cycle 45 — closed #3168/#3154/#3083, assigning jin/brook/historia/jet)
 - **Branch:** radford
-- **Idle students:** 0 (gilbert assigned: #3204 af-vol-15x-clean — vol-weight=15x/20x clean control)
+- **Idle students:** 0 (4 being assigned)
 - **PRs ready for review:** 0
+- **CRITICAL:** TFP champion (0.002383) is unreproducible — 0/3 seeds stay finite (#3168)
 
 ## Fleet Status (57 active PRs)
 
@@ -30,7 +31,8 @@
 - `#3161` spike: eta_min=1e-5 (cosine floor)
 - `#3160` griffith: 16H heads
 - `#3155` nobara: longer T_max (45/60)
-- `#3154` historia: monotonic cosine (no restarts)
+- `#NEW` historia: DM true monotonic cosine (T_max=393606) — corrected retest
+- `#NEW` jet: DM 600 batches + gc=0.5 + EMA (stabilized retest)
 - `#3152` eren: EMA decay sweep (0.999 vs 0.9995)
 - `#3146` taki: top-5 checkpoint averaging
 - `#3143` thorfinn: Lookahead(AdamW)
@@ -53,15 +55,17 @@
 - `#3180` chopper: ANP decoder alone — NOAM ABLATION
 - `#3150` yuji: clean test row — PAPER-FACING
 
-### TandemFoil Paper WIP (10 PRs)
-**Noam-pivot experiments (highest priority):**
-- `#3200` brook: TFP stabilization diagnostic (20-ep probes) — STABILIZATION
+### TandemFoil Paper WIP (11 PRs) — STABILIZATION CRISIS
+**Stabilization diagnostic (HIGHEST PRIORITY — baseline unreproducible):**
+- `#NEW` jin: TFP seed sensitivity (seed=0 verify, seed=42 + gc/warmup/asinh probes)
+- `#NEW` brook: TFP pressure stabilization (base config, lower LR, AdamW vs Lion)
+
+**Noam-pivot experiments:**
 - `#3183` rei: ANP+T_max=150 — NOAM ABLATION
 - `#3179` usopp: T_max=150+wake+96sl+Lookahead — NOAM ABLATION
 - `#3176` mitsuha: full noam stack — NOAM ABLATION
 
 **Other:**
-- `#3168` jin: multi-seed paper-facing (seeds 42/123/456)
 - `#3133` shinobu: WD sweep (5e-3/2e-2)
 - `#3098` shoya: clean test evaluation — URGENT PAPER-FACING
 - `#3088` mugen: T_max=20

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 00:00 (advisor cycle 52)
+- **Date:** 2026-04-24 00:15 (advisor cycle 53)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -10,6 +10,8 @@
 
 ### DrivAerML WIP (27 PRs)
 **Innovation track (new physics-aware/ML ideas per directive):**
+- fern: spectral normalization on attention layers — INNOVATION (PR pending)
+- `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3216` canute: attention distance bias (ALiBi-inspired spatial prior) — INNOVATION
 - `#3214` kakashi: auxiliary gradient prediction (∂p/∂x,y,z) — INNOVATION
 - `#3217` brook: Fourier encoding of surface normals — INNOVATION
@@ -44,13 +46,12 @@
 - `#3067` askeladd: 32k surface points (SENT BACK)
 - `#3046` sukuna: WD+gc compound (SENT BACK)
 
-### TandemFoil WIP (7 PRs) — GUARDRAIL ONLY per directive
-**Noam-pivot experiments:**
+### TandemFoil WIP (5 PRs) — GUARDRAIL ONLY per directive
+**New champion config:** ANP+full physics+T_max=150+gc=0.2+EMA=0.999+96sl+Lookahead+compile+re-strat (#3185)
+**Noam-pivot experiments (still running):**
 - `#3197` gojo: residual-prediction alone — NOAM ABLATION
 - `#3196` zenitsu: EMA decay sweep (0.9999/0.99995) — NOAM ABLATION
 - `#3189` emma: asinh+physics features — NOAM ABLATION
-- `#3186` norman: T_max=150 alone — NOAM ABLATION
-- `#3185` fern: full noam stack — NOAM ABLATION
 - `#3180` chopper: ANP decoder alone — NOAM ABLATION
 - `#3150` yuji: clean test row — PAPER-FACING
 
@@ -78,6 +79,7 @@
 **Other:**
 - `#3172` robin: LR warmup (5-ep/10-ep)
 - `#3169` nami: heads sweep 4H/16H
+- norman: volume smoothness regularization — AF VOLUME FOCUS (PR pending)
 - `#3222` rei: proximity-weighted volume loss (surface distance) — AF VOLUME FOCUS
 - `#3218` shouko: GradNorm adaptive multi-task loss balancing — AF VOLUME FOCUS
 - `#3215` tanjiro: Huber loss on volume channel (robust to outliers) — AF VOLUME FOCUS
@@ -93,7 +95,7 @@
 
 | Dataset | Metric | Current anchor |
 |---|---|---|
-| TandemFoil | `val_primary/surface_pressure_mae` | **21.350** (#3140 MERGED — gc=0.2+EMA=0.999) |
+| TandemFoil | `val_primary/surface_pressure_mae` | **21.319** (#3185 MERGED — full noam stack: ANP+physics+T_max=150+Lookahead+96sl) |
 | TandemFoil Paper | `val_primary/field_mse` | **0.002383** (#3025) |
 | AirfRANS | `val_primary/surface_mse` + `vol_mse` | **0.000296 / 0.002039** (#3135 MERGED — EMA+vol-weight=10x) |
 | DrivAerML | `val_primary/surface_rel_l2_pct` | **3.833%** (#3072 MERGED — EMA=0.9995+gc=0.5) |
@@ -102,7 +104,7 @@
 
 | Dataset | Metric | Current best | External target | Status |
 |---|---|---|---|---|
-| TandemFoil | `test_primary/surface_pressure_mae` | **23.195** (PR #3140) | (internal) | Improving |
+| TandemFoil | `test_primary/surface_pressure_mae` | **22.868** (PR #3185 MERGED) | (internal) | Improving |
 | TandemFoil Paper | `test_primary/field_mse` | **NO CLEAN ROW YET** | ~0.10-0.36/task | URGENT — #3098 in-progress |
 | AirfRANS | `Surf MSE / Vol MSE` | **0.000296 / 0.002039** | 0.0043 / 0.0017 | Surface 14.5x better, Volume 1.20x gap |
 | DrivAerML | `test_primary/surface_rel_l2_pct` | **4.685%** (#3072, partial eval) | 3.71% | Gap closing — #3164 paper eval in-progress |
@@ -218,7 +220,7 @@
 
 ## Mandatory Config Rules
 
-- **TF:** Lion lr=1.25e-4, T_max=10, gc=0.3, WD=1e-2, `--ema-decay 0.999`, 3L/192d
+- **TF:** Lion lr=1.25e-4, **T_max=150**, gc=0.2, WD=1e-2, `--ema-decay 0.999`, 3L/192d, **96 slices**, ANP+full physics+asinh-scale=0.75+residual+Lookahead+compile+re-strat (**UPDATED post #3185**)
 - **TFP:** Lion lr=1.25e-4, T_max=10, gc=0.5, WD=1e-2, `--ema-decay 0.999`, 3L/192d
 - **AF:** AdamW lr=6e-4, T_max=50, gc=1.0, WD=1e-2, `--ema-decay 0.999`, 2L/256d
 - **DM:** AdamW lr=5e-4, T_max=30, **gc=0.5**, **EMA=0.9995**, no WD, 4L/512d (**UPDATED post #3072**)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 09:00 (advisor cycle 73)
+- **Date:** 2026-04-24 09:15 (advisor cycle 74)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -9,8 +9,9 @@
 
 ## Fleet Status (58 active PRs)
 
-### DrivAerML WIP (29 PRs)
+### DrivAerML WIP (30 PRs)
 **Innovation track (new physics-aware/ML ideas per directive):**
+- `#3262` megumi: learnable register tokens N=2/4/8 (attention sink absorption, Darcet NeurIPS 2024) — INNOVATION
 - `#3260` casca: learnable Fourier frequency magnitudes (meta-learned encoding) — INNOVATION
 - `#3247` brook: EMA periodic reset (100/50-ep intervals) — INNOVATION
 - `#3243` jet: prediction-error-weighted surface sampling (hard example mining) — INNOVATION
@@ -233,6 +234,7 @@
 - Focal-MSE volume loss (error-based reweighting): gamma=2 +392%/+3993%, gamma=1 +222%/+320% (#3227). Batch-max normalization non-stationary + freestream scaffolding destroyed
 - 3L depth (with or without EMA): catastrophic divergence confirmed twice
 - 2L/384d and 3L/384d: catastrophic divergence
+- EMA>0.9995 (0.9999/0.99995 both ~85% worse, diverge early, #3199). EMA=0.9995 bracketed as sharp optimum with steep cliffs both directions
 - EMA<0.999 (0.99, 0.995 both worse)
 - T_max≠50 (30 and 100 both worse)
 - Vol-weight<10x (1.5x/2x/3x/5x/7x): ALL worse on both metrics across 6 tested values. 10x+EMA=0.999 is AF sweet spot

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 23:30 (advisor cycle 50)
+- **Date:** 2026-04-23 23:45 (advisor cycle 51)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -24,13 +24,13 @@
 - `#3194` bulma: higher LR sweep (5.5e-4/6e-4)
 - `#3188` chihiro: 2H/16H heads sweep — NOAM ABLATION
 - `#3181` himmel: asinh+residual on champion — NOAM ABLATION
-- `#3175` hinata: full noam stack — NOAM ABLATION
+- `#3219` hinata: SAM optimizer (flat-basin restart robustness) — INNOVATION
 
 **Champion tuning / paper-facing:**
 - `#3209` sanji: TFP cp_panel bug fix + multi-seed retest — STABILIZATION PRIORITY
 - `#3164` faye: paper-facing full eval (two-phase) — PAPER-FACING Track 1
 - `#3160` griffith: 16H heads
-- `#3155` nobara: longer T_max (45/60)
+- `#3220` nobara: Mixup regularization (feature interpolation) — INNOVATION
 - `#3207` historia: DM true monotonic cosine (T_max=393606) — corrected retest
 - `#3206` jet: DM 600 batches + gc=0.5 + EMA (stabilized retest)
 - `#3152` eren: EMA decay sweep (0.999 vs 0.9995)
@@ -177,7 +177,8 @@
 - Polynomial LR (no cosine troughs): catastrophic — troughs are load-bearing stability features
 - OneCycleLR (no troughs): 8.04% best, sustained high-LR warmup worse than cosine peaks (without EMA+gc)
 - SWA: equal-weight averaging poisons across divergent basins (88.98%)
-- T_max≠30: T_max=50+gc diverges; T_max=15→4.406% plateaued; T_max=20→4.943% diverged. T_max=30 ONLY viable period
+- T_max≠30: ALL tested — 15→4.406%, 20→4.943%, 30→3.833% CHAMPION, 45→4.638%, 50→diverge, 60→4.409%. T_max=30 is definitive sweet spot
+- Noam feature stack on DM: full stack→4.447%, asinh-only→4.421%, residual-only→4.651%. All diverge. Features tuned for T_max=150/3H/no-gc regime don't transfer to T_max=30/8H/gc=0.5
 - 10-ep warmup+gc=1.0: 11.2% then diverged
 - 5-ep warmup+gc=1.0: pending (chopper)
 - LR warmup + EMA+gc=0.5: 5-ep=11.325% diverged, 10-ep=3.918% plateaued (didn't beat 3.833%)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 11:00 (advisor cycle 80)
+- **Date:** 2026-04-24 11:15 (advisor cycle 81)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -13,7 +13,7 @@
 **Innovation track (new physics-aware/ML ideas per directive):**
 - `#3262` megumi: learnable register tokens N=2/4/8 (attention sink absorption, Darcet NeurIPS 2024) — INNOVATION
 - `#3260` casca: learnable Fourier frequency magnitudes (meta-learned encoding) — INNOVATION
-- `#3247` brook: EMA periodic reset (100/50-ep intervals) — INNOVATION
+- `#3270` brook: FiLM conditioning on global geometry statistics (per-car shape context) — INNOVATION
 - `#3243` jet: prediction-error-weighted surface sampling (hard example mining) — INNOVATION
 - `#3242` historia: label smoothing / target noise augmentation — INNOVATION
 - `#3235` kakashi: multi-exit prediction (aux losses at intermediate layers) — INNOVATION
@@ -196,6 +196,7 @@
 - Coordinate noise augmentation: σ=0.001→6.45% crashed, σ=0.005→21.44% Inf grads (#3256). Fourier freqs up to 32.0 amplify coord noise 32x. Structurally incompatible with Fourier PE
 - Progressive resolution (25k→50k / 30k→50k): 25k crashed ep112, 30k→4.711% +23% (#3252). Full 50k context needed from epoch 1. Reduced resolution creates irrecoverable representation deficit
 - Auxiliary surface normal prediction: w=0.1→4.724%, w=0.01→4.661% (#3258). Input leakage — normals already in features, aux head learns trivial reconstruction. Also epoch starvation (200 vs 511)
+- EMA periodic reset: 100ep→4.426% cascade ep335, 50ep→6.818% diverge ep108 (#3247). EMA is primary gradient stabilizer — reset removes protective smoothing at high-curvature basin point
 - EMA>0.9995: 0.9999→7.106% NaN ep171, 0.99995→7.095% collapse ep120 (#3199). EMA=0.9995 sharp optimum bracketed both directions
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,15 +1,18 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 03:45 (advisor cycle 61)
+- **Date:** 2026-04-24 04:30 (advisor cycle 62)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
 - **CRITICAL:** TFP champion config is BROKEN — code regression since #3025, seed=0 no longer reproduces (#3205). Waiting for sanji #3209 cp_panel bug fix.
+- **Known bug:** `primary_metric_key` shadowing in train.py (line ~1646 local var shadows function on line ~1428). 3 students independently fixed this cycle. Fix: rename local to `best_tracking_metric_key`.
 
 ## Fleet Status (53 active PRs)
 
-### DrivAerML WIP (29 PRs)
+### DrivAerML WIP (28 PRs)
 **Innovation track (new physics-aware/ML ideas per directive):**
+- `#3243` jet: prediction-error-weighted surface sampling (hard example mining) — INNOVATION
+- `#3242` historia: label smoothing / target noise augmentation — INNOVATION
 - `#3235` kakashi: multi-exit prediction (aux losses at intermediate layers) — INNOVATION
 - `#3233` gojo: stochastic depth (LayerDrop) regularization — INNOVATION
 - `#3231` emma: surface pressure gradient smoothness regularization — INNOVATION (physics-informed)
@@ -25,15 +28,12 @@
 - `#3199` megumi: EMA=0.9999/0.99995 (noam optimal decay) — NOAM ABLATION
 - `#3194` bulma: higher LR sweep (5.5e-4/6e-4)
 - `#3181` himmel: asinh+residual on champion — NOAM ABLATION
-- `#3219` hinata: SAM optimizer (flat-basin restart robustness) — INNOVATION
 
 **Champion tuning / paper-facing:**
 - `#3209` sanji: TFP cp_panel bug fix + multi-seed retest — STABILIZATION PRIORITY
 - `#3164` faye: paper-facing full eval (two-phase) — PAPER-FACING Track 1
 - `#3160` griffith: 16H heads
 - `#3237` nobara: snapshot ensemble at cosine troughs (test-time averaging) — INNOVATION
-- `#3207` historia: DM true monotonic cosine (T_max=393606) — corrected retest
-- `#3206` jet: DM 600 batches + gc=0.5 + EMA (stabilized retest)
 - `#3152` eren: EMA decay sweep (0.999 vs 0.9995)
 - `#3146` taki: top-5 checkpoint averaging
 - `#3143` thorfinn: Lookahead(AdamW)
@@ -65,11 +65,12 @@
 - `#3056` haku: Lion+EMA refinement (T_max/gc/LR sweep)
 - `#2949` vash: depth/width sweep (LR=5e-5)
 
-### AirfRANS WIP (13 PRs)
+### AirfRANS WIP (14 PRs)
 **Non-asinh noam feature ablation (highest priority — clean tests):**
 - `#3230` alphonse: residual-prediction + re-stratified sampling (NO asinh) — CLEAN NOAM ABLATION
 
 **Volume closure experiments:**
+- `#3241` hinata: T_max=75 + vol-weight=10x/12x on champion — AF VOLUME FOCUS (schedule gap-fill)
 - `#3236` gohan: Lookahead(AdamW) + torch.compile on vol-10x champion — AF VOLUME FOCUS
 - `#3234` jin: lower LR sweep (5e-4/4e-4) on vol-10x champion — AF VOLUME FOCUS
 - `#3232` nezuko: vol-weight warm-up schedule (1x→10x linear ramp over 200ep) — AF VOLUME FOCUS
@@ -189,6 +190,9 @@
 - Auxiliary gradient prediction (∂p/∂x,y,z): kNN targets too noisy — aux_weight=0.1 diverges ep22, aux_weight=0.01 best 5.485% (+43%). Noise dominates once primary loss flattens
 - Mixup regularization (buffer-based latent): 85-109% worse, crashed ~ep235. Buffer staleness + non-smooth geometry-specific latent space fundamentally incompatible with bs=1
 - Attention temperature annealing: 4.024% (+5% vs 3.833%). External annealed τ compounds with existing learnable per-head τ. noam result doesn't transfer
+- SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
+- True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete
+- 600 batches/epoch (stabilized retest): T_max=46 proportional diverged ep61; T_max=30 got 3.887% after MORE total batches than baseline. Data diversity per epoch saturated at 394
 - Head count sweep complete: 2H=catastrophic, 4H=6.650%, 8H=3.833% CHAMPION, 16H=4.099%. 8H (64d/head) is definitive
 - 10-ep warmup+gc=1.0: 11.2% then diverged
 - 5-ep warmup+gc=1.0: pending (chopper)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,13 +1,13 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 12:45 (advisor cycle 85)
+- **Date:** 2026-04-24 13:15 (advisor cycle 86)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
 - **TFP UNBLOCKED:** cp_panel bug fix merged (#3209). Multi-seed reproducibility confirmed. Sanji #3266 re-running champion config to verify 0.002383 is recoverable.
 - **Both bugs fixed in codebase:** cp_panel_prior_index() guard (#3209 MERGED) + primary_metric_key shadowing (#3209 MERGED).
 
-## Fleet Status (58 active PRs)
+## Fleet Status (59 active PRs)
 
 ### DrivAerML WIP (30 PRs)
 **Innovation track (new physics-aware/ML ideas per directive):**
@@ -26,7 +26,7 @@
 - `#3228` chopper: stochastic weight perturbation at cosine troughs — INNOVATION
 - `#3265` alphonse: hidden-space noise regularization (post-Fourier perturbation σ=0.01/0.05) — INNOVATION
 - `#3275` canute: local/windowed attention (KNN-restricted, K=512/2048 neighbors) — INNOVATION
-- `#3264` vegeta: Weight Standardization on linear layers (bs=1 loss smoothing, Qiao 2019) — INNOVATION
+- `#3277` vegeta: coordinate residual branch (parallel bypass MLP for spatial bias correction) — INNOVATION
 - `#3202` senku: GLU preprocess MLP — INNOVATION
 - `#3201` jet: DomainLayerNorm — INNOVATION
 
@@ -72,7 +72,7 @@
 ### AirfRANS WIP (13 PRs)
 **Volume closure experiments:**
 - `#3261` nezuko: 2L/320d wider model (width scaling for vol closure) — AF VOLUME FOCUS
-- `#3255` gohan: no-Lookahead/no-compile champion full budget — AF VOLUME FOCUS (critical ablation follow-up)
+- `#3278` gohan: separate volume prediction head with extra capacity (256→512→out) — AF VOLUME FOCUS
 - `#3257` chihiro: extended training via reduced eval frequency (every 3/5 epochs) — AF VOLUME FOCUS
 - `#3241` hinata: T_max=75 + vol-weight=10x/12x on champion — AF VOLUME FOCUS (schedule gap-fill)
 - `#3268` jin: higher LR sweep (7e-4/8e-4) on vol-10x+EMA champion — AF VOLUME FOCUS
@@ -203,6 +203,7 @@
 - Sparse MoE FFN (K=4/8, top-2): 5.09%/5.35% (#3263). 1.7-2.2x throughput penalty → epoch starvation. Routing collapses to uniform. Per-epoch curve parallel to dense — FFN is not the bottleneck
 - Input feature dropout (Fourier channels): p=0.1→4.73%, p=0.2→4.82% (#3253). Input-level dropout = information destruction. All 4 Fourier bands essential. Terminal divergence at both dropout rates
 - Curvature-weighted loss: alpha=1.0→4.48% diverge ep300, alpha=0.5→11.6% diverge ep53 (#3259). Train/eval mismatch (weighted vs uniform metric) + curvature amplifies gradient variance at restarts
+- Quadratic position features (x²/y²/z²/xy/xz/yz): 6.643% at ep168 timeout (#3272). Fatal 3x throughput penalty (168 vs 511 baseline epochs). Quad-only diverged ep63 — Fourier PE irreplaceable. Same epoch-starvation pattern as MoE (#3263).
 - EMA>0.9995: 0.9999→7.106% NaN ep171, 0.99995→7.095% collapse ep120 (#3199). EMA=0.9995 sharp optimum bracketed both directions
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete
@@ -246,6 +247,7 @@
 - Focal-MSE volume loss (error-based reweighting): gamma=2 +392%/+3993%, gamma=1 +222%/+320% (#3227). Batch-max normalization non-stationary + freestream scaffolding destroyed
 - Additive BL auxiliary volume loss (SDF targeting): all 3 trials +31-228% both metrics (#3239). SDF<0.05 captures 61% of vol points on AF meshes — "BL targeting" ≈ uniform upscaling. Pattern confirmed with #3222
 - Multi-seed champion (seeds 42/123/789): all worse than seed=0 baseline (#3254). Seed 42 diverged, 123/789 +39-76% vol. Champion config has high seed sensitivity — seed=0 is lucky initialization
+- No-Lookahead + no-compile at full budget: surface +575%, vol +84% (#3255). Lookahead slow-weight averaging is load-bearing for long-run convergence. compile gives meaningful throughput within timeout. Short-run ablation that showed these removable was misleading (epoch-count confound).
 - 3L depth (with or without EMA): catastrophic divergence confirmed twice
 - 2L/384d and 3L/384d: catastrophic divergence
 - EMA>0.9995 (0.9999/0.99995 both ~85% worse, diverge early, #3199). EMA=0.9995 bracketed as sharp optimum with steep cliffs both directions

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 09:15 (advisor cycle 74)
+- **Date:** 2026-04-24 09:30 (advisor cycle 75)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -17,7 +17,7 @@
 - `#3243` jet: prediction-error-weighted surface sampling (hard example mining) — INNOVATION
 - `#3242` historia: label smoothing / target noise augmentation — INNOVATION
 - `#3235` kakashi: multi-exit prediction (aux losses at intermediate layers) — INNOVATION
-- `#3233` gojo: stochastic depth (LayerDrop) regularization — INNOVATION
+- `#3263` gojo: Sparse MoE FFN (K=4/8 experts, top-2 routing, regime-specific computation) — INNOVATION
 - `#3251` fern: Pre-LayerNorm architecture ablation (+ RMSNorm variant) — INNOVATION
 - `#3259` zenitsu: curvature-weighted loss (per-point weighting by local curvature) — INNOVATION
 - `#3258` emma: auxiliary surface normal prediction (multi-task regularization) — INNOVATION
@@ -30,7 +30,6 @@
 - `#3201` jet: DomainLayerNorm — INNOVATION
 
 **Noam-pivot experiments:**
-- `#3199` megumi: EMA=0.9999/0.99995 (noam optimal decay) — NOAM ABLATION
 - `#3194` bulma: higher LR sweep (5.5e-4/6e-4)
 - `#3181` himmel: asinh+residual on champion — NOAM ABLATION
 
@@ -192,6 +191,8 @@
 - Self-distillation via EMA teacher: α=0.3→6.446% diverge ep170, α=0.1→4.323% diverge ep400. EMA=0.9995 lag creates destabilizing feedback loop. Same EMA for ckpt+teacher incompatible.
 - Pressure gradient smoothness reg (KNN): λ=0.01→4.481%, λ=0.1→4.876%, λ=1.0→12.52%. KNN 30% throughput overhead + sharp car features penalized. Remaining error is systematic bias, not noise.
 - Attention temperature annealing: 4.024% (+5% vs 3.833%). External annealed τ compounds with existing learnable per-head τ. noam result doesn't transfer
+- Stochastic depth/LayerDrop: p=0.1→4.317%, p=0.2→4.217%, p=0.3→4.411% (#3233). Only 4 layers — dropping 1 removes 25% capacity. Too coarse. EMA+gc already handles stability
+- EMA>0.9995: 0.9999→7.106% NaN ep171, 0.99995→7.095% collapse ep120 (#3199). EMA=0.9995 sharp optimum bracketed both directions
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete
 - 600 batches/epoch (stabilized retest): T_max=46 proportional diverged ep61; T_max=30 got 3.887% after MORE total batches than baseline. Data diversity per epoch saturated at 394

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 14:00 (advisor cycle 88)
+- **Date:** 2026-04-24 14:30 (advisor cycle 89)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -12,7 +12,7 @@
 ### DrivAerML WIP (30 PRs)
 **Innovation track (new physics-aware/ML ideas per directive):**
 - `#3281` megumi: MoE output heads (K=2/3 expert output MLPs with learned gating) — INNOVATION
-- `#3260` casca: learnable Fourier frequency magnitudes (meta-learned encoding) — INNOVATION
+- `#3282` casca: AF volume→surface cross-attention (volume queries attend to surface keys) — AF VOLUME FOCUS
 - `#3270` brook: FiLM conditioning on global geometry statistics (per-car shape context) — INNOVATION
 - `#3280` jet: per-channel output heads (separate MLPs for Ux, Uy, p) — INNOVATION
 - `#3242` historia: label smoothing / target noise augmentation — INNOVATION
@@ -110,7 +110,7 @@
 | TandemFoil | `test_primary/surface_pressure_mae` | **22.868** (PR #3185 MERGED) | (internal) | Improving |
 | TandemFoil Paper | `test_primary/field_mse` | **NO CLEAN ROW YET** | ~0.10-0.36/task | URGENT — #3098 in-progress |
 | AirfRANS | `Surf MSE / Vol MSE` | **0.000296 / 0.002039** | 0.0043 / 0.0017 | Surface 14.5x better, Volume 1.20x gap |
-| DrivAerML | `test_primary/surface_rel_l2_pct` | **4.685%** (#3072, partial eval) | 3.71% | Gap closing — #3244 paper eval in-progress (faye) |
+| DrivAerML | `test_primary/surface_rel_l2_pct` | **4.496%** (#3244 full-eval, ep403 ckpt) / 4.685% (batch-limited) | 3.71% | **Batch-limited eval ~24% optimistic.** Faye re-running full eval on champion ep511 ckpt |
 
 ## Current Research Focus
 
@@ -207,6 +207,7 @@
 - Grouped Query Attention (GQA, 2/4 KV heads): 12.88%/6.88% both crashed (#3273). Throughput-neutral (bottleneck is slice routing einsums, not QKV). GQA destabilizes per-head slice routing — coupled KV sharing explodes at cosine restarts.
 - Error-weighted surface sampling (hard example mining): crashed ep6 both trials (#3243). Distribution-shift collapse + 30-60min/epoch error-map compute + train/eval mismatch. Student note: error-weighted LOSS (not sampling) would avoid distribution shift but still faces mismatch.
 - Learnable register tokens (N=2/4/8): N=8 best 4.062% (+6%), N=2/N=4 NaN diverged (#3262). Category error — register tokens address pairwise attention sinks (ViT), but Transolver uses slice-based soft-clustering attention where sink mechanism doesn't apply.
+- Learnable Fourier frequencies: 5.262%/4.252% both diverged (#3260). Frequencies barely moved from init — fixed [0.5,2,8,32] are already near-optimal. Learnable freq + cosine restarts = cascading perturbation feedback loop.
 - EMA>0.9995: 0.9999→7.106% NaN ep171, 0.99995→7.095% collapse ep120 (#3199). EMA=0.9995 sharp optimum bracketed both directions
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,98 +1,121 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 14:30 (advisor cycle 89)
+- **Date:** 2026-04-24 15:30 (advisor cycle 90 — LAST DITCH RESTRUCTURING)
 - **Branch:** radford
-- **Idle students:** 0
-- **PRs ready for review:** 0
-- **TFP UNBLOCKED:** cp_panel bug fix merged (#3209). Multi-seed reproducibility confirmed. Sanji #3266 re-running champion config to verify 0.002383 is recoverable.
-- **Both bugs fixed in codebase:** cp_panel_prior_index() guard (#3209 MERGED) + primary_metric_key shadowing (#3209 MERGED).
+- **ACTIVE DIRECTIVE: Issue #3283 — Last Ditch Benchmark Push (~10 hours remaining)**
+- **Fleet restructuring IN PROGRESS:** killed 14 misaligned experiments, reassigning 15 students
 
-## Fleet Status (59 active PRs)
+## BINDING DIRECTIVE — Issue #3283 (2026-04-24)
 
-### DrivAerML WIP (30 PRs)
-**Innovation track (new physics-aware/ML ideas per directive):**
-- `#3281` megumi: MoE output heads (K=2/3 expert output MLPs with learned gating) — INNOVATION
-- `#3282` casca: AF volume→surface cross-attention (volume queries attend to surface keys) — AF VOLUME FOCUS
-- `#3270` brook: FiLM conditioning on global geometry statistics (per-car shape context) — INNOVATION
-- `#3280` jet: per-channel output heads (separate MLPs for Ux, Uy, p) — INNOVATION
-- `#3242` historia: label smoothing / target noise augmentation — INNOVATION
-- `#3235` kakashi: multi-exit prediction (aux losses at intermediate layers) — INNOVATION
-- `#3279` gojo: ReLU² activation in FFN (Primer-style squared ReLU for sparser features) — INNOVATION
-- `#3251` fern: Pre-LayerNorm architecture ablation (+ RMSNorm variant) — INNOVATION
-- `#3276` zenitsu: cosine similarity auxiliary loss (spatial pattern fidelity, w=0.1/0.5) — INNOVATION
-- `#3269` emma: learned error correction head (boosting-inspired self-correction) — INNOVATION
-- `#3267` mitsuha: SwiGLU FFN activation (replace GELU with gated linear unit) — INNOVATION
-- `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
-- `#3228` chopper: stochastic weight perturbation at cosine troughs — INNOVATION
-- `#3265` alphonse: hidden-space noise regularization (post-Fourier perturbation σ=0.01/0.05) — INNOVATION
-- `#3275` canute: local/windowed attention (KNN-restricted, K=512/2048 neighbors) — INNOVATION
-- `#3277` vegeta: coordinate residual branch (parallel bypass MLP for spatial bias correction) — INNOVATION
-- `#3202` senku: GLU preprocess MLP — INNOVATION
-- `#3201` jet: DomainLayerNorm — INNOVATION
+**Capacity split (59-student fleet):** 36 DM / 12 AF / 11 TFP / 0 TF
+**DM full-test gap: ~4.39-4.50% → 3.71% target (15% relative)**
+**Harness patches CRITICAL (vegeta #3284):** --load-checkpoint, --eval-interval, --ema-mode fixed, --skip-update-grad-norm, --save-checkpoint, kill gates
 
-**Noam-pivot experiments:**
-- `#3194` bulma: higher LR sweep (5.5e-4/6e-4)
-- `#3181` himmel: asinh+residual on champion — NOAM ABLATION
+### DM Strategy (36 students)
+**Truth/recovery (~40%):** champion replicas (seeds, no-compile, fixed EMA), checkpoint recovery, high-density surface (64k/96k/128k), gradient-spike-safe (gc=0.25, skip-update-grad-norm), narrow schedule (T_max=24/30/36, lr=4.8-5.2e-4), checkpoint soup/ensemble
+**Breakout (~60%):** AB-UPT-style anchored decoder, metric-aware fine-tune (mse_z + raw rel-L2), domain-normalized volume auxiliary, coordinate normalization + geometry features, final train+val retrain
 
-**Champion tuning / paper-facing:**
-- `#3266` sanji: TFP champion config re-verification post cp_panel fix (seed=0/42) — STABILIZATION VERIFY
-- `#3244` faye: DM Track 1 paper-facing full eval (champion config, NO --max-eval-batches) — PAPER-FACING Track 1
+### AF Strategy (12 students)
+vol-weight sweep 8-13, extended champion training, joint checkpoint selection, 1-2 architecture rescue lanes max. Kill: surface>0.001 at ep180, vol>0.004 at ep180, vol>0.003 at ep300.
+
+### TFP Strategy (11 students)
+Re-run haku/tfp-t20-gc05-lr1e4 for 2-8 seeds (best_val=0.002466, best_test=0.002393). Kill: field_mse>0.006 at ep220, >0.004 at ep350, no improvement for 160 epochs.
+
+### TF: FROZEN (only #3185 as guardrail)
+
+## Fleet Status (restructuring in progress)
+
+### INFRASTRUCTURE (1 PR)
+- `#3284` vegeta: HARNESS PATCHES (--load-checkpoint, --eval-interval, --ema-mode, --skip-update-grad-norm, --save-checkpoint, kill gates) — **HIGHEST PRIORITY**
+
+### DrivAerML WIP (~28 continuing + 8 new = 36 target)
+**Champion recovery / truth lanes (newly assigned):**
+- norman: champion recovery seed=0 no-compile (Bucket A)
+- jet: champion recovery seed=42 no-compile (Bucket A)
+- megumi: champion recovery seed=7 no-compile (Bucket A)
+- himmel: 64k surface points (Bucket C)
+- askeladd: 96k surface points (Bucket C)
+- robin: gradient-spike-safe gc=0.25 (Bucket D)
+- nami: T_max=24 narrow schedule (Bucket E)
+- chrome: T_max=36 narrow schedule (Bucket E)
+
+**Continuing DM experiments (from pre-restructure):**
+- `#3244` faye: paper-facing full eval (SENT BACK for champion ckpt eval)
+- `#3279` gojo: ReLU² activation
+- `#3270` brook: FiLM conditioning
+- `#3269` emma: error correction head
+- `#3267` mitsuha: SwiGLU FFN
+- `#3265` alphonse: hidden-space noise
+- `#3276` zenitsu: cosine similarity loss
+- `#3275` canute: local attention
+- `#3271` nobara: LLRD
+- `#3251` fern: Pre-LayerNorm
+- `#3249` shouko: decaying WD
+- `#3242` historia: label smoothing
+- `#3235` kakashi: multi-exit prediction
+- `#3228` chopper: stochastic weight perturbation
+- `#3221` franky: gradient noise injection
+- `#3202` senku: GLU preprocess
+- `#3194` bulma: probe LR above 5e-4
 - `#3160` griffith: 16H heads
-- `#3271` nobara: layer-wise LR decay (LLRD, decay=0.8/0.65 across 4 layers) — INNOVATION
-- `#3272` vegeta: quadratic position features (x², y², z², xy, xz, yz for implicit curvature) — INNOVATION
-- `#3249` shouko: decaying weight decay schedule (WD=1e-4/5e-5 → 0 over 300ep) — INNOVATION
-- `#3152` eren: EMA decay sweep (0.999 vs 0.9995)
-- `#3146` taki: top-5 checkpoint averaging
-- `#3143` thorfinn: Lookahead(AdamW)
-- `#3121` levi: dropout regularization sweep
-- `#3110` einar: beta2=0.99/0.995
-- `#3109` guts: lr=4e-4 full-eval
-- `#3085` kohaku: larger supernodes (SENT BACK)
-- `#3076` frieren: log-cosh loss (SENT BACK)
-- `#3067` askeladd: 32k surface points (SENT BACK)
-- `#3046` sukuna: WD+gc compound (SENT BACK)
+- `#3152` eren: EMA sweep
+- `#3146` taki: checkpoint averaging
+- `#3143` thorfinn: Lookahead
+- `#3121` levi: dropout sweep
+- `#3110` einar: beta2 sweep
+- `#3109` guts: lr=4e-4
+- `#3085` kohaku: larger supernodes
+- `#3076` frieren: log-cosh loss
+- `#3046` sukuna: WD+gc compound
 
-### TandemFoil WIP (2 PRs) — GUARDRAIL ONLY per directive
-**New champion config:** ANP+full physics+T_max=150+gc=0.2+EMA=0.999+96sl+Lookahead+compile+re-strat (#3185)
-- `#3150` yuji: clean test row — PAPER-FACING
+### AirfRANS WIP (10 continuing + 2 new = 12 target)
+**Newly assigned:**
+- jin: vol-weight=8 sweep
+- violet: vol-weight=9 sweep
 
-### TandemFoil Paper WIP (9 PRs) — STABILIZATION RESOLVED
-**Bug fix merged (#3209). Sanji #3266 verifying champion config reproducibility.**
-
-**Noam-pivot experiments:**
-- `#3179` usopp: T_max=150+wake+96sl+Lookahead — NOAM ABLATION
-
-**Other:**
-- `#3133` shinobu: WD sweep (5e-3/2e-2)
-- `#3098` shoya: clean test evaluation — URGENT PAPER-FACING
-- `#3088` mugen: T_max=20
-- `#3056` haku: Lion+EMA refinement (T_max/gc/LR sweep)
-- `#2949` vash: depth/width sweep (LR=5e-5)
-
-### AirfRANS WIP (13 PRs)
-**Volume closure experiments:**
-- `#3261` nezuko: 2L/320d wider model (width scaling for vol closure) — AF VOLUME FOCUS
-- `#3278` gohan: separate volume prediction head with extra capacity (256→512→out) — AF VOLUME FOCUS
-- `#3257` chihiro: extended training via reduced eval frequency (every 3/5 epochs) — AF VOLUME FOCUS
-- `#3241` hinata: T_max=75 + vol-weight=10x/12x on champion — AF VOLUME FOCUS (schedule gap-fill)
-- `#3268` jin: higher LR sweep (7e-4/8e-4) on vol-10x+EMA champion — AF VOLUME FOCUS
-
-**Noam-pivot experiments (asinh-dependent — likely to fail):**
-- `#3187` stark: asinh+residual on vol-10x champion — NOAM ABLATION (asinh confirmed dead for AF)
-- `#3184` wolfwood: full noam stack — NOAM ABLATION (asinh confirmed dead for AF)
-
-**Other:**
-- `#3172` robin: LR warmup — SENT BACK (confounded config, re-running with correct champion config)
-- `#3169` nami: heads sweep 4H/16H
-- `#3274` norman: Lion optimizer under vol-10x+EMA (lr=5e-5/1e-4/2e-4 sweep) — AF VOLUME FOCUS
-- `#3238` rei: WD=0 ablation on vol-10x+EMA champion — AF VOLUME FOCUS
-- `#3245` tanjiro: per-channel volume loss weighting (upweight nut×4, p×2) — AF VOLUME FOCUS
-- `#3211` spike: AF vol_loss_scale learnable scalar (noam port) — AF VOLUME FOCUS
-- `#3240` gilbert: joint checkpoint selection + vol-weight 11x/12x/13x fine sweep — AF VOLUME FOCUS
-- `#3195` piccolo: Re-stratified sampling
+**Continuing AF experiments:**
+- `#3282` casca: vol cross-attention (architectural rescue)
+- `#3278` gohan: separate vol head (architectural rescue)
+- `#3257` chihiro: extended training
+- `#3250` tanjiro: per-channel vol loss
+- `#3241` hinata: T_max=75
+- `#3240` gilbert: vol-weight 11x/12x/13x fine sweep
+- `#3238` rei: WD follow-up
+- `#3211` spike: learned vol_loss_scale
+- `#3195` piccolo: re-stratified sampling
 - `#3156` edward: softer gc=0.5
-- `#3144` violet: vol-weight=2.0+EMA=0.999
-- `#3129` chrome: 4L/256d deeper
+
+### TandemFoil Paper WIP (7 continuing + 4 new = 11 target)
+**Newly assigned (haku config replication):**
+- nezuko: haku seed=0
+- stark: haku seed=42
+- wolfwood: haku seed=7
+- yuji: haku seed=123
+
+**Continuing TFP experiments:**
+- `#3266` sanji: champion re-verify
+- `#3179` usopp: T_max=150+wake+96sl+Lookahead
+- `#3133` shinobu: WD sweep
+- `#3098` shoya: clean test eval
+- `#3088` mugen: T_max=20
+- `#3056` haku: Lion+EMA refinement
+- `#2949` vash: depth/width sweep
+
+### Experiments KILLED this cycle (14 PRs per #3283)
+- #3280 jet: DM per-channel heads (surface is single channel cp)
+- #3281 megumi: DM MoE output (directive: no MoE)
+- #3181 himmel: DM asinh+residual (noam dead for DM)
+- #3067 askeladd: DM 32k surface points (directive: only test denser)
+- #3274 norman: AF Lion (directive: stop Lion)
+- #3172 robin: AF LR warmup (directive: stop warmup)
+- #3169 nami: AF heads sweep (directive: stop broad heads)
+- #3129 chrome: AF 4L/256d (directive: stop broad depth)
+- #3261 nezuko: AF 2L/320d (directive: stop broad width)
+- #3187 stark: AF asinh+residual (asinh dead)
+- #3184 wolfwood: AF full noam stack (noam dead)
+- #3268 jin: AF higher LR (directive: stop higher-LR arms)
+- #3144 violet: AF vol-weight=2 (below directive range 8-13)
+- #3150 yuji: TF clean test (TF frozen)
 
 ## Steering Anchors
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 09:30 (advisor cycle 75)
+- **Date:** 2026-04-24 09:45 (advisor cycle 76)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -26,6 +26,7 @@
 - `#3228` chopper: stochastic weight perturbation at cosine troughs — INNOVATION
 - `#3256` alphonse: coordinate noise augmentation (σ=0.001/0.005 input perturbation) — INNOVATION
 - `#3253` canute: input feature dropout (Fourier channel dropout 10%/20%) — INNOVATION
+- `#3264` vegeta: Weight Standardization on linear layers (bs=1 loss smoothing, Qiao 2019) — INNOVATION
 - `#3202` senku: GLU preprocess MLP — INNOVATION
 - `#3201` jet: DomainLayerNorm — INNOVATION
 
@@ -87,7 +88,6 @@
 - `#3245` tanjiro: per-channel volume loss weighting (upweight nut×4, p×2) — AF VOLUME FOCUS
 - `#3211` spike: AF vol_loss_scale learnable scalar (noam port) — AF VOLUME FOCUS
 - `#3240` gilbert: joint checkpoint selection + vol-weight 11x/12x/13x fine sweep — AF VOLUME FOCUS
-- `#3239` vegeta: additive boundary layer auxiliary volume loss — AF VOLUME FOCUS
 - `#3195` piccolo: Re-stratified sampling
 - `#3156` edward: softer gc=0.5
 - `#3144` violet: vol-weight=2.0+EMA=0.999
@@ -233,6 +233,7 @@
 - Huber loss on volume channel: no improvement over MSE on either metric (#3215). AF volume residuals are well-behaved, not heavy-tailed — Huber δ threshold adds no benefit
 - Vol-weight warm-up (1x→10x ramp): 2/3 collapsed, best stable +28% surface/+69% vol (#3232). Cosine restarts inject LR peak when vol-weight ramps — destructive. Static 10x TRIPLE-CONFIRMED
 - Focal-MSE volume loss (error-based reweighting): gamma=2 +392%/+3993%, gamma=1 +222%/+320% (#3227). Batch-max normalization non-stationary + freestream scaffolding destroyed
+- Additive BL auxiliary volume loss (SDF targeting): all 3 trials +31-228% both metrics (#3239). SDF<0.05 captures 61% of vol points on AF meshes — "BL targeting" ≈ uniform upscaling. Pattern confirmed with #3222
 - 3L depth (with or without EMA): catastrophic divergence confirmed twice
 - 2L/384d and 3L/384d: catastrophic divergence
 - EMA>0.9995 (0.9999/0.99995 both ~85% worse, diverge early, #3199). EMA=0.9995 bracketed as sharp optimum with steep cliffs both directions

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -87,7 +87,7 @@
 - `#3223` norman: volume smoothness regularization — AF VOLUME FOCUS
 - `#3238` rei: WD=0 ablation on vol-10x+EMA champion — AF VOLUME FOCUS
 - `#3218` shouko: GradNorm adaptive multi-task loss balancing — AF VOLUME FOCUS
-- `#3215` tanjiro: Huber loss on volume channel (robust to outliers) — AF VOLUME FOCUS
+- `#3245` tanjiro: per-channel volume loss weighting (upweight nut×4, p×2) — AF VOLUME FOCUS
 - `#3211` spike: AF vol_loss_scale learnable scalar (noam port) — AF VOLUME FOCUS
 - `#3240` gilbert: joint checkpoint selection + vol-weight 11x/12x/13x fine sweep — AF VOLUME FOCUS
 - `#3239` vegeta: additive boundary layer auxiliary volume loss — AF VOLUME FOCUS
@@ -164,8 +164,7 @@
 
 **AF volume closure:**
 - vol_loss_scale learnable scalar (noam port, -15.9%) — spike #3211
-- PCGrad gradient surgery (surface/volume conflict resolution) — jin #3212
-- Huber loss on volume channel (robust to outlier gradients) — tanjiro #3215
+- Per-channel volume loss weighting (upweight nut×4, p×2) — tanjiro #3245
 
 ### Critical Known Bug
 - **`cp_panel_prior_index()` broken for tandemfoil_paper** (PR #3200): Fix in progress (sanji #3209).
@@ -222,6 +221,7 @@
 - asinh-pressure: DEFINITIVELY DEAD — 5 independent confirmations (#3191 T1/T2, #3177 T1/T2/T3). sinh() denormalization exponentially amplifies pressure errors. Non-pressure channels fine. Incompatible with AF pressure distribution.
 - PCGrad gradient surgery: 5-6x worse on both metrics (#3212). retain_graph=True disables torch.compile (40% throughput loss). Gradient conflict is NOT the bottleneck.
 - Proximity-weighted volume loss: 118-2516% worse (#3222). Extreme weight ratios starve far-field gradients while overdriving near-surface. Structural failure at scale=0.1/eps=0.01
+- Huber loss on volume channel: no improvement over MSE on either metric (#3215). AF volume residuals are well-behaved, not heavy-tailed — Huber δ threshold adds no benefit
 - 3L depth (with or without EMA): catastrophic divergence confirmed twice
 - 2L/384d and 3L/384d: catastrophic divergence
 - EMA<0.999 (0.99, 0.995 both worse)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,8 +1,8 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 19:30 (advisor cycle 41 — closed #3142/#3115/#3079, assigning zenitsu/gojo/piccolo)
+- **Date:** 2026-04-23 20:00 (advisor cycle 42 — closed #3132, assigning gohan)
 - **Branch:** radford
-- **Idle students:** 0 (zenitsu/gojo/piccolo being assigned)
+- **Idle students:** 0 (gohan being assigned)
 - **PRs ready for review:** 0
 
 ## Fleet Status (56 active PRs → 59 after assignments)
@@ -29,7 +29,7 @@
 - `#3152` eren: EMA decay sweep (0.999 vs 0.9995)
 - `#3146` taki: top-5 checkpoint averaging
 - `#3143` thorfinn: Lookahead(AdamW)
-- `#3132` gohan: eta_min=5e-5+gc=1.0
+- `#NEW` gohan: TFP asinh-pressure isolation — BEING ASSIGNED
 - `#3121` levi: dropout regularization sweep
 - `#3195` piccolo: AF re-stratified sampling alone — NOAM ABLATION
 - `#3110` einar: beta2=0.99/0.995
@@ -168,6 +168,7 @@
 - Bilateral symmetry aug, torch.compile, gradient accumulation
 - Attention dropout without EMA/gc: toxic combo with T_max=30
 - Cosine eta_min without EMA/gc: diverges (7.255-7.918%)
+- eta_min=5e-5+gc (any value): gc=1.0→6.311%, gc=0.5→8.617%, both diverge — 3rd confirmation
 - Surface points ≠50k: 16k=11.672%, 32k=7.558%, 64k=12.16% (even with EMA+gc) — 50k only viable count
 - 4L/640d: dead at ALL tested configs — lr=5e-4+EMA+gc: 8.636% diverge ep82 (#3159); lr=5e-4 no-EMA: 4.516%/6.457%/5.724% all diverge (#3079). Width amplifies gradients beyond gc containment.
 - lr<5e-4 under EMA: steep monotonic cliff (4.5e-4=4.134%, 4e-4=5.924%)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,15 +1,18 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 22:30 (advisor cycle 47)
+- **Date:** 2026-04-23 23:00 (advisor cycle 48)
 - **Branch:** radford
-- **Idle students:** 0
+- **Idle students:** 0 (5 being assigned)
 - **PRs ready for review:** 0
-- **CRITICAL:** TFP champion (0.002383) is unreproducible — 0/3 seeds stay finite (#3168)
+- **CRITICAL:** TFP champion config is BROKEN — code regression since #3025, seed=0 no longer reproduces (#3205). Waiting for sanji #3209 cp_panel bug fix.
 
-## Fleet Status (57 active PRs)
+## Fleet Status (53 active PRs)
 
 ### DrivAerML WIP (27 PRs)
-**Innovation track (code ports — new directive):**
+**Innovation track (new physics-aware/ML ideas per directive):**
+- `#3216` canute: attention distance bias (ALiBi-inspired spatial prior) — INNOVATION
+- `#3214` kakashi: auxiliary gradient prediction (∂p/∂x,y,z) — INNOVATION
+- `#3213` brook: surface normal input features — INNOVATION
 - `#3203` vegeta: attention temperature annealing — INNOVATION
 - `#3202` senku: GLU preprocess MLP — INNOVATION
 - `#3201` jet: DomainLayerNorm — INNOVATION
@@ -24,7 +27,6 @@
 - `#3175` hinata: full noam stack — NOAM ABLATION
 
 **Champion tuning / paper-facing:**
-- `#3173` kakashi: shorter cosine T_max=15/20
 - `#3209` sanji: TFP cp_panel bug fix + multi-seed retest — STABILIZATION PRIORITY
 - `#3164` faye: paper-facing full eval (two-phase) — PAPER-FACING Track 1
 - `#3163` shouko: attn dropout=0.05
@@ -41,7 +43,6 @@
 - `#3085` kohaku: larger supernodes (SENT BACK)
 - `#3076` frieren: log-cosh loss (SENT BACK)
 - `#3067` askeladd: 32k surface points (SENT BACK)
-- `#3063` canute: paper-facing full-eval (SENT BACK)
 - `#3046` sukuna: WD+gc compound (SENT BACK)
 
 ### TandemFoil WIP (7 PRs) — GUARDRAIL ONLY per directive
@@ -54,10 +55,8 @@
 - `#3180` chopper: ANP decoder alone — NOAM ABLATION
 - `#3150` yuji: clean test row — PAPER-FACING
 
-### TandemFoil Paper WIP (11 PRs) — STABILIZATION CRISIS
-**Stabilization diagnostic (HIGHEST PRIORITY — baseline unreproducible):**
-- `#3205` jin: TFP seed sensitivity (seed=0 verify, seed=42 + gc/warmup/asinh probes)
-- `#3208` brook: TFP pressure stabilization (base config, lower LR, AdamW vs Lion)
+### TandemFoil Paper WIP (9 PRs) — STABILIZATION CRISIS
+**Stabilization status: CODE REGRESSION CONFIRMED — seed=0 broken, waiting for sanji #3209 bug fix**
 
 **Noam-pivot experiments:**
 - `#3183` rei: ANP+T_max=150 — NOAM ABLATION
@@ -81,15 +80,14 @@
 **Other:**
 - `#3172` robin: LR warmup (5-ep/10-ep)
 - `#3169` nami: heads sweep 4H/16H
+- `#3215` tanjiro: Huber loss on volume channel (robust to outliers) — AF VOLUME FOCUS
+- `#3212` jin: PCGrad multi-objective gradient surgery — AF VOLUME FOCUS
 - `#3211` spike: AF vol_loss_scale learnable scalar (noam port) — AF VOLUME FOCUS
 - `#3204` gilbert: vol-weight=15x/20x clean control (no extra features) — AF VOLUME FOCUS
-- `#3167` gilbert: higher LR (8e-4/1e-3)
-- `#3166` vegeta: vol-weight=5.0/7.0+EMA=0.999
+- `#3195` piccolo: Re-stratified sampling
 - `#3156` edward: softer gc=0.5
 - `#3144` violet: vol-weight=2.0+EMA=0.999
-- `#3199` megumi: DM EMA=0.9999/0.99995 (noam optimal decay) — NOAM ABLATION
 - `#3129` chrome: 4L/256d deeper
-- `#3101` tanjiro: vol-loss-weight=1.5 (SENT BACK)
 
 ## Steering Anchors
 
@@ -128,12 +126,12 @@
 - **Track 2 (Innovation):** Genuinely new physics-aware and ML ideas — NOT Radford/Noam recipe retuning. Search for benchmark-specific improvements. Code ports from noam: attn temp annealing (#3203), GLU preprocess (#3202), DomainLayerNorm (#3201). Look beyond: mesh-based operators, physics-informed losses, geometry encoders, domain-specific normalizations.
 - Bold ideas permitted and encouraged here. Local neighborhood exhausted.
 
-#### TandemFoil Paper — Stabilization First (CRISIS MODE)
-- **The failure mode is NaN/inf, not underperformance.** Optimize for finding ONE finite reproducible recipe, not performance.
-- Protocol: smoke test (1-3 epochs) → short debug (10-20 epochs) → long run ONLY after both are clean.
+#### TandemFoil Paper — Stabilization First (CRISIS MODE — UPGRADED)
+- **CODE REGRESSION CONFIRMED (#3205):** seed=0 no longer reproduces champion. ALL seeds + ALL stabilization probes → Inf pressure. This is NOT seed sensitivity — it's a broken pressure transform path in current codebase.
+- **Base config (no physics) IS stable** across seeds (#3208): floor ~0.047-0.049. Velocity channels healthy. Pathology isolated to sinh inverse pressure transform.
+- **Root cause:** cp_panel_prior_index() bug (#3200) + possible eval-time sinh overflow. Sanji #3209 fixing the cp_panel bug — MUST land before any further TFP optimization.
+- Protocol: fix bug → verify seed=0 reproduces → then reintroduce pressure transforms one at a time.
 - NaN/inf failures get closed immediately, no extensions.
-- brook #3200 reveals: base config (no physics) stable at 0.047; `cp_panel_prior_index()` is broken for TFP dataset — **champion may be unreproducible** with current code.
-- Next step: fix `cp_panel_prior_index()` bug, then re-run stable configs.
 
 #### TandemFoil — Guardrail Only
 - Parity is healthy. Minimal compute sink. Keep as sanity anchor, not a major compute investment.
@@ -146,15 +144,25 @@
 - Physics features: TF only (TFP pipeline bug: cp_panel/TE/vortex corrupted)
 - `--re-stratified-sampling` — OOD Re robustness — TF/AF
 
-### DM Innovation Track (code ports from noam)
+### DM Innovation Track (expanded beyond recipe tuning)
+**Code ports from noam:**
 - Attention temperature annealing (-11% on noam) — vegeta #3203
 - GLU preprocess MLP — senku #3202
 - DomainLayerNorm — jet #3201 (merged; awaiting results)
-- Still needed: vol_loss_scale, PCGrad (for AF multi-objective)
+
+**New physics-aware/ML ideas (cycle 48):**
+- Surface normal input features (local geometry context) — brook #3213
+- Auxiliary gradient prediction (∂p/∂x,y,z as regularization) — kakashi #3214
+- Attention distance bias (ALiBi-inspired spatial prior) — canute #3216
+
+**AF volume closure:**
+- vol_loss_scale learnable scalar (noam port, -15.9%) — spike #3211
+- PCGrad gradient surgery (surface/volume conflict resolution) — jin #3212
+- Huber loss on volume channel (robust to outlier gradients) — tanjiro #3215
 
 ### Critical Known Bug
-- **`cp_panel_prior_index()` broken for tandemfoil_paper** (PR #3200): When `--enable-cp-panel` + `--enable-pressure-prior-addition` are both set, the function returns the wrong index (last Fourier feature, not cp_panel), corrupting all pressure predictions. Fix required before running any long TFP experiments with these flags.
-- **TFP champion (#3025, 0.002383) may be unreproducible** with current codebase — this is a CRITICAL issue to resolve.
+- **`cp_panel_prior_index()` broken for tandemfoil_paper** (PR #3200): Fix in progress (sanji #3209).
+- **TFP champion config BROKEN in current codebase** — code regression confirmed (#3205). Seed=0 no longer reproduces. Base config without physics is stable (#3208). Root cause: pressure transform path (sinh inverse).
 
 ## Key Dead Ends (Do Not Repeat)
 
@@ -169,7 +177,7 @@
 - Polynomial LR (no cosine troughs): catastrophic — troughs are load-bearing stability features
 - OneCycleLR (no troughs): 8.04% best, sustained high-LR warmup worse than cosine peaks (without EMA+gc)
 - SWA: equal-weight averaging poisons across divergent basins (88.98%)
-- T_max=50+gc (both 0.5 and 1.0): diverge — T_max=30 only viable period
+- T_max≠30: T_max=50+gc diverges; T_max=15→4.406% plateaued; T_max=20→4.943% diverged. T_max=30 ONLY viable period
 - 10-ep warmup+gc=1.0: 11.2% then diverged
 - 5-ep warmup+gc=1.0: pending (chopper)
 - LR warmup + EMA+gc=0.5: 5-ep=11.325% diverged, 10-ep=3.918% plateaued (didn't beat 3.833%)
@@ -199,7 +207,7 @@
 - 2L/384d and 3L/384d: catastrophic divergence
 - EMA<0.999 (0.99, 0.995 both worse)
 - T_max≠50 (30 and 100 both worse)
-- Vol-weight<10x (2x/5x/7x): all worse on both metrics. 10x+EMA=0.999 is AF sweet spot
+- Vol-weight<10x (1.5x/2x/3x/5x/7x): ALL worse on both metrics across 6 tested values. 10x+EMA=0.999 is AF sweet spot
 - Vol-weight=30x: catastrophic — surface 4.3x worse, vol 3.1x worse
 - LR>6e-4: 8e-4 +110% surface, 1e-3 catastrophic divergence
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 03:00 (advisor cycle 59)
+- **Date:** 2026-04-24 03:15 (advisor cycle 60)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -32,7 +32,7 @@
 - `#3209` sanji: TFP cp_panel bug fix + multi-seed retest — STABILIZATION PRIORITY
 - `#3164` faye: paper-facing full eval (two-phase) — PAPER-FACING Track 1
 - `#3160` griffith: 16H heads
-- `#3220` nobara: Mixup regularization (feature interpolation) — INNOVATION
+- `#3237` nobara: snapshot ensemble at cosine troughs (test-time averaging) — INNOVATION
 - `#3207` historia: DM true monotonic cosine (T_max=393606) — corrected retest
 - `#3206` jet: DM 600 batches + gc=0.5 + EMA (stabilized retest)
 - `#3152` eren: EMA decay sweep (0.999 vs 0.9995)
@@ -85,7 +85,7 @@
 - `#3227` casca: focal-MSE volume loss (upweight hard predictions) — AF VOLUME FOCUS
 - `#3226` chihiro: volume weight curriculum (20x→10x) — AF VOLUME FOCUS
 - `#3223` norman: volume smoothness regularization — AF VOLUME FOCUS
-- `#3222` rei: proximity-weighted volume loss (surface distance) — AF VOLUME FOCUS
+- `#3238` rei: WD=0 ablation on vol-10x+EMA champion — AF VOLUME FOCUS
 - `#3218` shouko: GradNorm adaptive multi-task loss balancing — AF VOLUME FOCUS
 - `#3215` tanjiro: Huber loss on volume channel (robust to outliers) — AF VOLUME FOCUS
 - `#3211` spike: AF vol_loss_scale learnable scalar (noam port) — AF VOLUME FOCUS
@@ -187,6 +187,7 @@
 - Noam features on DM: DEFINITIVELY DEAD. Asinh triple-confirmed (4.072%/4.421%/4.475%), residual needs asinh+still→3.999%, full stack→4.447%. Features tuned for T_max=150/3H/no-gc regime
 - Attention distance bias (ALiBi): linear diverges, log=5.511% at timeout. Redundant with slice-based spatial grouping
 - Auxiliary gradient prediction (∂p/∂x,y,z): kNN targets too noisy — aux_weight=0.1 diverges ep22, aux_weight=0.01 best 5.485% (+43%). Noise dominates once primary loss flattens
+- Mixup regularization (buffer-based latent): 85-109% worse, crashed ~ep235. Buffer staleness + non-smooth geometry-specific latent space fundamentally incompatible with bs=1
 - Head count sweep complete: 2H=catastrophic, 4H=6.650%, 8H=3.833% CHAMPION, 16H=4.099%. 8H (64d/head) is definitive
 - 10-ep warmup+gc=1.0: 11.2% then diverged
 - 5-ep warmup+gc=1.0: pending (chopper)
@@ -215,6 +216,7 @@
 **AirfRANS:**
 - asinh-pressure: DEFINITIVELY DEAD — 5 independent confirmations (#3191 T1/T2, #3177 T1/T2/T3). sinh() denormalization exponentially amplifies pressure errors. Non-pressure channels fine. Incompatible with AF pressure distribution.
 - PCGrad gradient surgery: 5-6x worse on both metrics (#3212). retain_graph=True disables torch.compile (40% throughput loss). Gradient conflict is NOT the bottleneck.
+- Proximity-weighted volume loss: 118-2516% worse (#3222). Extreme weight ratios starve far-field gradients while overdriving near-surface. Structural failure at scale=0.1/eps=0.01
 - 3L depth (with or without EMA): catastrophic divergence confirmed twice
 - 2L/384d and 3L/384d: catastrophic divergence
 - EMA<0.999 (0.99, 0.995 both worse)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 06:00 (advisor cycle 66)
+- **Date:** 2026-04-24 06:30 (advisor cycle 67)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -33,6 +33,7 @@
 - `#3209` sanji: TFP cp_panel bug fix + multi-seed retest — STABILIZATION PRIORITY
 - `#3244` faye: DM Track 1 paper-facing full eval (champion config, NO --max-eval-batches) — PAPER-FACING Track 1
 - `#3160` griffith: 16H heads
+- `#3249` shouko: decaying weight decay schedule (WD=1e-4/5e-5 → 0 over 300ep) — INNOVATION
 - `#3248` nobara: decaying peak LR at cosine restarts (SGDR eta_mult) — INNOVATION
 - `#3152` eren: EMA decay sweep (0.999 vs 0.9995)
 - `#3146` taki: top-5 checkpoint averaging
@@ -86,7 +87,6 @@
 - `#3226` chihiro: volume weight curriculum (20x→10x) — AF VOLUME FOCUS
 - `#3223` norman: volume smoothness regularization — AF VOLUME FOCUS
 - `#3238` rei: WD=0 ablation on vol-10x+EMA champion — AF VOLUME FOCUS
-- `#3218` shouko: GradNorm adaptive multi-task loss balancing — AF VOLUME FOCUS
 - `#3245` tanjiro: per-channel volume loss weighting (upweight nut×4, p×2) — AF VOLUME FOCUS
 - `#3211` spike: AF vol_loss_scale learnable scalar (noam port) — AF VOLUME FOCUS
 - `#3240` gilbert: joint checkpoint selection + vol-weight 11x/12x/13x fine sweep — AF VOLUME FOCUS
@@ -222,6 +222,7 @@
 **AirfRANS:**
 - asinh-pressure: DEFINITIVELY DEAD — 5 independent confirmations (#3191 T1/T2, #3177 T1/T2/T3). sinh() denormalization exponentially amplifies pressure errors. Non-pressure channels fine. Incompatible with AF pressure distribution.
 - PCGrad gradient surgery: 5-6x worse on both metrics (#3212). retain_graph=True disables torch.compile (40% throughput loss). Gradient conflict is NOT the bottleneck.
+- GradNorm adaptive loss balancing: surface 1.74x worse, vol 2.64x worse (#3218). retain_graph=True breaks compile (halves throughput). GradNorm converges to w_vol~8x, LOWER than hand-tuned 10x — fights intentional asymmetry
 - Proximity-weighted volume loss: 118-2516% worse (#3222). Extreme weight ratios starve far-field gradients while overdriving near-surface. Structural failure at scale=0.1/eps=0.01
 - Huber loss on volume channel: no improvement over MSE on either metric (#3215). AF volume residuals are well-behaved, not heavy-tailed — Huber δ threshold adds no benefit
 - 3L depth (with or without EMA): catastrophic divergence confirmed twice

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 08:00 (advisor cycle 70)
+- **Date:** 2026-04-24 08:30 (advisor cycle 71)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -18,6 +18,8 @@
 - `#3233` gojo: stochastic depth (LayerDrop) regularization — INNOVATION
 - `#3231` emma: surface pressure gradient smoothness regularization — INNOVATION (physics-informed)
 - `#3251` fern: Pre-LayerNorm architecture ablation (+ RMSNorm variant) — INNOVATION
+- `#3259` zenitsu: curvature-weighted loss (per-point weighting by local curvature) — INNOVATION
+- `#3258` emma: auxiliary surface normal prediction (multi-task regularization) — INNOVATION
 - `#3252` mitsuha: progressive surface point training (resolution curriculum) — INNOVATION
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3228` chopper: stochastic weight perturbation at cosine troughs — INNOVATION
@@ -48,10 +50,8 @@
 - `#3067` askeladd: 32k surface points (SENT BACK)
 - `#3046` sukuna: WD+gc compound (SENT BACK)
 
-### TandemFoil WIP (3 PRs) — GUARDRAIL ONLY per directive
+### TandemFoil WIP (2 PRs) — GUARDRAIL ONLY per directive
 **New champion config:** ANP+full physics+T_max=150+gc=0.2+EMA=0.999+96sl+Lookahead+compile+re-strat (#3185)
-**Noam-pivot experiments (still running):**
-- `#3196` zenitsu: EMA decay sweep (0.9999/0.99995) — NOAM ABLATION
 - `#3150` yuji: clean test row — PAPER-FACING
 
 ### TandemFoil Paper WIP (9 PRs) — STABILIZATION CRISIS
@@ -190,6 +190,7 @@
 - Snapshot ensemble (cosine trough checkpoints): test=6.044% single best, WORSE with more snapshots (K=3→6.24%, K=5→6.98%, K=6→7.81%). Quality gradient dominates diversity. EMA already provides implicit smoothing.
 - Spectral norm on QKV: 4.035% (+5.3%). σ=1 cap over-restricts attention capacity. Late collapse ep502 from unconstrained FFN layers. gc=0.5 already solves restart stability.
 - Self-distillation via EMA teacher: α=0.3→6.446% diverge ep170, α=0.1→4.323% diverge ep400. EMA=0.9995 lag creates destabilizing feedback loop. Same EMA for ckpt+teacher incompatible.
+- Pressure gradient smoothness reg (KNN): λ=0.01→4.481%, λ=0.1→4.876%, λ=1.0→12.52%. KNN 30% throughput overhead + sharp car features penalized. Remaining error is systematic bias, not noise.
 - Attention temperature annealing: 4.024% (+5% vs 3.833%). External annealed τ compounds with existing learnable per-head τ. noam result doesn't transfer
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 21:30 (advisor cycle 45 — closed #3168/#3154/#3083, assigning jin/brook/historia/jet)
+- **Date:** 2026-04-23 12:30 (advisor cycle 46 — updated per human directive #3174)
 - **Branch:** radford
 - **Idle students:** 0 (4 being assigned)
 - **PRs ready for review:** 0
@@ -111,27 +111,50 @@
 
 ## Current Research Focus
 
-### LATEST HUMAN DIRECTIVE — Issue #3174 Update (2026-04-23 11:08)
+### LATEST HUMAN DIRECTIVES — Issue #3174 (2026-04-23 11:08–11:48)
 
-1. **AirfRANS → "Finish the job"**: Surface is strong. ALL new AF work must focus on **volume error reduction only** (vol_mse < 0.0017), without regressing surface.
-2. **DrivAerML → Two-track strategy**:
-   - **Track 1:** Stable full-eval champion track (best-checkpoint test eval) — faye #3164
-   - **Track 2:** Innovation track for genuinely new physics-aware and ML ideas — NOT more Radford/Noam recipe tuning. Code ports from noam: attn temp annealing (vegeta #3203), GLU preprocess (senku #3202), DomainLayerNorm (jet #3201)
-3. **TandemFoil Paper → Stabilization-first**: Failure mode is NaN/inf, not underperformance. Short, cheap diagnostic experiments to find one finite reproducible recipe. brook #3200 mapping stability.
-4. **TandemFoil → Guardrail only**: Parity is healthy. Minimal compute sink.
+> "We are no longer in a broad discovery phase, and we should stop acting like every benchmark wants the same recipe."
+> — morganmcg1, 2026-04-23
 
-### Noam Feature Activation (still highest priority)
-- `--anp-srf` — ANP cross-attention decoder (-58.9% TF!) — TF/TFP only
-- `--asinh-pressure --asinh-scale 0.75` — asinh pressure norm — ALL datasets
-- `--residual-prediction` — learned correction to freestream — ALL datasets
-- Physics features: TF only (TFP pipeline bug: cp_panel/TE/vortex silently ignored)
-- `--re-stratified-sampling` — OOD Re robustness — TF/TFP/AF
+**Strategic posture by benchmark (BINDING):**
+
+#### AirfRANS — "Finish the Job" (Volume Closure Mode)
+- Surface is already strong. **ALL new AF experiments must target vol_mse < 0.0017 specifically.**
+- Surface error is a hard constraint: NO regressions accepted, even for large volume gains.
+- No more broad novelty sweeps. This lane is in finish-the-job mode.
+
+#### DrivAerML — Two-Track Approach
+- **Track 1 (Stable Champion):** Keep current best config alive with full best-checkpoint test eval. No shortcuts. No `--max-eval-batches` on paper-facing runs.
+- **Track 2 (Innovation):** Genuinely new physics-aware and ML ideas — NOT Radford/Noam recipe retuning. Search for benchmark-specific improvements. Code ports from noam: attn temp annealing (#3203), GLU preprocess (#3202), DomainLayerNorm (#3201). Look beyond: mesh-based operators, physics-informed losses, geometry encoders, domain-specific normalizations.
+- Bold ideas permitted and encouraged here. Local neighborhood exhausted.
+
+#### TandemFoil Paper — Stabilization First (CRISIS MODE)
+- **The failure mode is NaN/inf, not underperformance.** Optimize for finding ONE finite reproducible recipe, not performance.
+- Protocol: smoke test (1-3 epochs) → short debug (10-20 epochs) → long run ONLY after both are clean.
+- NaN/inf failures get closed immediately, no extensions.
+- brook #3200 reveals: base config (no physics) stable at 0.047; `cp_panel_prior_index()` is broken for TFP dataset — **champion may be unreproducible** with current code.
+- Next step: fix `cp_panel_prior_index()` bug, then re-run stable configs.
+
+#### TandemFoil — Guardrail Only
+- Parity is healthy. Minimal compute sink. Keep as sanity anchor, not a major compute investment.
+- No ambitious per-run experiments here.
+
+### Noam Feature Activation (context-dependent per benchmark)
+- `--anp-srf` — ANP cross-attention decoder (-58.9% TF!) — TF only (TFP stability-first)
+- `--asinh-pressure --asinh-scale 0.75` — asinh pressure norm — DM, AF (not TFP until stable)
+- `--residual-prediction` — learned correction to freestream — DM, AF
+- Physics features: TF only (TFP pipeline bug: cp_panel/TE/vortex corrupted)
+- `--re-stratified-sampling` — OOD Re robustness — TF/AF
 
 ### DM Innovation Track (code ports from noam)
 - Attention temperature annealing (-11% on noam) — vegeta #3203
 - GLU preprocess MLP — senku #3202
-- DomainLayerNorm — jet #3201
+- DomainLayerNorm — jet #3201 (merged; awaiting results)
 - Still needed: vol_loss_scale, PCGrad (for AF multi-objective)
+
+### Critical Known Bug
+- **`cp_panel_prior_index()` broken for tandemfoil_paper** (PR #3200): When `--enable-cp-panel` + `--enable-pressure-prior-addition` are both set, the function returns the wrong index (last Fourier feature, not cp_panel), corrupting all pressure predictions. Fix required before running any long TFP experiments with these flags.
+- **TFP champion (#3025, 0.002383) may be unreproducible** with current codebase — this is a CRITICAL issue to resolve.
 
 ## Key Dead Ends (Do Not Repeat)
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -29,7 +29,7 @@
 - `#3152` eren: EMA decay sweep (0.999 vs 0.9995)
 - `#3146` taki: top-5 checkpoint averaging
 - `#3143` thorfinn: Lookahead(AdamW)
-- `#NEW` gohan: TFP asinh-pressure isolation — BEING ASSIGNED
+- `#3198` gohan: TFP asinh-pressure isolation (scale=0.75/0.5) — NOAM ABLATION
 - `#3121` levi: dropout regularization sweep
 - `#3195` piccolo: AF re-stratified sampling alone — NOAM ABLATION
 - `#3110` einar: beta2=0.99/0.995

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -12,7 +12,7 @@
 **Innovation track (new physics-aware/ML ideas per directive):**
 - `#3224` fern: spectral normalization on attention layers — INNOVATION
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
-- canute: self-distillation with EMA teacher — INNOVATION (PR pending)
+- `#3225` canute: self-distillation with EMA teacher — INNOVATION
 - `#3214` kakashi: auxiliary gradient prediction (∂p/∂x,y,z) — INNOVATION
 - `#3217` brook: Fourier encoding of surface normals — INNOVATION
 - `#3203` vegeta: attention temperature annealing — INNOVATION
@@ -21,10 +21,10 @@
 
 **Noam-pivot experiments:**
 - `#3199` megumi: EMA=0.9999/0.99995 (noam optimal decay) — NOAM ABLATION
-- casca: → AF focal-MSE volume loss (PR pending)
+- `#3227` casca: → AF focal-MSE volume loss
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3194` bulma: higher LR sweep (5.5e-4/6e-4)
-- chihiro: → AF vol-weight curriculum (PR pending)
+- `#3226` chihiro: → AF vol-weight curriculum
 - `#3181` himmel: asinh+residual on champion — NOAM ABLATION
 - `#3219` hinata: SAM optimizer (flat-basin restart robustness) — INNOVATION
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -31,8 +31,8 @@
 - `#3161` spike: eta_min=1e-5 (cosine floor)
 - `#3160` griffith: 16H heads
 - `#3155` nobara: longer T_max (45/60)
-- `#NEW` historia: DM true monotonic cosine (T_max=393606) — corrected retest
-- `#NEW` jet: DM 600 batches + gc=0.5 + EMA (stabilized retest)
+- `#3207` historia: DM true monotonic cosine (T_max=393606) — corrected retest
+- `#3206` jet: DM 600 batches + gc=0.5 + EMA (stabilized retest)
 - `#3152` eren: EMA decay sweep (0.999 vs 0.9995)
 - `#3146` taki: top-5 checkpoint averaging
 - `#3143` thorfinn: Lookahead(AdamW)
@@ -57,8 +57,8 @@
 
 ### TandemFoil Paper WIP (11 PRs) — STABILIZATION CRISIS
 **Stabilization diagnostic (HIGHEST PRIORITY — baseline unreproducible):**
-- `#NEW` jin: TFP seed sensitivity (seed=0 verify, seed=42 + gc/warmup/asinh probes)
-- `#NEW` brook: TFP pressure stabilization (base config, lower LR, AdamW vs Lion)
+- `#3205` jin: TFP seed sensitivity (seed=0 verify, seed=42 + gc/warmup/asinh probes)
+- `#3208` brook: TFP pressure stabilization (base config, lower LR, AdamW vs Lion)
 
 **Noam-pivot experiments:**
 - `#3183` rei: ANP+T_max=150 — NOAM ABLATION

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -2,7 +2,7 @@
 
 - **Date:** 2026-04-23 23:30 (advisor cycle 50)
 - **Branch:** radford
-- **Idle students:** 0 (shouko being assigned)
+- **Idle students:** 0
 - **PRs ready for review:** 0
 - **CRITICAL:** TFP champion config is BROKEN — code regression since #3025, seed=0 no longer reproduces (#3205). Waiting for sanji #3209 cp_panel bug fix.
 
@@ -29,7 +29,6 @@
 **Champion tuning / paper-facing:**
 - `#3209` sanji: TFP cp_panel bug fix + multi-seed retest — STABILIZATION PRIORITY
 - `#3164` faye: paper-facing full eval (two-phase) — PAPER-FACING Track 1
-- `#3163` shouko: ~~attn dropout=0.05~~ → reassigning to AF GradNorm
 - `#3160` griffith: 16H heads
 - `#3155` nobara: longer T_max (45/60)
 - `#3207` historia: DM true monotonic cosine (T_max=393606) — corrected retest
@@ -80,6 +79,7 @@
 **Other:**
 - `#3172` robin: LR warmup (5-ep/10-ep)
 - `#3169` nami: heads sweep 4H/16H
+- `#3218` shouko: GradNorm adaptive multi-task loss balancing — AF VOLUME FOCUS
 - `#3215` tanjiro: Huber loss on volume channel (robust to outliers) — AF VOLUME FOCUS
 - `#3212` jin: PCGrad multi-objective gradient surgery — AF VOLUME FOCUS
 - `#3211` spike: AF vol_loss_scale learnable scalar (noam port) — AF VOLUME FOCUS

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -12,6 +12,7 @@
 **Innovation track (new physics-aware/ML ideas per directive):**
 - `#3224` fern: spectral normalization on attention layers — INNOVATION
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
+- `#3228` chopper: stochastic weight perturbation at cosine troughs — INNOVATION
 - `#3225` canute: self-distillation with EMA teacher — INNOVATION
 - `#3214` kakashi: auxiliary gradient prediction (∂p/∂x,y,z) — INNOVATION
 - `#3217` brook: Fourier encoding of surface normals — INNOVATION
@@ -21,10 +22,7 @@
 
 **Noam-pivot experiments:**
 - `#3199` megumi: EMA=0.9999/0.99995 (noam optimal decay) — NOAM ABLATION
-- `#3227` casca: → AF focal-MSE volume loss
-- `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3194` bulma: higher LR sweep (5.5e-4/6e-4)
-- `#3226` chihiro: → AF vol-weight curriculum
 - `#3181` himmel: asinh+residual on champion — NOAM ABLATION
 - `#3219` hinata: SAM optimizer (flat-basin restart robustness) — INNOVATION
 
@@ -52,7 +50,6 @@
 - `#3197` gojo: residual-prediction alone — NOAM ABLATION
 - `#3196` zenitsu: EMA decay sweep (0.9999/0.99995) — NOAM ABLATION
 - `#3189` emma: asinh+physics features — NOAM ABLATION
-- chopper: → DM weight perturbation at troughs (PR pending)
 - `#3150` yuji: clean test row — PAPER-FACING
 
 ### TandemFoil Paper WIP (9 PRs) — STABILIZATION CRISIS
@@ -79,6 +76,8 @@
 **Other:**
 - `#3172` robin: LR warmup (5-ep/10-ep)
 - `#3169` nami: heads sweep 4H/16H
+- `#3227` casca: focal-MSE volume loss (upweight hard predictions) — AF VOLUME FOCUS
+- `#3226` chihiro: volume weight curriculum (20x→10x) — AF VOLUME FOCUS
 - `#3223` norman: volume smoothness regularization — AF VOLUME FOCUS
 - `#3222` rei: proximity-weighted volume loss (surface distance) — AF VOLUME FOCUS
 - `#3218` shouko: GradNorm adaptive multi-task loss balancing — AF VOLUME FOCUS

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 11:30 (advisor cycle 82)
+- **Date:** 2026-04-24 11:45 (advisor cycle 83)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -17,7 +17,7 @@
 - `#3243` jet: prediction-error-weighted surface sampling (hard example mining) — INNOVATION
 - `#3242` historia: label smoothing / target noise augmentation — INNOVATION
 - `#3235` kakashi: multi-exit prediction (aux losses at intermediate layers) — INNOVATION
-- `#3263` gojo: Sparse MoE FFN (K=4/8 experts, top-2 routing, regime-specific computation) — INNOVATION
+- `#3273` gojo: Grouped Query Attention (GQA, 2/4 KV heads) — throughput-focused INNOVATION
 - `#3251` fern: Pre-LayerNorm architecture ablation (+ RMSNorm variant) — INNOVATION
 - `#3259` zenitsu: curvature-weighted loss (per-point weighting by local curvature) — INNOVATION
 - `#3269` emma: learned error correction head (boosting-inspired self-correction) — INNOVATION
@@ -200,6 +200,7 @@
 - EMA periodic reset: 100ep→4.426% cascade ep335, 50ep→6.818% diverge ep108 (#3247). EMA is primary gradient stabilizer — reset removes protective smoothing at high-curvature basin point
 - Weight Standardization: 67.9%/71.4% catastrophic (#3264). WS × cosine restarts × bs=1 feedback loop. Original BiT paper used epoch-level decay not per-batch restarts
 - SGDR eta_mult (decaying restart LR): 4.153%/12.64% (#3248). Confounded by switching to warm restarts. Sharp restart jumps more destabilizing than baseline's smooth cosine
+- Sparse MoE FFN (K=4/8, top-2): 5.09%/5.35% (#3263). 1.7-2.2x throughput penalty → epoch starvation. Routing collapses to uniform. Per-epoch curve parallel to dense — FFN is not the bottleneck
 - EMA>0.9995: 0.9999→7.106% NaN ep171, 0.99995→7.095% collapse ep120 (#3199). EMA=0.9995 sharp optimum bracketed both directions
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,11 +1,11 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 18:30 (advisor cycle 40 — closed #3159/#3158, assigning franky/bulma)
+- **Date:** 2026-04-23 19:30 (advisor cycle 41 — closed #3142/#3115/#3079, assigning zenitsu/gojo/piccolo)
 - **Branch:** radford
-- **Idle students:** 0
+- **Idle students:** 0 (zenitsu/gojo/piccolo being assigned)
 - **PRs ready for review:** 0
 
-## Fleet Status (59 active PRs)
+## Fleet Status (56 active PRs → 59 after assignments)
 
 ### DrivAerML WIP (30 PRs)
 **Noam-pivot experiments (highest priority):**
@@ -31,12 +31,12 @@
 - `#3143` thorfinn: Lookahead(AdamW)
 - `#3132` gohan: eta_min=5e-5+gc=1.0
 - `#3121` levi: dropout regularization sweep
-- `#3115` piccolo: bs2+25k pts (SENT BACK — 50k+gc=0.5+EMA)
+- `#NEW` piccolo: AF re-stratified sampling alone — BEING ASSIGNED
 - `#3110` einar: beta2=0.99/0.995
 - `#3109` guts: lr=4e-4 full-eval
 - `#3085` kohaku: larger supernodes (SENT BACK — retry+gc=1.0)
 - `#3083` jet: max-train-batches=600
-- `#3079` gojo: 4L/640d (SENT BACK — lr=3e-4+T_max=60+EMA)
+- `#NEW` gojo: TF residual-prediction alone — BEING ASSIGNED
 - `#3076` frieren: log-cosh loss (SENT BACK — retry+gc=1.0)
 - `#3067` askeladd: 32k surface points (SENT BACK — add max-eval-batches 200)
 - `#3063` canute: paper-facing full-eval (SENT BACK — two-phase)
@@ -50,8 +50,8 @@
 - `#3180` chopper: ANP decoder alone — NOAM ABLATION
 
 **Other:**
+- `#NEW` zenitsu: TF EMA decay sweep (0.9999/0.99995) — BEING ASSIGNED
 - `#3150` yuji: clean test row gc=0.3 champion — PAPER-FACING
-- `#3142` zenitsu: gc=0.3+longer budget (480-min)
 
 ### TandemFoil Paper WIP (10 PRs)
 **Noam-pivot experiments (highest priority):**
@@ -169,8 +169,9 @@
 - Attention dropout without EMA/gc: toxic combo with T_max=30
 - Cosine eta_min without EMA/gc: diverges (7.255-7.918%)
 - Surface points ≠50k: 16k=11.672%, 32k=7.558%, 64k=12.16% (even with EMA+gc) — 50k only viable count
-- 4L/640d at lr=5e-4: 8.636% then diverge ep82 even with EMA+gc (grad_norm=Infinity)
+- 4L/640d: dead at ALL tested configs — lr=5e-4+EMA+gc: 8.636% diverge ep82 (#3159); lr=5e-4 no-EMA: 4.516%/6.457%/5.724% all diverge (#3079). Width amplifies gradients beyond gc containment.
 - lr<5e-4 under EMA: steep monotonic cliff (4.5e-4=4.134%, 4e-4=5.924%)
+- bs=2: Blackwell bf16+bs>1 CUBLAS bug forces fp32, gets only 37% of optimizer steps. 4.373% at bs=2/fp32 vs 3.833% bs=1/bf16. Platform-blocked.
 
 **TandemFoil Paper:**
 - T_max≠10 (all directions diverge)
@@ -190,6 +191,7 @@
 
 **TandemFoil:**
 - gc≥0.5: monotonically worse than gc=0.3
+- Longer budget (480-min): no benefit with cosine T_max=10 cycling — more epochs = more independent draws, not monotone descent (22.016 at 480min vs 21.909 at 360min)
 
 ## Mandatory Config Rules
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -22,8 +22,8 @@
 - `#3163` shouko: attn dropout=0.05
 - `#3161` spike: eta_min=1e-5 (cosine floor)
 - `#3160` griffith: 16H heads
-- `#NEW` franky: DM residual-prediction alone — BEING ASSIGNED
-- `#NEW` bulma: DM higher LR sweep (5.5e-4/6e-4) — BEING ASSIGNED
+- `#3193` franky: DM residual-prediction alone — NOAM ABLATION
+- `#3194` bulma: DM higher LR sweep (5.5e-4/6e-4)
 - `#3155` nobara: longer T_max (45/60)
 - `#3154` historia: monotonic cosine (no restarts)
 - `#3152` eren: EMA decay sweep (0.999 vs 0.9995)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 07:30 (advisor cycle 69)
+- **Date:** 2026-04-24 08:00 (advisor cycle 70)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -21,6 +21,7 @@
 - `#3252` mitsuha: progressive surface point training (resolution curriculum) — INNOVATION
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3228` chopper: stochastic weight perturbation at cosine troughs — INNOVATION
+- `#3256` alphonse: coordinate noise augmentation (σ=0.001/0.005 input perturbation) — INNOVATION
 - `#3253` canute: input feature dropout (Fourier channel dropout 10%/20%) — INNOVATION
 - `#3202` senku: GLU preprocess MLP — INNOVATION
 - `#3201` jet: DomainLayerNorm — INNOVATION
@@ -67,12 +68,10 @@
 - `#2949` vash: depth/width sweep (LR=5e-5)
 
 ### AirfRANS WIP (14 PRs)
-**Non-asinh noam feature ablation (highest priority — clean tests):**
-- `#3230` alphonse: residual-prediction + re-stratified sampling (NO asinh) — CLEAN NOAM ABLATION
-
 **Volume closure experiments:**
+- `#3255` gohan: no-Lookahead/no-compile champion full budget — AF VOLUME FOCUS (critical ablation follow-up)
+- `#3257` chihiro: extended training via reduced eval frequency (every 3/5 epochs) — AF VOLUME FOCUS
 - `#3241` hinata: T_max=75 + vol-weight=10x/12x on champion — AF VOLUME FOCUS (schedule gap-fill)
-- `#3236` gohan: Lookahead(AdamW) + torch.compile on vol-10x champion — AF VOLUME FOCUS
 - `#3234` jin: lower LR sweep (5e-4/4e-4) on vol-10x champion — AF VOLUME FOCUS
 - `#3232` nezuko: vol-weight warm-up schedule (1x→10x linear ramp over 200ep) — AF VOLUME FOCUS
 
@@ -84,7 +83,6 @@
 - `#3172` robin: LR warmup — SENT BACK (confounded config, re-running with correct champion config)
 - `#3169` nami: heads sweep 4H/16H
 - `#3227` casca: focal-MSE volume loss (upweight hard predictions) — AF VOLUME FOCUS
-- `#3226` chihiro: volume weight curriculum (20x→10x) — AF VOLUME FOCUS
 - `#3254` norman: multi-seed champion run (seeds 42/123/789) — AF VOLUME FOCUS
 - `#3238` rei: WD=0 ablation on vol-10x+EMA champion — AF VOLUME FOCUS
 - `#3245` tanjiro: per-channel volume loss weighting (upweight nut×4, p×2) — AF VOLUME FOCUS
@@ -226,6 +224,9 @@
 - PCGrad gradient surgery: 5-6x worse on both metrics (#3212). retain_graph=True disables torch.compile (40% throughput loss). Gradient conflict is NOT the bottleneck.
 - GradNorm adaptive loss balancing: surface 1.74x worse, vol 2.64x worse (#3218). retain_graph=True breaks compile (halves throughput). GradNorm converges to w_vol~8x, LOWER than hand-tuned 10x — fights intentional asymmetry
 - Volume smoothness regularization (KNN): ALL 4 trials regressed both metrics 44-97% (#3223). KNN Euclidean smoothness penalizes legitimate BL/wake/shear gradients. Even λ=1e-4 harmful
+- Residual prediction (no asinh): +55-72% surface worse (#3230). AF has large separated regions — "correction from freestream" IS the entire signal. Re-stratified sampling is no-op (uniform weights)
+- Vol-weight curriculum (20x→10x / 15x→10x): collapsed or 38-52% worse on both metrics (#3226). Static 10x validated as optimal — any deviation above hurts
+- Lookahead hurts AF surface by 53% at equal epochs (#3236 ablation). Compile also hurts surface despite more epochs. Both are default-on in baseline — ambiguity on synergistic effect at long training
 - Proximity-weighted volume loss: 118-2516% worse (#3222). Extreme weight ratios starve far-field gradients while overdriving near-surface. Structural failure at scale=0.1/eps=0.01
 - Huber loss on volume channel: no improvement over MSE on either metric (#3215). AF volume residuals are well-behaved, not heavy-tailed — Huber δ threshold adds no benefit
 - 3L depth (with or without EMA): catastrophic divergence confirmed twice

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,10 +1,10 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 16:15 (advisor cycle 92)
+- **Date:** 2026-04-24 17:30 (advisor cycle 94)
 - **Branch:** radford
-- **ACTIVE DIRECTIVE: Issue #3283 — Last Ditch Benchmark Push (~8 hours remaining)**
-- **Fleet restructured.** 36 DM / 12 AF / 11 TFP / 0 TF.
-- **Harness patches (#3284):** 5/6 implemented, sent back for merge-blocking bug fix. HIGHEST PRIORITY.
+- **ACTIVE DIRECTIVE: Issue #3283 — Last Ditch Benchmark Push (~6-7 hours remaining)**
+- **Fleet:** 59 students active. 36 DM / 12 AF / 11 TFP / 0 TF.
+- **Harness patches (#3284): MERGED.** All new DM runs use --save-checkpoint --skip-update-grad-norm 100 --ema-mode fixed --ema-start-step 50
 
 ## BINDING DIRECTIVE — Issue #3283 (2026-04-24)
 
@@ -26,31 +26,31 @@ Re-run haku/tfp-t20-gc05-lr1e4 for 2-8 seeds (best_val=0.002466, best_test=0.002
 
 ## Fleet Status (restructuring in progress)
 
-### INFRASTRUCTURE (1 PR)
-- `#3284` vegeta: HARNESS PATCHES — SENT BACK for merge-blocking bug (double best-tracking). 5/6 patches implemented. **HIGHEST PRIORITY — awaiting fix.**
+### DrivAerML WIP (36 students)
+**Breakout lanes:**
+- `#3300` vegeta: **Breakout 1** — AB-UPT-style anchored decoder (geometry supernodes → surface anchor cross-attention → point decoding)
+- `#3299` zenitsu: **Breakout 4** — coordinate normalization + geometry features (xyz_norm using geometry_center/scale, normals, log_area, front-facing indicator)
+- `#3301` brook: **Breakout 3** — domain-normalized volume auxiliary (fix normalization bug at line 790, separate surface/volume TargetTransform, vol_loss_weight 0.03/0.1/0.3)
+- **Breakout 2** (metric-aware fine-tune: mse_z + raw rel-L2) — NOT YET ASSIGNED
+- **Breakout 5** (train+val retrain) — NOT YET ASSIGNED
 
-### DrivAerML WIP (~28 continuing + 8 new = 36 target)
-**Champion recovery / truth lanes (newly assigned):**
-- norman: champion recovery seed=0 no-compile (Bucket A)
-- jet: champion recovery seed=42 no-compile (Bucket A)
-- megumi: champion recovery seed=7 no-compile (Bucket A)
-- himmel: 64k surface points (Bucket C)
-- askeladd: 96k surface points (Bucket C)
-- robin: gradient-spike-safe gc=0.25 (Bucket D)
-- nami: T_max=24 narrow schedule (Bucket E)
-- chrome: T_max=36 narrow schedule (Bucket E)
-
-**Breakout lanes (newly assigned):**
-- `#3299` zenitsu: Breakout 4 — coordinate normalization + geometry features (xyz_norm, normals, log_area, front-facing)
+**Champion recovery / truth lanes:**
+- `#3293` norman: champion recovery seed=0 no-compile (Bucket A)
+- `#3285` jet: champion recovery seed=42 no-compile fixed-EMA (Bucket A)
+- `#3286` megumi: champion recovery seed=7 no-compile (Bucket A)
+- `#3289` himmel: 64k surface points (Bucket C)
+- `#3290` askeladd: 96k surface points (Bucket C)
+- `#3294` robin: gradient-spike-safe gc=0.25 (Bucket D)
+- `#3297` nami: T_max=24 narrow schedule (Bucket E)
+- `#3298` chrome: T_max=36 narrow schedule (Bucket E)
 
 **Continuing DM experiments (from pre-restructure):**
-- `#3244` faye: paper-facing full eval (SENT BACK for champion ckpt eval)
+- `#3244` faye: paper-facing full eval (SENT BACK for champion ckpt eval using --load-checkpoint)
 - `#3279` gojo: ReLU² activation
-- `#3270` brook: FiLM conditioning
 - `#3269` emma: error correction head
 - `#3267` mitsuha: SwiGLU FFN
 - `#3265` alphonse: hidden-space noise
-- `#3276` zenitsu: cosine similarity loss
+- ~~`#3276` zenitsu: cosine similarity loss~~ CLOSED dead end
 - `#3275` canute: local attention
 - `#3271` nobara: LLRD
 - `#3251` fern: Pre-LayerNorm

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,11 +1,11 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 10:00 (advisor cycle 77)
+- **Date:** 2026-04-24 10:15 (advisor cycle 78)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
-- **CRITICAL:** TFP champion config is BROKEN — code regression since #3025, seed=0 no longer reproduces (#3205). Waiting for sanji #3209 cp_panel bug fix.
-- **Known bug:** `primary_metric_key` shadowing in train.py (line ~1646 local var shadows function on line ~1428). 3 students independently fixed this cycle. Fix: rename local to `best_tracking_metric_key`.
+- **TFP UNBLOCKED:** cp_panel bug fix merged (#3209). Multi-seed reproducibility confirmed. Sanji #3266 re-running champion config to verify 0.002383 is recoverable.
+- **Both bugs fixed in codebase:** cp_panel_prior_index() guard (#3209 MERGED) + primary_metric_key shadowing (#3209 MERGED).
 
 ## Fleet Status (58 active PRs)
 
@@ -21,7 +21,7 @@
 - `#3251` fern: Pre-LayerNorm architecture ablation (+ RMSNorm variant) — INNOVATION
 - `#3259` zenitsu: curvature-weighted loss (per-point weighting by local curvature) — INNOVATION
 - `#3258` emma: auxiliary surface normal prediction (multi-task regularization) — INNOVATION
-- `#3252` mitsuha: progressive surface point training (resolution curriculum) — INNOVATION
+- `#3267` mitsuha: SwiGLU FFN activation (replace GELU with gated linear unit) — INNOVATION
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3228` chopper: stochastic weight perturbation at cosine troughs — INNOVATION
 - `#3265` alphonse: hidden-space noise regularization (post-Fourier perturbation σ=0.01/0.05) — INNOVATION
@@ -35,7 +35,7 @@
 - `#3181` himmel: asinh+residual on champion — NOAM ABLATION
 
 **Champion tuning / paper-facing:**
-- `#3209` sanji: TFP cp_panel bug fix + multi-seed retest — STABILIZATION PRIORITY
+- `#3266` sanji: TFP champion config re-verification post cp_panel fix (seed=0/42) — STABILIZATION VERIFY
 - `#3244` faye: DM Track 1 paper-facing full eval (champion config, NO --max-eval-batches) — PAPER-FACING Track 1
 - `#3160` griffith: 16H heads
 - `#3249` shouko: decaying weight decay schedule (WD=1e-4/5e-5 → 0 over 300ep) — INNOVATION
@@ -55,8 +55,8 @@
 **New champion config:** ANP+full physics+T_max=150+gc=0.2+EMA=0.999+96sl+Lookahead+compile+re-strat (#3185)
 - `#3150` yuji: clean test row — PAPER-FACING
 
-### TandemFoil Paper WIP (9 PRs) — STABILIZATION CRISIS
-**Stabilization status: CODE REGRESSION CONFIRMED — seed=0 broken, waiting for sanji #3209 bug fix**
+### TandemFoil Paper WIP (9 PRs) — STABILIZATION RESOLVED
+**Bug fix merged (#3209). Sanji #3266 verifying champion config reproducibility.**
 
 **Noam-pivot experiments:**
 - `#3179` usopp: T_max=150+wake+96sl+Lookahead — NOAM ABLATION
@@ -163,9 +163,10 @@
 - vol_loss_scale learnable scalar (noam port, -15.9%) — spike #3211
 - Per-channel volume loss weighting (upweight nut×4, p×2) — tanjiro #3245
 
-### Critical Known Bug
-- **`cp_panel_prior_index()` broken for tandemfoil_paper** (PR #3200): Fix in progress (sanji #3209).
-- **TFP champion config BROKEN in current codebase** — code regression confirmed (#3205). Seed=0 no longer reproduces. Base config without physics is stable (#3208). Root cause: pressure transform path (sinh inverse).
+### Bug Fixes (RESOLVED)
+- **`cp_panel_prior_index()` FIXED** (#3209 MERGED): Guard returns None for tandemfoil_paper. No more sinh overflow.
+- **`primary_metric_key` shadowing FIXED** (#3209 MERGED): Local variable at line ~1652 renamed, no longer shadows function at line ~1434.
+- **TFP champion config recovery in progress** — sanji #3266 verifying that 0.002383 baseline is reproducible under the fixed codebase.
 
 ## Key Dead Ends (Do Not Repeat)
 
@@ -193,6 +194,7 @@
 - Attention temperature annealing: 4.024% (+5% vs 3.833%). External annealed τ compounds with existing learnable per-head τ. noam result doesn't transfer
 - Stochastic depth/LayerDrop: p=0.1→4.317%, p=0.2→4.217%, p=0.3→4.411% (#3233). Only 4 layers — dropping 1 removes 25% capacity. Too coarse. EMA+gc already handles stability
 - Coordinate noise augmentation: σ=0.001→6.45% crashed, σ=0.005→21.44% Inf grads (#3256). Fourier freqs up to 32.0 amplify coord noise 32x. Structurally incompatible with Fourier PE
+- Progressive resolution (25k→50k / 30k→50k): 25k crashed ep112, 30k→4.711% +23% (#3252). Full 50k context needed from epoch 1. Reduced resolution creates irrecoverable representation deficit
 - EMA>0.9995: 0.9999→7.106% NaN ep171, 0.99995→7.095% collapse ep120 (#3199). EMA=0.9995 sharp optimum bracketed both directions
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -20,7 +20,7 @@
 **Noam-pivot experiments:**
 - `#3199` megumi: EMA=0.9999/0.99995 (noam optimal decay) — NOAM ABLATION
 - `#3192` casca: asinh-pressure alone (scale=0.75/0.5) — NOAM ABLATION
-- franky: gradient noise injection — INNOVATION (PR pending)
+- `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3194` bulma: higher LR sweep (5.5e-4/6e-4)
 - `#3188` chihiro: 2H/16H heads sweep — NOAM ABLATION
 - `#3181` himmel: asinh+residual on champion — NOAM ABLATION
@@ -78,7 +78,7 @@
 **Other:**
 - `#3172` robin: LR warmup (5-ep/10-ep)
 - `#3169` nami: heads sweep 4H/16H
-- rei: proximity-weighted volume loss — AF VOLUME FOCUS (PR pending)
+- `#3222` rei: proximity-weighted volume loss (surface distance) — AF VOLUME FOCUS
 - `#3218` shouko: GradNorm adaptive multi-task loss balancing — AF VOLUME FOCUS
 - `#3215` tanjiro: Huber loss on volume channel (robust to outliers) — AF VOLUME FOCUS
 - `#3212` jin: PCGrad multi-objective gradient surgery — AF VOLUME FOCUS

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -7,50 +7,51 @@
 
 ## Fleet Status (57 active PRs)
 
-### DrivAerML WIP (30 PRs)
-**Noam-pivot experiments (highest priority):**
-- `#3192` casca: asinh-pressure alone (scale=0.75/0.5 sweep) — NOAM ABLATION
-- `#3188` chihiro: 2H/16H heads sweep on champion — NOAM ABLATION
-- `#3181` himmel: asinh+residual on champion — NOAM ABLATION
-- `#3175` hinata: full noam stack on champion — NOAM ABLATION
+### DrivAerML WIP (27 PRs)
+**Innovation track (code ports — new directive):**
+- `#3203` vegeta: attention temperature annealing — INNOVATION
+- `#3202` senku: GLU preprocess MLP — INNOVATION
+- `#3201` jet: DomainLayerNorm — INNOVATION
 
-**Pre-pivot champion tuning:**
+**Noam-pivot experiments:**
+- `#3199` megumi: EMA=0.9999/0.99995 (noam optimal decay) — NOAM ABLATION
+- `#3192` casca: asinh-pressure alone (scale=0.75/0.5) — NOAM ABLATION
+- `#3193` franky: residual-prediction alone — NOAM ABLATION
+- `#3194` bulma: higher LR sweep (5.5e-4/6e-4)
+- `#3188` chihiro: 2H/16H heads sweep — NOAM ABLATION
+- `#3181` himmel: asinh+residual on champion — NOAM ABLATION
+- `#3175` hinata: full noam stack — NOAM ABLATION
+
+**Champion tuning / paper-facing:**
 - `#3173` kakashi: shorter cosine T_max=15/20
-- `#3171` sanji: LR warmup (5-ep/10-ep) on champion
-- `#3165` senku: 4H heads (128d/head)
-- `#3164` faye: paper-facing full eval (two-phase) — PAPER-FACING
+- `#3171` sanji: LR warmup (5-ep/10-ep)
+- `#3164` faye: paper-facing full eval (two-phase) — PAPER-FACING Track 1
 - `#3163` shouko: attn dropout=0.05
 - `#3161` spike: eta_min=1e-5 (cosine floor)
 - `#3160` griffith: 16H heads
-- `#3193` franky: DM residual-prediction alone — NOAM ABLATION
-- `#3194` bulma: DM higher LR sweep (5.5e-4/6e-4)
 - `#3155` nobara: longer T_max (45/60)
 - `#3154` historia: monotonic cosine (no restarts)
 - `#3152` eren: EMA decay sweep (0.999 vs 0.9995)
 - `#3146` taki: top-5 checkpoint averaging
 - `#3143` thorfinn: Lookahead(AdamW)
-- `#3198` gohan: TFP asinh-pressure isolation (scale=0.75/0.5) — NOAM ABLATION
 - `#3121` levi: dropout regularization sweep
-- `#3195` piccolo: AF re-stratified sampling alone — NOAM ABLATION
 - `#3110` einar: beta2=0.99/0.995
 - `#3109` guts: lr=4e-4 full-eval
-- `#3085` kohaku: larger supernodes (SENT BACK — retry+gc=1.0)
-- `#3197` gojo: TF residual-prediction alone — NOAM ABLATION
-- `#3076` frieren: log-cosh loss (SENT BACK — retry+gc=1.0)
-- `#3067` askeladd: 32k surface points (SENT BACK — add max-eval-batches 200)
-- `#3063` canute: paper-facing full-eval (SENT BACK — two-phase)
-- `#3046` sukuna: WD+gc compound (SENT BACK — WD=5e-4/1e-4+gc=1.0)
+- `#3085` kohaku: larger supernodes (SENT BACK)
+- `#3076` frieren: log-cosh loss (SENT BACK)
+- `#3067` askeladd: 32k surface points (SENT BACK)
+- `#3063` canute: paper-facing full-eval (SENT BACK)
+- `#3046` sukuna: WD+gc compound (SENT BACK)
 
-### TandemFoil WIP (6 PRs)
-**Noam-pivot experiments (highest priority):**
-- `#3189` emma: asinh+physics features (no ANP, no T_max) — NOAM ABLATION
-- `#3186` norman: T_max=150 alone (gc=0.3/0.5) — NOAM ABLATION
-- `#3185` fern: full noam stack (ANP+physics+T_max=150) — NOAM ABLATION
+### TandemFoil WIP (7 PRs) — GUARDRAIL ONLY per directive
+**Noam-pivot experiments:**
+- `#3197` gojo: residual-prediction alone — NOAM ABLATION
+- `#3196` zenitsu: EMA decay sweep (0.9999/0.99995) — NOAM ABLATION
+- `#3189` emma: asinh+physics features — NOAM ABLATION
+- `#3186` norman: T_max=150 alone — NOAM ABLATION
+- `#3185` fern: full noam stack — NOAM ABLATION
 - `#3180` chopper: ANP decoder alone — NOAM ABLATION
-
-**Other:**
-- `#3196` zenitsu: TF EMA decay sweep (0.9999/0.99995) — NOAM ABLATION
-- `#3150` yuji: clean test row gc=0.3 champion — PAPER-FACING
+- `#3150` yuji: clean test row — PAPER-FACING
 
 ### TandemFoil Paper WIP (10 PRs)
 **Noam-pivot experiments (highest priority):**
@@ -106,46 +107,27 @@
 
 ## Current Research Focus
 
-### STRATEGIC PIVOT — "Think Bigger" (Human directive, issue #3174)
+### LATEST HUMAN DIRECTIVE — Issue #3174 Update (2026-04-23 11:08)
 
-**Key finding:** The noam branch has ~100 merged PRs with winning techniques. Many are ALREADY PORTED to radford's train.py but UNUSED. We've been doing incremental HP sweeps when major architectural features were available all along.
+1. **AirfRANS → "Finish the job"**: Surface is strong. ALL new AF work must focus on **volume error reduction only** (vol_mse < 0.0017), without regressing surface.
+2. **DrivAerML → Two-track strategy**:
+   - **Track 1:** Stable full-eval champion track (best-checkpoint test eval) — faye #3164
+   - **Track 2:** Innovation track for genuinely new physics-aware and ML ideas — NOT more Radford/Noam recipe tuning. Code ports from noam: attn temp annealing (vegeta #3203), GLU preprocess (senku #3202), DomainLayerNorm (jet #3201)
+3. **TandemFoil Paper → Stabilization-first**: Failure mode is NaN/inf, not underperformance. Short, cheap diagnostic experiments to find one finite reproducible recipe. brook #3200 mapping stability.
+4. **TandemFoil → Guardrail only**: Parity is healthy. Minimal compute sink.
 
-**New priority:** Every new assignment should test noam-ported features or bold new approaches. No more incremental tweaks.
-
-### Available features NOT USED (ready in train.py)
+### Noam Feature Activation (still highest priority)
 - `--anp-srf` — ANP cross-attention decoder (-58.9% TF!) — TF/TFP only
-- `--asinh-pressure --asinh-scale 0.75` — asinh pressure norm (-8% ood) — ALL datasets
+- `--asinh-pressure --asinh-scale 0.75` — asinh pressure norm — ALL datasets
 - `--residual-prediction` — learned correction to freestream — ALL datasets
-- `--enable-cp-panel`, `--enable-te-coord-frame`, `--enable-wake-deficit`, `--enable-wake-angle`, `--enable-vortex-panel-velocity` — physics features — TF/TFP
+- Physics features: TF only (TFP pipeline bug: cp_panel/TE/vortex silently ignored)
 - `--re-stratified-sampling` — OOD Re robustness — TF/TFP/AF
-- `--compile-model` — throughput gain (more epochs in time budget) — ALL
-- 96 slices, 3 heads (at 192d), Lookahead — all defaults we haven't tested
 
-### Key config mismatches
-- TF/TFP T_max=10 vs noam optimal T_max=150 (15x longer!)
-- Radford 8 heads vs noam 3 heads (at 192d)
-- Missing: vol_loss_scale, PCGrad, temperature annealing, DomainLayerNorm (need code ports)
-
-### Benchmark Sprint Priorities (revised)
-
-1. **TandemFoil** — HIGHEST PRIORITY for noam feature activation
-   - ANP decoder alone was -58.9% on noam. With full stack: potentially 9-12 range vs our 21.909
-   - **Next assignments:** full noam stack, ANP alone, T_max=150 alone
-   - Paper-facing: yuji #3150 clean test
-
-2. **TandemFoil Paper** — Same noam features apply
-   - T_max=150 could break the "fully locked" constraint — it was locked at the WRONG config
-   - ANP + physics features could transform results
-   - **Next assignments:** full noam stack, ANP + T_max=150
-
-3. **DrivAerML** — val=3.833%, gap to AB-UPT only 0.013 pp
-   - **Applicable noam features:** asinh-pressure, residual-prediction, compile-model, 96 slices
-   - **Bold changes:** Lion optimizer (noam's final choice), higher EMA decay (0.9999)
-   - Existing champion platform still valid as base
-
-4. **AirfRANS volume** — 1.63x gap to target
-   - **Applicable noam features:** asinh-pressure, residual-prediction, re-stratified-sampling
-   - **Bold changes:** 96 slices, compile for throughput, vol_loss_scale (needs code port)
+### DM Innovation Track (code ports from noam)
+- Attention temperature annealing (-11% on noam) — vegeta #3203
+- GLU preprocess MLP — senku #3202
+- DomainLayerNorm — jet #3201
+- Still needed: vol_loss_scale, PCGrad (for AF multi-objective)
 
 ## Key Dead Ends (Do Not Repeat)
 
@@ -173,6 +155,7 @@
 - 4L/640d: dead at ALL tested configs — lr=5e-4+EMA+gc: 8.636% diverge ep82 (#3159); lr=5e-4 no-EMA: 4.516%/6.457%/5.724% all diverge (#3079). Width amplifies gradients beyond gc containment.
 - lr<5e-4 under EMA: steep monotonic cliff (4.5e-4=4.134%, 4e-4=5.924%)
 - bs=2: Blackwell bf16+bs>1 CUBLAS bug forces fp32, gets only 37% of optimizer steps. 4.373% at bs=2/fp32 vs 3.833% bs=1/bf16. Platform-blocked.
+- 4H heads with EMA+gc: 6.650% ep123, diverged ep133. DM heads: 8H optimal, 4H/16H both worse
 
 **TandemFoil Paper:**
 - T_max≠10 (all directions diverge)
@@ -188,8 +171,9 @@
 - 2L/384d and 3L/384d: catastrophic divergence
 - EMA<0.999 (0.99, 0.995 both worse)
 - T_max≠50 (30 and 100 both worse)
-- Vol-weight=10x: worse on both metrics
+- Vol-weight<10x (2x/5x/7x): all worse on both metrics. 10x+EMA=0.999 is AF sweet spot
 - Vol-weight=30x: catastrophic — surface 4.3x worse, vol 3.1x worse
+- LR>6e-4: 8e-4 +110% surface, 1e-3 catastrophic divergence
 
 **TandemFoil:**
 - gc≥0.5: monotonically worse than gc=0.3

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 01:45 (advisor cycle 56)
+- **Date:** 2026-04-24 02:00 (advisor cycle 57)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -8,8 +8,9 @@
 
 ## Fleet Status (53 active PRs)
 
-### DrivAerML WIP (28 PRs)
+### DrivAerML WIP (29 PRs)
 **Innovation track (new physics-aware/ML ideas per directive):**
+- `#3233` gojo: stochastic depth (LayerDrop) regularization — INNOVATION
 - `#3231` emma: surface pressure gradient smoothness regularization — INNOVATION (physics-informed)
 - `#3224` fern: spectral normalization on attention layers — INNOVATION
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
@@ -45,10 +46,9 @@
 - `#3067` askeladd: 32k surface points (SENT BACK)
 - `#3046` sukuna: WD+gc compound (SENT BACK)
 
-### TandemFoil WIP (4 PRs) — GUARDRAIL ONLY per directive
+### TandemFoil WIP (3 PRs) — GUARDRAIL ONLY per directive
 **New champion config:** ANP+full physics+T_max=150+gc=0.2+EMA=0.999+96sl+Lookahead+compile+re-strat (#3185)
 **Noam-pivot experiments (still running):**
-- `#3197` gojo: residual-prediction alone — NOAM ABLATION
 - `#3196` zenitsu: EMA decay sweep (0.9999/0.99995) — NOAM ABLATION
 - `#3150` yuji: clean test row — PAPER-FACING
 
@@ -69,6 +69,9 @@
 ### AirfRANS WIP (13 PRs)
 **Non-asinh noam feature ablation (highest priority — clean tests):**
 - `#3230` alphonse: residual-prediction + re-stratified sampling (NO asinh) — CLEAN NOAM ABLATION
+
+**Volume closure experiments:**
+- `#3234` jin: lower LR sweep (5e-4/4e-4) on vol-10x champion — AF VOLUME FOCUS
 - `#3232` nezuko: vol-weight warm-up schedule (1x→10x linear ramp over 200ep) — AF VOLUME FOCUS
 
 **Noam-pivot experiments (asinh-dependent — likely to fail):**
@@ -84,7 +87,6 @@
 - `#3222` rei: proximity-weighted volume loss (surface distance) — AF VOLUME FOCUS
 - `#3218` shouko: GradNorm adaptive multi-task loss balancing — AF VOLUME FOCUS
 - `#3215` tanjiro: Huber loss on volume channel (robust to outliers) — AF VOLUME FOCUS
-- `#3212` jin: PCGrad multi-objective gradient surgery — AF VOLUME FOCUS
 - `#3211` spike: AF vol_loss_scale learnable scalar (noam port) — AF VOLUME FOCUS
 - `#3204` gilbert: vol-weight=15x/20x clean control (no extra features) — AF VOLUME FOCUS
 - `#3195` piccolo: Re-stratified sampling
@@ -210,6 +212,7 @@
 
 **AirfRANS:**
 - asinh-pressure: DEFINITIVELY DEAD — 5 independent confirmations (#3191 T1/T2, #3177 T1/T2/T3). sinh() denormalization exponentially amplifies pressure errors. Non-pressure channels fine. Incompatible with AF pressure distribution.
+- PCGrad gradient surgery: 5-6x worse on both metrics (#3212). retain_graph=True disables torch.compile (40% throughput loss). Gradient conflict is NOT the bottleneck.
 - 3L depth (with or without EMA): catastrophic divergence confirmed twice
 - 2L/384d and 3L/384d: catastrophic divergence
 - EMA<0.999 (0.99, 0.995 both worse)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 00:30 (advisor cycle 54)
+- **Date:** 2026-04-24 01:45 (advisor cycle 56)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -8,8 +8,9 @@
 
 ## Fleet Status (53 active PRs)
 
-### DrivAerML WIP (27 PRs)
+### DrivAerML WIP (28 PRs)
 **Innovation track (new physics-aware/ML ideas per directive):**
+- `#3231` emma: surface pressure gradient smoothness regularization — INNOVATION (physics-informed)
 - `#3224` fern: spectral normalization on attention layers — INNOVATION
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3228` chopper: stochastic weight perturbation at cosine troughs — INNOVATION
@@ -44,12 +45,11 @@
 - `#3067` askeladd: 32k surface points (SENT BACK)
 - `#3046` sukuna: WD+gc compound (SENT BACK)
 
-### TandemFoil WIP (5 PRs) — GUARDRAIL ONLY per directive
+### TandemFoil WIP (4 PRs) — GUARDRAIL ONLY per directive
 **New champion config:** ANP+full physics+T_max=150+gc=0.2+EMA=0.999+96sl+Lookahead+compile+re-strat (#3185)
 **Noam-pivot experiments (still running):**
 - `#3197` gojo: residual-prediction alone — NOAM ABLATION
 - `#3196` zenitsu: EMA decay sweep (0.9999/0.99995) — NOAM ABLATION
-- `#3189` emma: asinh+physics features — NOAM ABLATION
 - `#3150` yuji: clean test row — PAPER-FACING
 
 ### TandemFoil Paper WIP (9 PRs) — STABILIZATION CRISIS
@@ -67,14 +67,16 @@
 - `#2949` vash: depth/width sweep (LR=5e-5)
 
 ### AirfRANS WIP (13 PRs)
-**Noam-pivot experiments (highest priority):**
-- `#3191` alphonse: noam features on base and vol-10x — NOAM ABLATION
-- `#3187` stark: asinh+residual on vol-10x champion — NOAM ABLATION
-- `#3184` wolfwood: full noam stack — NOAM ABLATION
-- `#3177` nezuko: vol-weight 15x/20x + asinh+residual — NOAM ABLATION
+**Non-asinh noam feature ablation (highest priority — clean tests):**
+- `#3230` alphonse: residual-prediction + re-stratified sampling (NO asinh) — CLEAN NOAM ABLATION
+- `#3232` nezuko: vol-weight warm-up schedule (1x→10x linear ramp over 200ep) — AF VOLUME FOCUS
+
+**Noam-pivot experiments (asinh-dependent — likely to fail):**
+- `#3187` stark: asinh+residual on vol-10x champion — NOAM ABLATION (asinh confirmed dead for AF)
+- `#3184` wolfwood: full noam stack — NOAM ABLATION (asinh confirmed dead for AF)
 
 **Other:**
-- `#3172` robin: LR warmup (5-ep/10-ep)
+- `#3172` robin: LR warmup — SENT BACK (confounded config, re-running with correct champion config)
 - `#3169` nami: heads sweep 4H/16H
 - `#3227` casca: focal-MSE volume loss (upweight hard predictions) — AF VOLUME FOCUS
 - `#3226` chihiro: volume weight curriculum (20x→10x) — AF VOLUME FOCUS
@@ -207,6 +209,7 @@
 - T_max=20/30: field_mse never reaches finite values
 
 **AirfRANS:**
+- asinh-pressure: DEFINITIVELY DEAD — 5 independent confirmations (#3191 T1/T2, #3177 T1/T2/T3). sinh() denormalization exponentially amplifies pressure errors. Non-pressure channels fine. Incompatible with AF pressure distribution.
 - 3L depth (with or without EMA): catastrophic divergence confirmed twice
 - 2L/384d and 3L/384d: catastrophic divergence
 - EMA<0.999 (0.99, 0.995 both worse)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 13:35 (advisor cycle 87)
+- **Date:** 2026-04-24 14:00 (advisor cycle 88)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -11,7 +11,7 @@
 
 ### DrivAerML WIP (30 PRs)
 **Innovation track (new physics-aware/ML ideas per directive):**
-- `#3262` megumi: learnable register tokens N=2/4/8 (attention sink absorption, Darcet NeurIPS 2024) — INNOVATION
+- `#3281` megumi: MoE output heads (K=2/3 expert output MLPs with learned gating) — INNOVATION
 - `#3260` casca: learnable Fourier frequency magnitudes (meta-learned encoding) — INNOVATION
 - `#3270` brook: FiLM conditioning on global geometry statistics (per-car shape context) — INNOVATION
 - `#3280` jet: per-channel output heads (separate MLPs for Ux, Uy, p) — INNOVATION
@@ -206,6 +206,7 @@
 - Quadratic position features (x²/y²/z²/xy/xz/yz): 6.643% at ep168 timeout (#3272). Fatal 3x throughput penalty (168 vs 511 baseline epochs). Quad-only diverged ep63 — Fourier PE irreplaceable. Same epoch-starvation pattern as MoE (#3263).
 - Grouped Query Attention (GQA, 2/4 KV heads): 12.88%/6.88% both crashed (#3273). Throughput-neutral (bottleneck is slice routing einsums, not QKV). GQA destabilizes per-head slice routing — coupled KV sharing explodes at cosine restarts.
 - Error-weighted surface sampling (hard example mining): crashed ep6 both trials (#3243). Distribution-shift collapse + 30-60min/epoch error-map compute + train/eval mismatch. Student note: error-weighted LOSS (not sampling) would avoid distribution shift but still faces mismatch.
+- Learnable register tokens (N=2/4/8): N=8 best 4.062% (+6%), N=2/N=4 NaN diverged (#3262). Category error — register tokens address pairwise attention sinks (ViT), but Transolver uses slice-based soft-clustering attention where sink mechanism doesn't apply.
 - EMA>0.9995: 0.9999→7.106% NaN ep171, 0.99995→7.095% collapse ep120 (#3199). EMA=0.9995 sharp optimum bracketed both directions
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,8 +1,8 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 05:00 (advisor cycle 63)
+- **Date:** 2026-04-24 05:30 (advisor cycle 64)
 - **Branch:** radford
-- **Idle students:** 0 (faye just assigned #3244)
+- **Idle students:** 0
 - **PRs ready for review:** 0
 - **CRITICAL:** TFP champion config is BROKEN — code regression since #3025, seed=0 no longer reproduces (#3205). Waiting for sanji #3209 cp_panel bug fix.
 - **Known bug:** `primary_metric_key` shadowing in train.py (line ~1646 local var shadows function on line ~1428). 3 students independently fixed this cycle. Fix: rename local to `best_tracking_metric_key`.
@@ -11,6 +11,7 @@
 
 ### DrivAerML WIP (28 PRs)
 **Innovation track (new physics-aware/ML ideas per directive):**
+- `#3247` brook: EMA periodic reset (100/50-ep intervals) — INNOVATION
 - `#3243` jet: prediction-error-weighted surface sampling (hard example mining) — INNOVATION
 - `#3242` historia: label smoothing / target noise augmentation — INNOVATION
 - `#3235` kakashi: multi-exit prediction (aux losses at intermediate layers) — INNOVATION
@@ -20,7 +21,6 @@
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3228` chopper: stochastic weight perturbation at cosine troughs — INNOVATION
 - `#3225` canute: self-distillation with EMA teacher — INNOVATION
-- `#3217` brook: Fourier encoding of surface normals — INNOVATION
 - `#3202` senku: GLU preprocess MLP — INNOVATION
 - `#3201` jet: DomainLayerNorm — INNOVATION
 
@@ -188,6 +188,7 @@
 - Attention distance bias (ALiBi): linear diverges, log=5.511% at timeout. Redundant with slice-based spatial grouping
 - Auxiliary gradient prediction (∂p/∂x,y,z): kNN targets too noisy — aux_weight=0.1 diverges ep22, aux_weight=0.01 best 5.485% (+43%). Noise dominates once primary loss flattens
 - Mixup regularization (buffer-based latent): 85-109% worse, crashed ~ep235. Buffer staleness + non-smooth geometry-specific latent space fundamentally incompatible with bs=1
+- Fourier-encoded surface normals: 4.374%/4.454% (4 bands/2 bands). Normals are unit vectors in [-1,1] — don't benefit from Fourier lifting like unbounded coords. More bands = earlier divergence
 - Attention temperature annealing: 4.024% (+5% vs 3.833%). External annealed τ compounds with existing learnable per-head τ. noam result doesn't transfer
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 02:00 (advisor cycle 57)
+- **Date:** 2026-04-24 02:30 (advisor cycle 58)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -10,13 +10,13 @@
 
 ### DrivAerML WIP (29 PRs)
 **Innovation track (new physics-aware/ML ideas per directive):**
+- `#3235` kakashi: multi-exit prediction (aux losses at intermediate layers) — INNOVATION
 - `#3233` gojo: stochastic depth (LayerDrop) regularization — INNOVATION
 - `#3231` emma: surface pressure gradient smoothness regularization — INNOVATION (physics-informed)
 - `#3224` fern: spectral normalization on attention layers — INNOVATION
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3228` chopper: stochastic weight perturbation at cosine troughs — INNOVATION
 - `#3225` canute: self-distillation with EMA teacher — INNOVATION
-- `#3214` kakashi: auxiliary gradient prediction (∂p/∂x,y,z) — INNOVATION
 - `#3217` brook: Fourier encoding of surface normals — INNOVATION
 - `#3203` vegeta: attention temperature annealing — INNOVATION
 - `#3202` senku: GLU preprocess MLP — INNOVATION
@@ -185,6 +185,7 @@
 - T_max≠30: ALL tested — 15→4.406%, 20→4.943%, 30→3.833% CHAMPION, 45→4.638%, 50→diverge, 60→4.409%. T_max=30 is definitive sweet spot
 - Noam features on DM: DEFINITIVELY DEAD. Asinh triple-confirmed (4.072%/4.421%/4.475%), residual needs asinh+still→3.999%, full stack→4.447%. Features tuned for T_max=150/3H/no-gc regime
 - Attention distance bias (ALiBi): linear diverges, log=5.511% at timeout. Redundant with slice-based spatial grouping
+- Auxiliary gradient prediction (∂p/∂x,y,z): kNN targets too noisy — aux_weight=0.1 diverges ep22, aux_weight=0.01 best 5.485% (+43%). Noise dominates once primary loss flattens
 - Head count sweep complete: 2H=catastrophic, 4H=6.650%, 8H=3.833% CHAMPION, 16H=4.099%. 8H (64d/head) is definitive
 - 10-ep warmup+gc=1.0: 11.2% then diverged
 - 5-ep warmup+gc=1.0: pending (chopper)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 08:30 (advisor cycle 71)
+- **Date:** 2026-04-24 09:00 (advisor cycle 73)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -9,14 +9,14 @@
 
 ## Fleet Status (58 active PRs)
 
-### DrivAerML WIP (28 PRs)
+### DrivAerML WIP (29 PRs)
 **Innovation track (new physics-aware/ML ideas per directive):**
+- `#3260` casca: learnable Fourier frequency magnitudes (meta-learned encoding) — INNOVATION
 - `#3247` brook: EMA periodic reset (100/50-ep intervals) — INNOVATION
 - `#3243` jet: prediction-error-weighted surface sampling (hard example mining) — INNOVATION
 - `#3242` historia: label smoothing / target noise augmentation — INNOVATION
 - `#3235` kakashi: multi-exit prediction (aux losses at intermediate layers) — INNOVATION
 - `#3233` gojo: stochastic depth (LayerDrop) regularization — INNOVATION
-- `#3231` emma: surface pressure gradient smoothness regularization — INNOVATION (physics-informed)
 - `#3251` fern: Pre-LayerNorm architecture ablation (+ RMSNorm variant) — INNOVATION
 - `#3259` zenitsu: curvature-weighted loss (per-point weighting by local curvature) — INNOVATION
 - `#3258` emma: auxiliary surface normal prediction (multi-task regularization) — INNOVATION
@@ -67,13 +67,13 @@
 - `#3056` haku: Lion+EMA refinement (T_max/gc/LR sweep)
 - `#2949` vash: depth/width sweep (LR=5e-5)
 
-### AirfRANS WIP (14 PRs)
+### AirfRANS WIP (13 PRs)
 **Volume closure experiments:**
+- `#3261` nezuko: 2L/320d wider model (width scaling for vol closure) — AF VOLUME FOCUS
 - `#3255` gohan: no-Lookahead/no-compile champion full budget — AF VOLUME FOCUS (critical ablation follow-up)
 - `#3257` chihiro: extended training via reduced eval frequency (every 3/5 epochs) — AF VOLUME FOCUS
 - `#3241` hinata: T_max=75 + vol-weight=10x/12x on champion — AF VOLUME FOCUS (schedule gap-fill)
 - `#3234` jin: lower LR sweep (5e-4/4e-4) on vol-10x champion — AF VOLUME FOCUS
-- `#3232` nezuko: vol-weight warm-up schedule (1x→10x linear ramp over 200ep) — AF VOLUME FOCUS
 
 **Noam-pivot experiments (asinh-dependent — likely to fail):**
 - `#3187` stark: asinh+residual on vol-10x champion — NOAM ABLATION (asinh confirmed dead for AF)
@@ -82,7 +82,6 @@
 **Other:**
 - `#3172` robin: LR warmup — SENT BACK (confounded config, re-running with correct champion config)
 - `#3169` nami: heads sweep 4H/16H
-- `#3227` casca: focal-MSE volume loss (upweight hard predictions) — AF VOLUME FOCUS
 - `#3254` norman: multi-seed champion run (seeds 42/123/789) — AF VOLUME FOCUS
 - `#3238` rei: WD=0 ablation on vol-10x+EMA champion — AF VOLUME FOCUS
 - `#3245` tanjiro: per-channel volume loss weighting (upweight nut×4, p×2) — AF VOLUME FOCUS
@@ -230,6 +229,8 @@
 - Lookahead hurts AF surface by 53% at equal epochs (#3236 ablation). Compile also hurts surface despite more epochs. Both are default-on in baseline — ambiguity on synergistic effect at long training
 - Proximity-weighted volume loss: 118-2516% worse (#3222). Extreme weight ratios starve far-field gradients while overdriving near-surface. Structural failure at scale=0.1/eps=0.01
 - Huber loss on volume channel: no improvement over MSE on either metric (#3215). AF volume residuals are well-behaved, not heavy-tailed — Huber δ threshold adds no benefit
+- Vol-weight warm-up (1x→10x ramp): 2/3 collapsed, best stable +28% surface/+69% vol (#3232). Cosine restarts inject LR peak when vol-weight ramps — destructive. Static 10x TRIPLE-CONFIRMED
+- Focal-MSE volume loss (error-based reweighting): gamma=2 +392%/+3993%, gamma=1 +222%/+320% (#3227). Batch-max normalization non-stationary + freestream scaffolding destroyed
 - 3L depth (with or without EMA): catastrophic divergence confirmed twice
 - 2L/384d and 3L/384d: catastrophic divergence
 - EMA<0.999 (0.99, 0.995 both worse)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -31,12 +31,12 @@
 - `#3143` thorfinn: Lookahead(AdamW)
 - `#3132` gohan: eta_min=5e-5+gc=1.0
 - `#3121` levi: dropout regularization sweep
-- `#NEW` piccolo: AF re-stratified sampling alone — BEING ASSIGNED
+- `#3195` piccolo: AF re-stratified sampling alone — NOAM ABLATION
 - `#3110` einar: beta2=0.99/0.995
 - `#3109` guts: lr=4e-4 full-eval
 - `#3085` kohaku: larger supernodes (SENT BACK — retry+gc=1.0)
 - `#3083` jet: max-train-batches=600
-- `#NEW` gojo: TF residual-prediction alone — BEING ASSIGNED
+- `#3197` gojo: TF residual-prediction alone — NOAM ABLATION
 - `#3076` frieren: log-cosh loss (SENT BACK — retry+gc=1.0)
 - `#3067` askeladd: 32k surface points (SENT BACK — add max-eval-batches 200)
 - `#3063` canute: paper-facing full-eval (SENT BACK — two-phase)
@@ -50,7 +50,7 @@
 - `#3180` chopper: ANP decoder alone — NOAM ABLATION
 
 **Other:**
-- `#NEW` zenitsu: TF EMA decay sweep (0.9999/0.99995) — BEING ASSIGNED
+- `#3196` zenitsu: TF EMA decay sweep (0.9999/0.99995) — NOAM ABLATION
 - `#3150` yuji: clean test row gc=0.3 champion — PAPER-FACING
 
 ### TandemFoil Paper WIP (10 PRs)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 23:45 (advisor cycle 51)
+- **Date:** 2026-04-24 00:00 (advisor cycle 52)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -20,7 +20,7 @@
 **Noam-pivot experiments:**
 - `#3199` megumi: EMA=0.9999/0.99995 (noam optimal decay) — NOAM ABLATION
 - `#3192` casca: asinh-pressure alone (scale=0.75/0.5) — NOAM ABLATION
-- `#3193` franky: residual-prediction alone — NOAM ABLATION
+- franky: gradient noise injection — INNOVATION (PR pending)
 - `#3194` bulma: higher LR sweep (5.5e-4/6e-4)
 - `#3188` chihiro: 2H/16H heads sweep — NOAM ABLATION
 - `#3181` himmel: asinh+residual on champion — NOAM ABLATION
@@ -58,7 +58,6 @@
 **Stabilization status: CODE REGRESSION CONFIRMED — seed=0 broken, waiting for sanji #3209 bug fix**
 
 **Noam-pivot experiments:**
-- `#3183` rei: ANP+T_max=150 — NOAM ABLATION
 - `#3179` usopp: T_max=150+wake+96sl+Lookahead — NOAM ABLATION
 - `#3176` mitsuha: full noam stack — NOAM ABLATION
 
@@ -79,6 +78,7 @@
 **Other:**
 - `#3172` robin: LR warmup (5-ep/10-ep)
 - `#3169` nami: heads sweep 4H/16H
+- rei: proximity-weighted volume loss — AF VOLUME FOCUS (PR pending)
 - `#3218` shouko: GradNorm adaptive multi-task loss balancing — AF VOLUME FOCUS
 - `#3215` tanjiro: Huber loss on volume channel (robust to outliers) — AF VOLUME FOCUS
 - `#3212` jin: PCGrad multi-objective gradient surgery — AF VOLUME FOCUS
@@ -178,7 +178,7 @@
 - OneCycleLR (no troughs): 8.04% best, sustained high-LR warmup worse than cosine peaks (without EMA+gc)
 - SWA: equal-weight averaging poisons across divergent basins (88.98%)
 - T_max≠30: ALL tested — 15→4.406%, 20→4.943%, 30→3.833% CHAMPION, 45→4.638%, 50→diverge, 60→4.409%. T_max=30 is definitive sweet spot
-- Noam feature stack on DM: full stack→4.447%, asinh-only→4.421%, residual-only→4.651%. All diverge. Features tuned for T_max=150/3H/no-gc regime don't transfer to T_max=30/8H/gc=0.5
+- Noam feature stack on DM: full stack→4.447%, asinh-only→4.421%, residual-only→4.651%/15.0%(crashed). All diverge. Features tuned for T_max=150/3H/no-gc regime. Residual-pred requires asinh as hard prerequisite; even combined→3.999% (doesn't beat 3.833%)
 - 10-ep warmup+gc=1.0: 11.2% then diverged
 - 5-ep warmup+gc=1.0: pending (chopper)
 - LR warmup + EMA+gc=0.5: 5-ep=11.325% diverged, 10-ep=3.918% plateaued (didn't beat 3.833%)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -25,7 +25,7 @@
 
 **Champion tuning / paper-facing:**
 - `#3173` kakashi: shorter cosine T_max=15/20
-- `#3171` sanji: LR warmup (5-ep/10-ep)
+- `#NEW` sanji: TFP cp_panel bug fix + multi-seed retest — STABILIZATION PRIORITY
 - `#3164` faye: paper-facing full eval (two-phase) — PAPER-FACING Track 1
 - `#3163` shouko: attn dropout=0.05
 - `#3161` spike: eta_min=1e-5 (cosine floor)
@@ -172,6 +172,7 @@
 - T_max=50+gc (both 0.5 and 1.0): diverge — T_max=30 only viable period
 - 10-ep warmup+gc=1.0: 11.2% then diverged
 - 5-ep warmup+gc=1.0: pending (chopper)
+- LR warmup + EMA+gc=0.5: 5-ep=11.325% diverged, 10-ep=3.918% plateaued (didn't beat 3.833%)
 - Huber loss, relative L2 loss (degenerate), SGDR, RAdam
 - beta2≠0.999, LR≠5e-4 (without EMA), WD+gc heavy (WD=1e-3: 4.44%)
 - Bilateral symmetry aug, torch.compile, gradient accumulation

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,18 @@
 # SENPAI Research Results
 
+## 2026-04-24 10:00 — PR #3256: DM coordinate noise augmentation (alphonse) — CLOSED (dead end)
+
+- alphonse/dm-coord-noise-augmentation, W&B runs: hapy2g9k (σ=0.001), qfu1j89b (σ=0.005), group: dm-coord-noise-aug
+- Hypothesis: Gaussian noise on input coordinates provides regularization against overfitting to exact point positions
+
+| Trial | σ | best val_pct | vs baseline | Status |
+|-------|---|-------------|-------------|--------|
+| T1 | 0.001 | 6.450% | +68% | Crashed ep172, grad norm peaked 732,950 |
+| T2 | 0.005 | 21.445% | +459% | 117/168 grad norms = Infinity |
+
+- **Root cause: Fourier frequency amplification.** Frequencies up to 32.0 amplify σ=0.001 to σ=0.032 in feature space, σ=0.005 to σ=0.16. Structural incompatibility with Fourier PE — not a tuning issue.
+- **Follow-up assigned:** Hidden-space noise (post-Fourier perturbation) avoids the amplification entirely.
+
 ## 2026-04-24 09:45 — PR #3239: AF additive boundary-layer auxiliary volume loss (vegeta) — CLOSED (dead end)
 
 - vegeta/af-bl-auxiliary-loss, W&B runs: 6y7xod45 (bl-w=1.0,t=0.05), 7w4btwaj (bl-w=0.5,t=0.05), pjrv0090 (bl-w=1.0,t=0.10)

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,16 @@
 # SENPAI Research Results
 
+## 2026-04-24 19:00 — PR #3275: DrivAerML local/windowed attention (canute) — CLOSED dead end
+
+- canute/dm-local-attention
+- Hypothesis: KNN-restricted local attention provides physics-aligned spatial inductive bias for surface pressure prediction
+- Trial 1 (K=512): 5.81% val at ep89, only 89 epochs due to 3-4x throughput collapse (19GB VRAM). W&B: 9a3yodiw.
+- Trial 2 (K=2048): 13.59% val at ep29, only 29 epochs (60GB VRAM). W&B: 7shsfomx.
+- Architecture mismatch: Transolver routes 50k tokens → 96 physics-aware slices, NOT point-to-point attention. Adding parallel KNN O(N·K) pathway is redundant with slice mechanism and destroys throughput. At matched epochs, K=512 and K=2048 show similar val metrics — local attention adds no signal beyond what slicing already captures.
+- **Canute assigned to Breakout 2 (#3302): metric-aware MSE + raw-rel-L2 loss**
+
+---
+
 ## 2026-04-24 18:30 — PR #3301: DrivAerML Breakout 3 domain-normalized volume auxiliary (brook) — SENT BACK (round 2)
 
 - brook/dm-domain-normalized-volume-aux

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,32 @@
 # SENPAI Research Results
 
+## 2026-04-24 12:15 — PR #3254: AF multi-seed champion run (norman) — CLOSED (diagnostic, no winner)
+
+- norman/af-multi-seed-champion, W&B runs: 69bgiyis (seed=42), v3bl8pgv (seed=123), cv4fdye6 (seed=789), group: af-multi-seed
+- Hypothesis: a different seed might find vol_mse < 0.0017 under the champion config
+
+| Seed | surface_mse | vs baseline | vol_mse | vs baseline | Status |
+|------|-------------|-------------|---------|-------------|--------|
+| 0 (baseline) | **0.000296** | — | **0.002039** | — | Stable |
+| 42 | 0.000869 | +194% | 0.007117 | +249% | Diverged ep300 |
+| 123 | 0.000535 | +81% | 0.002831 | +39% | Stable |
+| 789 | 0.000532 | +80% | 0.003585 | +76% | Diverged at end |
+
+- **Diagnostic finding: Champion config has HIGH seed sensitivity.** Seed=0 significantly outperforms all 3 tested seeds. Cross-seed vol std=0.002200 (151% spread). The baseline benefits from initialization luck.
+- **Implication:** Config improvements must be tested multi-seed to confirm robustness.
+
+## 2026-04-24 12:15 — PR #3253: DM input feature dropout (canute) — CLOSED (dead end)
+
+- canute/dm-input-feature-dropout, W&B runs: 5kpd4fu0 (p=0.1), rso1a99o (p=0.2), group: dm-fourier-dropout
+- Hypothesis: Fourier channel dropout forces redundant representations
+
+| Trial | Dropout p | best val_pct | vs baseline | Terminal divergence |
+|-------|-----------|-------------|-------------|-------------------|
+| T1 | 0.1 | 4.732% | +23% | final 18.27% |
+| T2 | 0.2 | 4.821% | +26% | final 67.97% |
+
+- **Root cause:** Input-level dropout = information destruction, not regularization. All 4 Fourier frequency bands carry essential geometric information. Network can't route around absent INPUT features like it can with hidden-layer dropout. Dose-dependent degradation confirms smooth information loss.
+
 ## 2026-04-24 11:45 — PR #3263: DM Sparse MoE FFN (gojo) — CLOSED (dead end)
 
 - gojo/dm-moe-ffn, W&B runs: rei05zxk (K=4), hjkzjnn8 (K=8), group: dm-moe-ffn

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,9 @@
 # SENPAI Research Results
 
+## 2026-04-23 23:30 — PR #3163: DM attn-dropout=0.05 + EMA+gc (shouko) — CLOSED (dead end)
+
+- Best val=10.118% ep73 (W&B: j0t5bn67), 2.64x worse than 3.833%. Catastrophic divergence ep74 — grad_norm→Infinity, gc=0.5 firing every step (394 clip events/epoch) but couldn't contain compounding dropout noise. Final val=75.33%. EMA preserved ep73 checkpoint. Confirms attn-dropout incompatible with DM at any stability level: without EMA/gc → 12.533% (#3113), with EMA/gc → 10.118% (19% better early but same ultimate fate). The multiplicative noise from dropout compounds faster than gc can clip as the loss landscape steepens at cosine restart boundaries. Added to dead ends.
+
 ## 2026-04-23 23:15 — PR #3213: DM surface normal input features (brook) — CLOSED (already implemented)
 
 - No trials ran. Brook discovered surface normals are ALREADY present in DrivAerML input tensor (columns 3-5 of SURFACE_X_DIM=7, loaded from surface_normals.npy in prepare_drivaerml.py). The champion already has full access to normals. Hypothesis moot. Pivot: Fourier encoding of normals (currently only xyz cols 0-2 get Fourier features, not normals) — reassigning brook to this follow-up.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,17 @@
 # SENPAI Research Results
 
+## 2026-04-23 19:30 — PR #3142: TF gc=0.3 longer budget 480-min (zenitsu) — CLOSED
+
+- Best val=22.016 ep460 (W&B: `w0wlkumg`). Doesn't beat 21.350 baseline (#3140). Extra 120min budget provides no benefit — cosine T_max=10 cycling means more epochs are independent LR-cycle draws, not monotone descent. Three gc=0.3 runs span 0.7 MAE variance (21.909, 21.350, 22.016). gc=0.3 clips rarely (44 events/467 epochs, grad_norm_mean=0.1884) — functionally equivalent to gc=0.2. geom_camber_rc ~30.9 MAE remains persistent architectural bottleneck.
+
+## 2026-04-23 19:30 — PR #3115: DM bs=2 + 50k pts + EMA+gc (piccolo) — CLOSED
+
+- Phase 1 (bs=2/25k/fp16): val=4.323% (W&B: `l7np1pv0`), confounded by 13 gradient spikes from fp16 fallback. Phase 2 (bs=2/50k/fp32/EMA+gc): val=4.373% ep368 (W&B: `oohxhf86`). Both worse than 3.833% baseline. Blackwell bf16+bs>1 CUBLAS bug forces fp32, which only gets 37% of baseline optimizer steps within 6h timeout. The gradient-variance hypothesis cannot be fairly tested on this platform. Per-step efficiency signal weakly interesting (4.37% at 37% steps) but not actionable.
+
+## 2026-04-23 19:30 — PR #3079: DM 4L/640d (gojo) — CLOSED
+
+- Run 1: val=4.516% ep359 (W&B: `7uuhe2qr`), diverged ep360+. Run 2: 6.457% ep137 (W&B: `ho8eosr3`), crashed ep152. Run 3: 5.724% ep169 (W&B: `txttvm2n`), diverged ep244+. All 3 runs used lr=5e-4/T_max=30/no-EMA — student never applied instructed config (lr=3e-4/T_max=60/EMA) despite 2 send-backs. Combined with franky #3159 (640d+EMA → 8.636%), 640d is dead at any tested config. Width amplifies gradient magnitudes beyond gc=0.5 containment.
+
 ## 2026-04-23 18:30 — PR #3159: DM 4L/640d wider on EMA+gc champion (franky) — CLOSED
 
 - 640d: best val=8.636% ep81 (W&B: `yccjqzbi`), catastrophic divergence ep82 → 86% terminal. gc=0.5 clipped every batch but couldn't contain gradient explosion. grad_norm_mean=Infinity confirmed. EMA+gc delayed divergence vs prior 640d attempt (gojo #3079, ep28) but didn't prevent it. 640d at lr=5e-4 is fundamentally incompatible. Bug fix: primary_metric_key shadowing.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,9 @@
 # SENPAI Research Results
 
+## 2026-04-23 20:00 — PR #3132: DM eta_min=5e-5 + gc compound (gohan) — CLOSED
+
+- gc=1.0+eta_min=5e-5: 6.311% ep149, diverged ep150 → 112.66% (W&B: `h6jblqjq`). gc=0.5+eta_min=5e-5: 8.617% ep70, diverged → 72% (W&B: `7fmjg0cu`). Third confirmation eta_min=5e-5 is dead — alone (#3126), +gc=1.0, +gc=0.5 all diverge catastrophically. Non-zero LR floor prevents gradient momentum dissipation at cosine troughs; gc delays but cannot prevent cumulative drift. gc=0.5 is counterproductive here — clips 288/394 batches (throttles signal), worse than gc=1.0 which clips only 73/394.
+
 ## 2026-04-23 19:30 — PR #3142: TF gc=0.3 longer budget 480-min (zenitsu) — CLOSED
 
 - Best val=22.016 ep460 (W&B: `w0wlkumg`). Doesn't beat 21.350 baseline (#3140). Extra 120min budget provides no benefit — cosine T_max=10 cycling means more epochs are independent LR-cycle draws, not monotone descent. Three gc=0.3 runs span 0.7 MAE variance (21.909, 21.350, 22.016). gc=0.3 clips rarely (44 events/467 epochs, grad_norm_mean=0.1884) — functionally equivalent to gc=0.2. geom_camber_rc ~30.9 MAE remains persistent architectural bottleneck.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,21 @@
 # SENPAI Research Results
 
+## 2026-04-23 21:00 — PR #3190: TFP physics features isolation (brook) — CLOSED
+
+- Trial 1 (all physics): val=Infinity — cp_panel_prior_index() wrong index for tandemfoil_paper (W&B: `0eq5jqij`). Trial 2 (wake only): val=0.7396, diverged (W&B: `kqknlctz`). CRITICAL: TFP pipeline only supports enable_fourier/wake_deficit/wake_angle — other physics flags silently ignored.
+
+## 2026-04-23 21:00 — PR #3167: AF higher LR 8e-4/1e-3 (gilbert) — CLOSED
+
+- lr=8e-4: surface +110%, vol +89% vs baseline (W&B: `dfed8vam`). lr=1e-3: catastrophic divergence (W&B: `tb2h5odt`). LR=6e-4 confirmed AF sweet spot.
+
+## 2026-04-23 21:00 — PR #3166: AF vol-weight=5x/7x (vegeta) — CLOSED
+
+- 5x: surface +46%, vol +52% (W&B: `dxna9k23`). 7x: surface +48%, vol +154%, diverged (W&B: `20nl7euu`). 10x+EMA=0.999 confirmed AF sweet spot.
+
+## 2026-04-23 21:00 — PR #3165: DM 4H heads EMA+gc (senku) — CLOSED
+
+- Best val=6.650% ep123, diverged ep133 (W&B: `o5mcbmp9`). 4H unstable at 4L/512d. DM heads: 8H champion > 4H > 16H.
+
 ## 2026-04-23 20:30 — PR #3134: AF vol-weight=30x (megumi) — CLOSED
 
 - Surface=0.001264 (4.3x worse than 0.000296 baseline), vol=0.006235 (3.1x worse than 0.002039 baseline) (W&B: `wupz6iuj`). 30x volume weighting massively overshoots — optimizer saturates on volume gradients and both metrics collapse. Model diverged post-ep400, terminal surface=0.621 vol=1.533. No Pareto improvement at any epoch. Sweet spot confirmed at 10x (#3135). Adding to dead ends: vol-weight≥30x catastrophic.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,29 @@
 # SENPAI Research Results
 
+## 2026-04-24 11:30 — PR #3264: DM Weight Standardization (vegeta) — CLOSED (dead end)
+
+- vegeta/dm-weight-standardization, W&B runs: x0biqh3s (lr=5e-4), i7nvv6gj (lr=6e-4), group: dm-weight-standardization
+- Hypothesis: WS smooths loss landscape at bs=1 (Qiao et al., 2019)
+
+| Trial | LR | best val_pct | vs baseline | Status |
+|-------|-----|-------------|-------------|--------|
+| T1 | 5e-4 | 67.925% | +1673% | 100% grad clip, Inf grad norm |
+| T2 | 6e-4 | 71.410% | +1764% | 100% grad clip, grad_norm 9.4e16 |
+
+- **Root cause:** WS reparameterization + cosine restarts (T_max=30) + bs=1 → feedback loop. LR peak jolts raw weights, WS recenters, but AdamW momentum was built on pre-WS effective weights → persistent direction mismatch. Original BiT paper used epoch-level decay, not per-batch restarts.
+
+## 2026-04-24 11:30 — PR #3248: DM SGDR eta_mult decaying restart LR (nobara) — CLOSED (dead end)
+
+- nobara/dm-decaying-restart-lr, W&B runs: fgtjrzmc (eta_mult=0.9999), 39vnze9p (eta_mult=0.99995), group: dm-sgdr-eta-mult
+- Hypothesis: decaying peak LR at each cosine restart makes late restarts gentler
+
+| Trial | eta_mult | best val_pct | vs baseline | Status |
+|-------|----------|-------------|-------------|--------|
+| T1 | 0.9999 | 4.153% | +8.3% | Stable, peak LR decayed to 52.6% by ep490 |
+| T2 | 0.99995 | 12.643% | +230% | Diverged ep60, sharp restart jumps |
+
+- **Confound:** Switched from CosineAnnealingLR (smooth) to CosineAnnealingWarmRestarts (sharp jumps). T2 divergence proves sharp restart jumps more destabilizing than baseline's smooth oscillation. T1 stable only because severe peak decay compensated.
+
 ## 2026-04-24 11:15 — PR #3247: DM EMA periodic reset (brook) — CLOSED (dead end)
 
 - brook/dm-ema-periodic-reset, W&B runs: ltfotg72 (reset@100ep), q221x53o (reset@50ep), group: dm-ema-periodic-reset

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,13 @@
 # SENPAI Research Results
 
+## 2026-04-23 23:45 — PR #3175: DM full noam stack + individual ablations (hinata) — CLOSED (dead end)
+
+- Full stack (asinh+residual+compile+96sl+srf): best val=4.447% ep342 (W&B: vddf3qle), diverged → 64%. Asinh-only (scale=0.75): best val=4.421% ep303 (W&B: 0ks1aaz5), diverged → 61%. Residual-only: best val=4.651% ep242 (W&B: xmx6y3ws), diverged → NaN. All 0.6-0.8pp worse than 3.833%. Root cause: noam features were tuned for T_max=150/3H/no-gc regime — cosine T_max=30 restarts amplify gradient instability through these features despite gc=0.5. Asinh least harmful, residual most harmful. Individual ablations (casca #3192, franky #3193) may find narrower windows. Bug fix: primary_metric_key scoping.
+
+## 2026-04-23 23:45 — PR #3155: DM longer T_max=45/60 + EMA+gc (nobara) — CLOSED (dead end)
+
+- T_max=45: best val=4.638% ep240, diverged → 61.4% (W&B: tskmw04v). T_max=60: best val=4.409% ep331, diverged → 54.9% (W&B: fmxxu3ol). Both worse than 3.833%. Longer cycles keep model in high-LR territory too long, causing progressive destabilization. T_max=30 gives ~17 restart cycles in 500 epochs, which is the optimal frequency. Now ALL T_max values tested: 15 (4.406%), 20 (4.943%), 30 (3.833% champion), 45 (4.638%), 50 (diverge), 60 (4.409%). T_max=30 is definitive DM sweet spot.
+
 ## 2026-04-23 23:30 — PR #3163: DM attn-dropout=0.05 + EMA+gc (shouko) — CLOSED (dead end)
 
 - Best val=10.118% ep73 (W&B: j0t5bn67), 2.64x worse than 3.833%. Catastrophic divergence ep74 — grad_norm→Infinity, gc=0.5 firing every step (394 clip events/epoch) but couldn't contain compounding dropout noise. Final val=75.33%. EMA preserved ep73 checkpoint. Confirms attn-dropout incompatible with DM at any stability level: without EMA/gc → 12.533% (#3113), with EMA/gc → 10.118% (19% better early but same ultimate fate). The multiplicative noise from dropout compounds faster than gc can clip as the loss landscape steepens at cosine restart boundaries. Added to dead ends.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,13 @@
 # SENPAI Research Results
 
+## 2026-04-23 18:30 — PR #3159: DM 4L/640d wider on EMA+gc champion (franky) — CLOSED
+
+- 640d: best val=8.636% ep81 (W&B: `yccjqzbi`), catastrophic divergence ep82 → 86% terminal. gc=0.5 clipped every batch but couldn't contain gradient explosion. grad_norm_mean=Infinity confirmed. EMA+gc delayed divergence vs prior 640d attempt (gojo #3079, ep28) but didn't prevent it. 640d at lr=5e-4 is fundamentally incompatible. Bug fix: primary_metric_key shadowing.
+
+## 2026-04-23 18:30 — PR #3158: DM lr=4e-4/4.5e-4 under EMA+gc (bulma) — CLOSED
+
+- lr=4e-4: 5.924% ep175 (+54.5%, W&B: `zq5czggz`). lr=4.5e-4: 4.134% ep429 (+7.9%, W&B: `2ddsixfm`). Steep monotonic cliff below lr=5e-4 — EMA regime does NOT shift LR optimum downward. Lower LR converges too slowly and gets destroyed at cosine restart peaks. Gradient points upward: lr>5e-4 is the unexplored direction. Bug fix: primary_metric_key shadowing.
+
 ## 2026-04-23 18:00 — PR #3068: DM 64k surface points (brook) — CLOSED
 
 - 64k points + EMA=0.9995 + gc=0.5: surface_rel_l2=12.16% (W&B: `j2p2i1c0`). Prior 64k without EMA+gc: 8.18%. Adding EMA+gc on 64k made it WORSE — structural instability compounds. 50k remains the only viable surface point count for DM. Full surface point investigation complete: 16k=11.672%, 32k=7.558%, 64k=12.16%, all dead vs 50k=3.833% baseline.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,23 @@
 # SENPAI Research Results
 
+## 2026-04-24 03:15 — PR #3220: DM Mixup regularization (nobara) — CLOSED (dead end)
+
+- nobara/dm-mixup, W&B group: dm-mixup
+- Hypothesis: latent-space Mixup (buffer-based for bs=1 DM) regularizes learned manifold
+- Trial 1 (alpha=0.2, W&B: m39js3jn): best val=8.031% ep221, crashed to 29.2% — 110% worse than 3.833%
+- Trial 2 (alpha=1.0, W&B: 0h81e7tw): best val=7.096% ep232, crashed to 56.1% — 85% worse
+- **Root cause: buffer staleness + non-smooth latent space.** Mixing current latents with stale-checkpoint latents creates incoherent targets. Transolver's slice-attention learns geometry-specific decompositions that don't interpolate between cars.
+- **Conclusion: Mixup dead for DM.** Structural incompatibility with bs=1 + geometry-specific latent space. Buffer approach fundamentally flawed.
+
+## 2026-04-24 03:15 — PR #3222: AF proximity-weighted volume loss (rei) — CLOSED (dead end)
+
+- rei/af-proximity-volume-weighting, W&B group: af-proximity-vol
+- Hypothesis: weight volume loss inversely proportional to surface distance to focus on boundary layer
+- Trial 1 (inverse-distance eps=0.01, W&B: aoecdk20): surface +647%, vol +2516% worse
+- Trial 2 (exponential scale=0.1, W&B: 9n27zxp2): surface +118%, vol +1766% worse
+- **Root cause: extreme weight ratios.** exp(-d/0.1) assigns zero weight to points >0.7 normalized distance from surface, starving far-field gradients. Since eval uses uniform MSE, undertrained far-field dominates error. 355 gradient clip events in T2 = every step.
+- **Conclusion: proximity weighting dead for AF at these scales.** Structural gradient starvation. Much softer weighting (scale=1-2) or additive auxiliary BL loss (avoid touching main loss) could be tried separately.
+
 ## 2026-04-24 03:00 — PR #3198: TFP asinh pressure scale ablation 0.75/0.5 (gohan) — CLOSED (dead end)
 
 - gohan/tfp-asinh-pressure

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,18 @@
 # SENPAI Research Results
 
+## 2026-04-24 11:00 — PR #3258: DM auxiliary surface normal prediction (emma) — CLOSED (dead end)
+
+- emma/dm-aux-normal-prediction, W&B runs: fkiz67ki (w=0.1), g9zs1wsh (w=0.01), group: dm-aux-normal-prediction
+- Hypothesis: multi-task regularization via predicting surface normals as auxiliary target
+
+| Trial | Aux weight | best val_pct | vs baseline | Epochs |
+|-------|-----------|-------------|-------------|--------|
+| T1 | 0.1 | 4.724% | +23% | 202 (timeout) |
+| T2 | 0.01 | 4.661% | +22% | 212 (timeout) |
+
+- **Root cause (dual):** (1) Input leakage — normals already in input features, aux head learns trivial reconstruction (aux_loss collapses to <0.001 in 30-50ep). (2) Epoch starvation — aux head overhead limits runs to ~200 vs 511 epochs.
+- **Conceptual flaw:** Predicting inputs from latent ≠ meaningful information bottleneck. The task is trivially solvable and provides no regularization signal.
+
 ## 2026-04-24 10:45 — PR #3244: DM paper-facing full eval (faye) — SENT BACK (strategy change)
 
 - faye/dm-paper-facing-full-eval, W&B run: l7jxns6d, group: dm-paper-facing

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,20 @@
 # SENPAI Research Results
 
+## 2026-04-24 14:00 — PR #3262: DM learnable register tokens (megumi) — CLOSED (dead end)
+
+- megumi/dm-register-tokens, W&B runs: x2dp3s92 (N=2), jr1s77um (N=4), 3ftciy41 (N=8), group: dm-register-tokens
+- Hypothesis: register tokens (Darcet et al. 2024) absorb attention sinks, reducing systematic spatial bias
+
+| Trial | N | best val_pct | Epoch at best | Total epochs | Outcome |
+|-------|---|-------------|---------------|--------------|---------|
+| N=2 | 2 | 13.143% | 49 | 482 | NaN diverged ep114 |
+| N=4 | 4 | 10.010% | 62 | 481 | NaN diverged ep163 |
+| N=8 | 8 | 4.062% | 470 | 474 | Finished |
+
+**Conclusion:** Register tokens are a category error for Transolver. Darcet et al. documented attention sinks in ViTs with dense pairwise attention, but Transolver uses slice-based soft-clustering attention where the sink mechanism doesn't apply. N=8 preserved throughput (474 epochs) but converged to a 6% worse optimum. N=2/N=4 diverged to NaN at cosine restart boundaries. Student correctly identified the architectural mismatch.
+
+---
+
 ## 2026-04-24 13:35 — PR #3273: DM Grouped Query Attention (gojo) — CLOSED (dead end)
 
 - gojo/dm-grouped-query-attention, W&B runs: rq2tz9hh (2KV), wbygalr3 (4KV), group: dm-gqa

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,14 @@
 # SENPAI Research Results
 
+## 2026-04-24 05:30 — PR #3217: DM Fourier-encoded surface normals (brook) — CLOSED (dead end)
+
+- brook/dm-fourier-normals, W&B group: dm-fourier-normals
+- Hypothesis: Fourier encoding of surface normals (like positional encoding for coordinates) gives richer geometric info for high-curvature regions
+- Trial 1 (4 bands, +24 dims, W&B: xwcdmp8k): val=4.374% ep274, test=5.103%. Diverged catastrophically after ep274, terminal val ~53.7%
+- Trial 2 (2 bands, +12 dims, W&B: jiaqu42c): val=4.454% ep317, test=5.021%. Diverged after ep317, terminal val ~75.0%
+- **Root cause: surface normals are unit vectors in [-1,1] with angular semantics — unlike unbounded spatial coordinates, they don't benefit from Fourier lifting.** The NeRF analogy doesn't transfer. More bands = earlier divergence (expanded input dims amplify gradients at cosine restart peaks).
+- **Conclusion: Fourier normals dead for DM.** Raw float normals already carry the geometric curvature information. No path to recovery.
+
 ## 2026-04-24 05:00 — PR #3164: DM paper-facing full eval two-phase (faye) — CLOSED (did not reproduce champion)
 
 - faye/dm-ema-paper-fulleval, W&B: qd7g8npf (Phase 1 training), 37gsknn6 (Phase 2 full eval)

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,23 @@
 # SENPAI Research Results
 
+## 2026-04-24 07:30 — PR #3225: DM self-distillation via EMA teacher (canute) — CLOSED (dead end)
+
+- canute/dm-self-distillation, W&B runs: 1df67nu8 (α=0.3), r8c2ztmm (α=0.1), group: dm-self-distillation
+- Hypothesis: EMA model as soft-target teacher for online model, loss = (1-α)*MSE(pred,target) + α*MSE(pred,ema_pred)
+- Trial A (α=0.3): val=6.446% ep159, diverged ~ep170. +68% vs baseline
+- Trial B (α=0.1): val=4.323% ep335, diverged ~ep400. +12.8% vs baseline
+- **Structural flaw: EMA=0.9995 creates ~2000-step teacher lag → destabilizing feedback loop in late training.** Higher α → earlier divergence (clean monotonic relationship). The distillation term overcomes gc=0.5 and sends grad norms to infinity.
+- **Conclusion: self-distillation dead for DM.** Same EMA for checkpoint tracking and distillation is fundamentally incompatible. Would need separate lower-decay EMA teacher + alpha decay schedule — a substantially different approach.
+
+## 2026-04-24 07:30 — PR #3223: AF volume smoothness regularization (norman) — CLOSED (dead end)
+
+- norman/af-volume-smooth-regularization, W&B runs: 6oo3dn4f, q2zyfwfg, 6dqv5rod, wr3xsn6u
+- Hypothesis: KNN-based spatial smoothness penalty on volume predictions encourages physically smooth fields
+- 4 trials (2 formulations × 2 lambda/k settings): ALL regressed BOTH metrics. Surface 44-94% worse, volume 60-97% worse
+- Best trial (Form A, λ=0.01, k=4): surface=0.000426 (+44%), vol=0.004791 (+88%)
+- **Root cause: KNN Euclidean smoothness is physically misaligned.** BL, wakes, shear layers have legitimate sharp gradients. Penalty suppresses real physics. Gradient interference from shared backbone also corrupts surface gradients.
+- **Conclusion: volume smoothness reg dead for AF.** Even λ=1e-4 harmful. Mesh-topology-aware or residual-gradient approaches would be fundamentally different.
+
 ## 2026-04-24 07:00 — PR #3224: DM spectral normalization on attention (fern) — CLOSED (dead end)
 
 - fern/dm-spectral-norm, W&B run: 4ylvrt7k, group: dm-spectral-norm

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,19 @@
 # SENPAI Research Results
 
+## 2026-04-24 09:45 — PR #3239: AF additive boundary-layer auxiliary volume loss (vegeta) — CLOSED (dead end)
+
+- vegeta/af-bl-auxiliary-loss, W&B runs: 6y7xod45 (bl-w=1.0,t=0.05), 7w4btwaj (bl-w=0.5,t=0.05), pjrv0090 (bl-w=1.0,t=0.10)
+- Hypothesis: auxiliary volume loss targeting near-wall cells (SDF < threshold) provides focused BL supervision
+
+| Trial | Config | surface_mse | vs baseline | vol_mse | vs baseline |
+|-------|--------|-------------|-------------|---------|-------------|
+| T1 | bl-w=1.0, t=0.05 | 0.000448 | +51% | 0.004213 | +107% |
+| T2 | bl-w=0.5, t=0.05 | 0.000494 | +67% | 0.002664 | +31% |
+| T3 | bl-w=1.0, t=0.10 | 0.000972 | +228% | 0.006162 | +202% |
+
+- **Root cause:** AF wall-resolved meshes have SDF<0.05 covering 61% of ALL volume points, SDF<0.10 covering 68%. "BL targeting" becomes near-uniform volume upscaling. Same failure mode as proximity-weighting (#3222).
+- **Pattern confirmed:** Any SDF-based volume re-weighting fails on AF meshes because the mesh itself is already an SDF-weighted sampler. Two independent confirmations now (#3222 + #3239).
+
 ## 2026-04-24 09:30 — PR #3238: AF WD=0 ablation on vol-10x+EMA champion (rei) — SENT BACK
 
 - rei/af-wd0-ablation, W&B runs: sqotwbxs (WD=0), cjcftqo8 (WD=5e-3), group: af-no-wd

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,15 @@
 # SENPAI Research Results
 
+## 2026-04-24 03:00 — PR #3198: TFP asinh pressure scale ablation 0.75/0.5 (gohan) — CLOSED (dead end)
+
+- gohan/tfp-asinh-pressure
+- Hypothesis: asinh pressure normalization alone (without physics stack) can stabilize TFP pressure
+- Trial 1 (asinh-0.75, W&B: 08s8cxns): field_mse=0.775 apparent best ep324, but 60/554 steps Inf (chaotic transient). Terminal 9.05e+08. ~325x worse than 0.002383 baseline
+- Trial 2 (asinh-0.50, W&B: pqawyn4k): field_mse=34,047 ep501 — 14M x worse
+- **NOT caused by cp_panel code regression** — runs don't use physics stack. This is a clean result.
+- **Root cause: without residual prediction + pressure prior, sinh() denormalization exponentially amplifies pressure errors.** Velocity channels (Ux, Uy) healthy; failure entirely pressure-specific.
+- **Conclusion: asinh alone incompatible with TFP.** Requires full physics stack scaffolding to constrain pressure prediction.
+
 ## 2026-04-24 02:30 — PR #3214: DM auxiliary surface gradient prediction (kakashi) — CLOSED (dead end)
 
 - kakashi/dm-auxiliary-gradient, W&B group: dm-auxiliary-gradient

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,18 @@
 # SENPAI Research Results
 
+## 2026-04-24 12:45 — PR #3259: DM curvature-weighted loss (zenitsu) — CLOSED (dead end)
+
+- zenitsu/dm-curvature-weighted-loss, W&B runs: rwkptewj (alpha=1.0), 434enoo9 (alpha=0.5), group: dm-curvature-weighted-loss
+- Hypothesis: weighting MSE by local surface curvature focuses learning on high-curvature regions (edges, junctions)
+
+| Trial | alpha | best val_pct | vs baseline | Outcome |
+|-------|-------|-------------|-------------|---------|
+| T1 | 1.0 | 4.482% | +17% | Catastrophic divergence ep300 (final 70.75%) |
+| T2 | 0.5 | 11.602% | +203% | Diverged ep53 (final 72.44%) |
+
+- **Dual root cause:** (1) Train/eval mismatch — curvature weighting optimizes a different objective than the uniform relative-L2 metric. (2) Curvature weights amplify gradient variance at cosine restarts → explosive divergence. Lighter alpha diverged FASTER (shallower basin, less restart-tolerant).
+- **Conclusion:** Any static geometry-based per-point loss weighting creates structural misalignment with the uniform evaluation metric.
+
 ## 2026-04-24 12:15 — PR #3254: AF multi-seed champion run (norman) — CLOSED (diagnostic, no winner)
 
 - norman/af-multi-seed-champion, W&B runs: 69bgiyis (seed=42), v3bl8pgv (seed=123), cv4fdye6 (seed=789), group: af-multi-seed

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,48 @@
 # SENPAI Research Results
 
+## 2026-04-24 01:15 — PR #3191: AF noam features (asinh+residual+re-strat) on base and vol-10x (alphonse) — CLOSED (dead end)
+
+- alphonse/af-noam-features, W&B group: af-noam-features-base
+- Hypothesis: noam features (asinh-pressure, residual-prediction, re-stratified-sampling) transfer to AirfRANS
+- Trial 1 (no vol-weight, W&B: wvdm76ep): surface_mse=0.646 (1408x worse than 0.000459), vol_mse=Inf — catastrophic
+- Trial 2 (vol-10x, W&B: rmg1uigw): surface_mse=0.611 (2063x worse than 0.000296), vol_mse=Inf — catastrophic
+- **Root cause: sinh() denormalization exponentially amplifies pressure errors on AF.** Non-pressure channels (Ux, Uy, nut) converge fine. Failure is entirely pressure-specific via asinh-pressure feature.
+- **Conclusion: asinh-pressure is DEFINITIVELY incompatible with AirfRANS.** Combined with nezuko #3177 (3 asinh trials → Inf) = 5 independent confirmations. Added to AF dead ends. Bug fix: primary_metric_key shadowing noted.
+- Student suggestion: test residual-prediction + re-stratified WITHOUT asinh — high value follow-up.
+
+## 2026-04-24 01:15 — PR #3189: TF asinh+physics features, no ANP, no T_max change (emma) — CLOSED (dead end)
+
+- emma/tf-asinh-residual-physics, W&B group: tf-noam-features-no-anp
+- Hypothesis: isolate contribution of physics features (wake-deficit, wake-angle, cp-panel, vortex-panel) + asinh normalization on TF without ANP
+- Trial 1 (full physics, W&B: 7kdfc3by): val=22.423 ep311, test=23.427 — +5.2% worse than 21.319 baseline
+- Trial 2 (norm only, W&B: qfycb0ww): val=22.911 ep324, test=24.365 — +7.5% worse
+- **Confound: both trials omitted --enable-pressure-prior-addition** which champion uses. Cannot attribute regression to physics features vs missing pressure prior.
+- Physics features do add modest benefit (+0.49 MAE improvement T1 vs T2).
+- **Conclusion: experiment confounded. TF needs pressure-prior-addition.** geom_camber_rc remains hardest split (val ~34-36 vs ~12 for cruise).
+
+## 2026-04-24 01:15 — PR #3177: AF vol-weight 15x/20x + asinh+residual compound push (nezuko) — CLOSED (dead end)
+
+- nezuko/af-vol-weight-compound-push, W&B group: af-vol-weight-compound
+- Hypothesis: compound higher vol-weight + asinh + residual to break vol_mse < 0.0017
+- 6 trials total (3 instructed + 3 fallback):
+  - Trials 1-3 (with asinh): ALL catastrophic — vol_mse_p → Inf (pressure volume explosion)
+  - Trial 4 (15x no-asinh, W&B: m2p9bi0f): crashed ep325, vol_mse=0.005437 best
+  - Trial 5 (20x no-asinh, W&B: vt5yzmm7): surface=0.000304 ep665, vol=0.002689 ep653 — still running ep699 but won't reach baseline
+  - Trial 6 (10x no-asinh, W&B: z1n4yt1k): crashed ep108
+- **Key finding: non-monotonic stability** — 10x crashed, 15x crashed at LR peak, 20x stable through ep700+. Heavier vol-weight paradoxically dampens pressure gradient oscillations at cosine peaks.
+- Best result: surface=0.000304 (+2.7%), vol=0.002689 (+31.9%) — neither beats baseline.
+- **Conclusion: asinh-pressure confirmed broken for AF volume fields (3 more confirmations = 5 total). 20x vol-weight is stable but slow to converge.**
+
+## 2026-04-24 01:15 — PR #3172: AF LR warmup 5ep/10ep + EMA (robin) — SENT BACK (confounded)
+
+- robin/af-warmup-ema
+- Hypothesis: linear LR warmup before cosine annealing improves AF training stability
+- Trial 1 (5ep warmup, W&B: p7xqdmxx): surface=0.000312, vol=0.004723, diverged ep586
+- Trial 2 (10ep warmup, W&B: gcc0sb6p): surface=0.000333, vol=0.003189, stable
+- Neither beats baseline (surface=0.000296, vol=0.002039).
+- **Confound: used 8H (not champion's 4H) and omitted vol-loss-weight=10x.** Experiment uninterpretable — warmup hypothesis untested, not disproven.
+- Sent back with corrected config: exact champion + --warmup-epochs 5 as only change.
+
 ## 2026-04-24 00:30 — PR #3216: DM attention distance bias ALiBi-inspired (canute) — CLOSED (dead end)
 
 - Linear bias: 12.144% ep45, diverged ep90 (W&B: 306ayrb2). Log bias: 5.511% ep169, stable but still converging at timeout (W&B: pbnxsdha). Neither beats 3.833%. Alpha values barely moved from init — distance prior redundant with existing Transolver slice-based spatial grouping.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,35 @@
 # SENPAI Research Results
 
+## 2026-04-24 14:30 — PR #3260: DM learnable Fourier encoding frequencies (casca) — CLOSED (dead end)
+
+- casca/dm-learnable-fourier-freqs, W&B runs: wss8o89v (T1 default init), 6cg34qtr (T2 wide init), group: dm-learnable-fourier
+- Hypothesis: making Fourier encoding frequencies learnable (nn.Parameter) lets the model adapt spatial encoding to DrivAerML's specific scale structure
+
+| Trial | Init | best val_pct | Epoch at best | Outcome |
+|-------|------|-------------|---------------|---------|
+| T1 default [0.5,2,8,32] | baseline | 5.262% (ep179) | 179 | Diverged post-cosine-restart, terminal 53.1% |
+| T2 wide [0.1,1,10,100] | wider | 4.252% (ep371) | 371 | Diverged post-cosine-restart, terminal 72.2% |
+
+**Conclusion:** Both diverge catastrophically. Key diagnostic: frequencies barely moved from initialization in T2 (terminal [0.05,1.53,10.03,99.73] vs init [0.1,1,10,100]). Fixed frequencies are already near-optimal for DrivAerML. Learnable freq + cosine LR restarts = cascading perturbation feedback loop. No variant worth pursuing.
+
+---
+
+## 2026-04-24 14:30 — PR #3244: DM paper-facing full eval (faye) — SENT BACK (need champion checkpoint eval)
+
+- faye/dm-paper-eval, W&B runs: l7jxns6d (naive full-eval), rzx46x2j (Phase 1 batch-limited), f7f1kmcz (Phase 2 full-eval)
+- Purpose: obtain paper-facing full-eval metrics for DM champion (no --max-eval-batches)
+
+| Phase | W&B run | val_pct | test_pct | eval method | Outcome |
+|-------|---------|---------|----------|------------|---------|
+| Phase 0 (naive) | l7jxns6d | 12.356% (ep50) | 11.881% | full eval | Timeout after 50 epochs |
+| Phase 1 (train) | rzx46x2j | 3.966% (ep403) | — | batch-limited 200 | Crashed ep417 (grad norm 7449) |
+| Phase 2 (eval) | f7f1kmcz | 4.933% | 4.496% | full eval | Checkpoint from Phase 1 ep403 |
+| Champion | ncl1dh88 | 3.833% (ep511) | 4.685% | batch-limited 200 | Reference |
+
+**CRITICAL FINDING:** Batch-limited eval is ~24% optimistic for val (3.966% batch-limited → 4.933% full-eval). This means our 3.833% baseline is likely ~4.8% under full eval. Sent back to run full eval on the actual champion ep511 checkpoint (not the ep403 crash-truncated version).
+
+---
+
 ## 2026-04-24 14:00 — PR #3262: DM learnable register tokens (megumi) — CLOSED (dead end)
 
 - megumi/dm-register-tokens, W&B runs: x2dp3s92 (N=2), jr1s77um (N=4), 3ftciy41 (N=8), group: dm-register-tokens

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,24 @@
 # SENPAI Research Results
 
+## 2026-04-24 15:30 — FLEET RESTRUCTURING per Issue #3283 (Last Ditch Benchmark Push)
+
+**14 experiments KILLED to reallocate fleet to 36 DM / 12 AF / 11 TFP / 0 TF:**
+
+DM kills: #3280 jet (per-channel heads, surface is single cp), #3281 megumi (MoE output, directive), #3181 himmel (asinh+residual, noam dead), #3067 askeladd (32k surface, directive says denser only)
+AF kills: #3274 norman (Lion), #3172 robin (warmup), #3169 nami (heads sweep), #3129 chrome (4L/256d depth), #3261 nezuko (2L/320d width), #3187 stark (asinh), #3184 wolfwood (noam stack), #3268 jin (higher LR), #3144 violet (vol-weight=2)
+TF kills: #3150 yuji (TF frozen)
+
+**15 new assignments:**
+- vegeta #3284: HARNESS PATCHES (highest priority infrastructure)
+- DM champion recovery: jet #3285 (seed=42), megumi #3286 (seed=7), norman #3293 (seed=0 ncl1dh88 replica)
+- DM surface density: himmel #3289 (64k), askeladd #3290 (96k)
+- DM gradient-safe: robin #3294 (gc=0.25)
+- DM narrow schedule: nami #3297 (T_max=24), chrome #3298 (T_max=36)
+- TFP haku replication: nezuko #3287 (seed=0), stark #3288 (seed=42), wolfwood #3291 (seed=7), yuji #3292 (seed=123)
+- AF vol-weight sweep: jin #3295 (vol-weight=8), violet #3296 (vol-weight=9)
+
+---
+
 ## 2026-04-24 14:30 — PR #3260: DM learnable Fourier encoding frequencies (casca) — CLOSED (dead end)
 
 - casca/dm-learnable-fourier-freqs, W&B runs: wss8o89v (T1 default init), 6cg34qtr (T2 wide init), group: dm-learnable-fourier

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,29 @@
 # SENPAI Research Results
 
+## 2026-04-24 16:15 — PR #3276: DM cosine similarity auxiliary loss (zenitsu) — CLOSED (dead end)
+
+- zenitsu/dm-cosine-sim-aux-loss, W&B runs: ry1lq2vw (w=0.1), flnnss55 (w=0.5), group: dm-cosine-sim-loss
+- Hypothesis: cosine similarity aux loss captures spatial pattern fidelity that MSE misses
+
+| Trial | Weight | best val_pct | Epoch | Outcome |
+|-------|--------|-------------|-------|---------|
+| T1 | 0.1 | 4.661% | 241 | Crashed ep244 — NaN at cosine restart |
+| T2 | 0.5 | 6.569% | 109 | Crashed ep159 — gradual divergence |
+
+**Conclusion:** Cosine similarity saturates >0.99 by epoch ~100 — the model already learns spatial patterns from MSE alone. Cos_sim loss is informationally redundant. Near-unity cos_sim makes (1-cos_sim) gradients ill-conditioned at LR restart boundaries, causing divergence. Zenitsu reassigned to Breakout 4 (coord normalization, #3299).
+
+---
+
+## 2026-04-24 16:15 — PR #3284: Harness patches (vegeta) — SENT BACK (merge-blocking bug)
+
+- vegeta/harness-patches-last-ditch, changes to train.py (+215/-37)
+- 5/6 patches implemented: --load-checkpoint, --eval-interval, --ema-mode fixed|warmup, --skip-update-grad-norm, --save-checkpoint
+- 3/5 kill gates implemented: --kill-if-best-val-above, --kill-if-no-improvement, --kill-if-grad-nonfinite-steps
+- **Merge-blocking bug:** double best-tracking chains — --save-checkpoint saves from chain 2 but final eval restores from chain 1. Different epochs can be selected. Sent back with specific fix instructions.
+- Missing: --kill-if-metric-above, --kill-if-nonfinite-metric (deferred)
+
+---
+
 ## 2026-04-24 15:30 — FLEET RESTRUCTURING per Issue #3283 (Last Ditch Benchmark Push)
 
 **14 experiments KILLED to reallocate fleet to 36 DM / 12 AF / 11 TFP / 0 TF:**

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,19 @@
 # SENPAI Research Results
 
+## 2026-04-24 09:15 — PR #3199: DM EMA=0.9999/0.99995 upward sweep (megumi) — CLOSED (dead end)
+
+- megumi/dm-ema-0.9999, W&B runs: c168t4dq (EMA=0.9999), 26n0lcmg (EMA=0.99995)
+- Hypothesis: higher EMA decay (slower shadow update) might find a deeper basin by reducing noise in the EMA weights
+
+| Trial | EMA | best val_pct | vs baseline | Diverged |
+|-------|-----|-------------|-------------|---------|
+| T1 | 0.9999 | 7.106% | +85% | NaN ep~171 |
+| T2 | 0.99995 | 7.095% | +85% | Collapse ep~120, plateau 83.56% |
+
+- **Mechanism:** Both values cause EMA shadow weights to lag too far behind the online model. Cosine LR peaks (T_max=30) produce gradient spikes that gc=0.5 can't contain when the gap between online and shadow is too large. Both floor at ~7.1% then diverge.
+- **Combined with #3152 (eren, EMA=0.999 sweep downward):** EMA=0.9995 is now bracketed as a sharp optimum — steep cliff in both directions. Not a broad plateau.
+- **Conclusion: EMA=0.9995 is the definitive DM optimum.** Dead end.
+
 ## 2026-04-24 09:00 — PR #3232: AF vol-weight warm-up schedule (nezuko) — CLOSED (dead end)
 
 - nezuko/af-vol-warmup, W&B runs: 9tc2udwf (200ep ramp), gp149j2g (100ep ramp), o8ifqyac (50ep ramp), group: af-vol-warmup

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,15 @@
 # SENPAI Research Results
 
+## 2026-04-24 06:00 — PR #3237: DM snapshot ensemble at cosine troughs (nobara) — CLOSED (dead end)
+
+- nobara/dm-snapshot-ensemble, W&B group: dm-snapshot-ensemble, runs: cwg22dhi (single best), lcil8t4n (K=3), c8bn99m6 (K=5), lp19d8uo (K=6), c31seso3 (training)
+- Hypothesis: save EMA checkpoints at cosine LR troughs, average predictions at test time for variance reduction
+- Training run: val=4.807% ep193, then crashed ep214 (grad explosion: 0.19→0.50→3.25→100.4→6459 in 15 epochs). Never reached baseline quality.
+- Single best checkpoint (ep180): test=6.044% (+29% vs 4.685% baseline)
+- **Ensembling makes it WORSE monotonically:** K=3→6.238%, K=5→6.980%, K=6→7.810%. Quality gradient dominates — early checkpoints (ep30=17.3%) dilute later ones (ep180=5.0%)
+- **Root cause: EMA=0.9995 already provides implicit smoothing over ~2000 steps. Snapshot averaging on top of EMA adds noise, not signal.** Also, available snapshots were from a run that crashed before reaching baseline quality.
+- **Conclusion: snapshot ensemble dead for DM.** Requires similarly-capable checkpoints with diverse predictions — but single-run cosine trough checkpoints have dominant quality gradient.
+
 ## 2026-04-24 05:30 — PR #3217: DM Fourier-encoded surface normals (brook) — CLOSED (dead end)
 
 - brook/dm-fourier-normals, W&B group: dm-fourier-normals

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,21 @@
 # SENPAI Research Results
 
+## 2026-04-24 00:30 — PR #3216: DM attention distance bias ALiBi-inspired (canute) — CLOSED (dead end)
+
+- Linear bias: 12.144% ep45, diverged ep90 (W&B: 306ayrb2). Log bias: 5.511% ep169, stable but still converging at timeout (W&B: pbnxsdha). Neither beats 3.833%. Alpha values barely moved from init — distance prior redundant with existing Transolver slice-based spatial grouping.
+
+## 2026-04-24 00:30 — PR #3192: DM asinh-pressure alone scale=0.75/0.5 (casca) — CLOSED (dead end — TRIPLE CONFIRMED)
+
+- scale=0.75: 4.072% (W&B: mh9wcdop), scale=0.5: 4.475% diverged ep310 (W&B: uzpui6j5). Neither beats 3.833%. Combined with hinata #3175 (asinh-only=4.421%) and franky #3193 (residual+asinh=3.999%), asinh is TRIPLE CONFIRMED harmful on DM. Signal compression hurts fine-grained surface learning. Added to dead ends.
+
+## 2026-04-24 00:30 — PR #3188: DM 2H/16H attention heads sweep (chihiro) — CLOSED (dead end)
+
+- 2H: 13.878% crashed ep40 (W&B: qcaxbz95). 16H: 4.099% diverged ep431 (W&B: 6n9i88a3). Neither beats 3.833%. ALL head counts now tested: 2H=catastrophic, 4H=6.650% diverge, 8H=3.833% champion, 16H=4.099% late-diverge. 8H (64d/head) is the definitive DM sweet spot.
+
+## 2026-04-24 00:30 — PR #3180: TF ANP decoder alone (chopper) — CLOSED (dead end)
+
+- ANP+T_max=10 gc=0.3: val=21.590 (W&B: eaat1lne). ANP+T_max=150 gc=0.3: val=22.057 (W&B: 4kwi4mv2). Neither beats old baseline (21.350) or new (#3185=21.319). ANP alone doesn't help TF — benefit requires full stack combination.
+
 ## 2026-04-24 00:15 — PR #3185: TF full noam stack (fern) — MERGED ✓ NEW TF CHAMPION
 
 - Trial 1 (full stack: ANP+physics+T_max=150+96sl+Lookahead+compile+re-strat): val=21.319 ep277, test=22.868 (W&B: v05jt92n). Beats baseline 21.350/23.195 on both metrics (-0.15% val, -1.41% test). Trial 2 (ANP+physics only, T_max=10): val=22.276 ep233 (W&B: anluw1ab), diverged ep289. Key insight: full-stack extras (Lookahead, compile, 96 slices, re-stratified) only compound in late training (after ep200). T2 led for first 180 epochs. T_max=150 essential for full benefit. New TF config: Lion lr=1.25e-4, T_max=150, gc=0.2, EMA=0.999, 96 slices, ANP+full physics+asinh-scale=0.75+residual+Lookahead+compile+re-strat.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,25 @@
 # SENPAI Research Results
 
+## 2026-04-24 19:30 — PR #3244: DrivAerML paper-facing full eval (faye) — CLOSED (critical finding)
+
+- faye/dm-paper-facing-champion-full-eval
+- **AUTHORITATIVE PAPER-FACING TEST: 4.324%** (W&B run zx5syby1, full eval on ep517 checkpoint from w4ufs8m1)
+- Phase 1: champion recovery with --save-checkpoint, 524 epochs, best batch-limited val 3.900% at ep517 (vs champion 3.833% at ep511). Zero grad-skip events (threshold=500).
+- Phase 2: --load-checkpoint full eval (no --max-eval-batches): val=4.698%, test=4.324%
+- Batch-limited eval bias: val is ~0.8pp optimistic (3.900→4.698%), test is ~0.5pp PESSIMISTIC (4.859→4.324%)
+- Does not beat baseline val (3.900% > 3.833%), but provides the authoritative full-eval methodology.
+- **Faye assigned to #3303: compile-mode champion recovery**
+
+## 2026-04-24 19:30 — PR #3295: AF vol-weight=8 (jin) — CLOSED dead end
+
+- jin/af-vol-weight-8, W&B: kazfrlg7
+- surface_mse=0.000288 (-2.7% vs baseline 0.000296) but vol_mse=0.003171 (+55% vs 0.002039)
+- Trade-off non-linear: reducing vol-weight below 10 loses far more volume accuracy than it gains surface. Confirms vol-weight=10 is near Pareto front.
+- Lower bound of AF vol-weight sweep established at 8: no need to test below.
+- **Jin assigned to #3304: AF extended 600-min champion training**
+
+---
+
 ## 2026-04-24 19:00 — PR #3275: DrivAerML local/windowed attention (canute) — CLOSED dead end
 
 - canute/dm-local-attention

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,33 @@
 # SENPAI Research Results
 
+## 2026-04-24 04:30 — PR #3219: DM SAM optimizer (hinata) — CLOSED (dead end)
+
+- hinata/dm-sam-optimizer, W&B group: dm-sam-optimizer
+- Hypothesis: SAM (Sharpness-Aware Minimization) wrapping AdamW finds flat basins robust to cosine LR restarts
+- Trial 1 (rho=0.05, W&B: 7z3a4ous): val=5.359% ep273, then catastrophic divergence at ep278+ (grad_norm=3.18, 353 clips at ep288). +40% worse than 3.833%
+- Trial 2 (rho=0.02, W&B: dn33cgny): val=9.082% ep97, crashed ep103 (grad_norm → 38.5M). +137% worse. Negative sharpness (-0.000166) at ep130 = SAM lost regularization effect
+- **Root cause: SAM's perturbation step compounds destructively with cosine LR restarts.** Double shock (LR jump + SAM perturbation) at restart boundaries. Also 2x compute penalty — only reached ep276-289 vs ~500 baseline epochs.
+- **Conclusion: SAM dead for DM.** Flat-basin hypothesis not disproven, but SAM is incompatible with rapid cosine restarts. SWA (averaging checkpoints across cycles) would avoid both compute penalty and restart-shock.
+
+## 2026-04-24 04:30 — PR #3207: DM true monotonic cosine T_max=393606 (historia) — CLOSED (dead end)
+
+- historia/dm-true-monotonic-cosine, W&B run: 6yiwl01x, group: dm-monotonic-cosine
+- Hypothesis: single half-cosine decay from lr=5e-4 to 0 over full 999 epochs (no restarts) removes restart-induced gradient perturbation, allowing smoother EMA accumulation
+- Result: val=4.086% ep519, test=4.390%. +0.253pp / +6.6% worse than 3.833% baseline
+- Training dynamics: clean smooth convergence, grad norms dropped 9.4→0.08, no instability. LR decayed to 2.46e-4 at ep521 (52% through cycle). Val plateauing well above baseline.
+- **Compared to PR #3154 (T_max=999 steps, accidental rapid cycling): meaningful improvement 4.086% vs 4.39%, but still can't match baseline's rapid restarts.**
+- **Conclusion: monotonic cosine dead for DM.** Confirms T_max=30 rapid restarts are a core mechanism, not noise. Beneficial gradient perturbation from restarts is essential.
+
+## 2026-04-24 04:30 — PR #3206: DM 600 batches + gc=0.5 + EMA stabilized (jet) — CLOSED (dead end)
+
+- jet/dm-600-batches-stabilized, W&B group: dm-data-efficiency
+- Hypothesis: 600 batches/epoch (+52% data per epoch) with full stability stack (gc=0.5+EMA=0.9995) finds deeper basins through greater car diversity per epoch
+- Trial 1 (T_max=46 proportional, W&B: pv8nchbg): val=11.451% ep46, NaN divergence from ep61. Cosine restart at ep46 catastrophic despite gc=0.5. +199% worse
+- Trial 2 (T_max=30 baseline schedule, W&B: wr1x3ked): val=3.887% ep378, stable. +0.054pp vs 3.833%. Time-limited at 378 epochs but ran 226,800 total batches vs baseline's 201,334 at best epoch
+- **Key analysis: Trial 2 saw more total data than baseline yet couldn't match it.** Late trajectory (3.92-4.06% at ep375) shows no sign of descending toward new minimum. Data diversity per epoch is not the bottleneck.
+- **Conclusion: 600 batches/epoch dead for DM.** 394 batches/epoch already saturates data diversity. Proportional T_max scaling (T_max=46) confirmed unstable at higher batch counts.
+- **Bug fix noted:** jet fixed primary_metric_key shadowing bug (also fixed independently by hinata and historia in their PRs).
+
 ## 2026-04-24 03:45 — PR #3203: DM attention temperature annealing (vegeta) — CLOSED (dead end)
 
 - vegeta/dm-attn-temp-annealing, W&B run: ybh108ny

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,15 @@
 # SENPAI Research Results
 
+## 2026-04-24 06:30 — PR #3218: AF GradNorm adaptive multi-task loss balancing (shouko) — CLOSED (dead end)
+
+- shouko/af-gradnorm, W&B runs: p5b6fgoa (α=1.5), 93rkwc57 (α=0.5)
+- Hypothesis: GradNorm (Chen et al. 2018) learns task weights dynamically by balancing gradient magnitudes across surface/volume losses
+- Trial 1 (α=1.5): surface=0.000514 (1.74x worse), vol=0.005390 (2.64x worse), ep338. Final weights: w_surf=3.03, w_vol=7.97
+- Trial 2 (α=0.5): surface=0.000907 (3.06x worse), vol=0.004845 (2.38x worse), ep337. Final weights: w_surf=3.67, w_vol=7.33
+- **Structural problems:** (1) retain_graph=True breaks torch.compile → halves throughput → only 339 epochs vs baseline's 763. (2) GradNorm converges to w_volume~8x, systematically LOWER than hand-tuned 10x — fights against intentional asymmetry.
+- **Interesting insight:** GradNorm pushes w_surface from 1.0 toward 3.0-3.7, suggesting surface is "under-weighted" by gradient-norm standards. Worth noting for future experiments.
+- **Conclusion: GradNorm dead for AF.** Computational overhead + learned weights fighting the hand-tuned asymmetry = double structural failure.
+
 ## 2026-04-24 06:00 — PR #3237: DM snapshot ensemble at cosine troughs (nobara) — CLOSED (dead end)
 
 - nobara/dm-snapshot-ensemble, W&B group: dm-snapshot-ensemble, runs: cwg22dhi (single best), lcil8t4n (K=3), c8bn99m6 (K=5), lp19d8uo (K=6), c31seso3 (training)

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,14 @@
 # SENPAI Research Results
 
+## 2026-04-24 05:00 — PR #3164: DM paper-facing full eval two-phase (faye) — CLOSED (did not reproduce champion)
+
+- faye/dm-ema-paper-fulleval, W&B: qd7g8npf (Phase 1 training), 37gsknn6 (Phase 2 full eval)
+- Goal: get clean paper-facing full-eval test metric for DM champion config (no --max-eval-batches)
+- Phase 1 (training, no-compile): val=4.198% ep432, test=4.793% (truncated). Champion is 3.833% — 0.365pp gap. Model did NOT reproduce champion quality.
+- Phase 2 (full eval on Phase 1 best checkpoint): test=4.496% full eval (vs 4.793% truncated) — confirms truncated eval slightly overstates error (~0.3pp).
+- Two compiled runs diverged ep60-87 (grad_norm to 65k) — torch.compile + DrivAerML is a systematic regression, likely from EMAWithWarmup interaction.
+- **Conclusion: full eval test for true champion still unknown. faye's 4.496% is from a weaker model.** Reassigned faye to #3244 for a clean rerun.
+
 ## 2026-04-24 04:30 — PR #3219: DM SAM optimizer (hinata) — CLOSED (dead end)
 
 - hinata/dm-sam-optimizer, W&B group: dm-sam-optimizer

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,33 @@
 # SENPAI Research Results
 
+## 2026-04-24 13:15 — PR #3272: DM quadratic position features (vegeta) — CLOSED (dead end)
+
+- vegeta/dm-quadratic-pos-encoding, W&B runs: equlqwg4 (quad+Fourier), qm4gk9bi (quad-only)
+- Hypothesis: x², y², z², xy, xz, yz features alongside Fourier PE provide implicit surface curvature information
+
+| Trial | Config | best val_pct | Epochs | Outcome |
+|-------|--------|-------------|--------|---------|
+| T1 | quad + Fourier | 6.643% (ep128) | 168 (timeout) | Timeout at ~3x throughput penalty |
+| T2 | quad only | 10.736% (ep63) | 163 | Diverged ep63, inf gradients |
+
+**Conclusion:** Fatal throughput penalty (168 vs 511 epochs baseline). Quad-only diverged at ep63, confirming Fourier PE is irreplaceable. Even with T_max adjustments, structural 3x throughput hit from expanded input dimension means epoch starvation. Late-epoch grad-clip rate 74% suggests cosine restart instability. Pattern matches #3263 (MoE FFN): any input expansion that slows per-epoch throughput gets epoch-starved on DM.
+
+---
+
+## 2026-04-24 13:15 — PR #3255: AF no-Lookahead/no-compile (gohan) — CLOSED (dead end)
+
+- gohan/af-no-lookahead-compile, W&B run: 4auwwy2g, group: af-no-lookahead-compile
+- Hypothesis: removing Lookahead + torch.compile (confirmed as individually removable in short ablation) would hold at full budget
+
+| Metric | Baseline | This run | Delta |
+|--------|----------|----------|-------|
+| val surface_mse | 0.000296 | 0.001999 | +575% |
+| val vol_mse | 0.002039 | 0.003754 | +84% |
+
+**Conclusion:** Catastrophically worse. Lookahead's slow-weight averaging is load-bearing for long-run convergence (not just early-training noise). torch.compile provides meaningful throughput gains within the 360-min timeout budget. Short-run ablation #3236 was misleading due to epoch-count confound. Both optimizations are non-negotiable for AF champion config.
+
+---
+
 ## 2026-04-24 12:45 — PR #3259: DM curvature-weighted loss (zenitsu) — CLOSED (dead end)
 
 - zenitsu/dm-curvature-weighted-loss, W&B runs: rwkptewj (alpha=1.0), 434enoo9 (alpha=0.5), group: dm-curvature-weighted-loss

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,24 @@
 # SENPAI Research Results
 
+## 2026-04-24 07:00 — PR #3224: DM spectral normalization on attention (fern) — CLOSED (dead end)
+
+- fern/dm-spectral-norm, W&B run: 4ylvrt7k, group: dm-spectral-norm
+- Hypothesis: spectral norm on QKV projections constrains Lipschitz constant, stabilizing cosine restart boundaries
+- Trial 1 (SN-QKV): val=4.035% ep479, test=5.113%. +0.202pp / +5.3% vs 3.833% baseline
+- Stability validated: zero grad spikes across 16 restart boundaries. Grad norm monotonically decreased 9.7→0.09.
+- **Late collapse at ep502:** grad_norm jumped 0.39→0.88→4.74→423 in 25 epochs. Collapse from UNCONSTRAINED FFN/embedding layers, not from SN-protected QKV (sigma stayed bounded at ~5.6).
+- **Root cause: σ=1 hard cap over-restricts attention representational capacity from epoch 1. The gradient spike problem it was designed to solve doesn't exist — gc=0.5 already handles restart stability in the baseline.**
+- **Conclusion: spectral norm dead for DM.** Partial Lipschitz bounds create asymmetric instability.
+
+## 2026-04-24 07:00 — PR #3176: TF full noam stack at T_max=150 (mitsuha) — CLOSED (dead end)
+
+- mitsuha/tfp-noam-stack (pivoted from TFP to TF due to dataset compatibility), W&B runs: i9wvy2bd/nx4gpbp4 (T1), wue7pa0i/4hxt7np6 (T2), 5kdoiqr0/kr931hp9 (T3)
+- Hypothesis: full noam stack (ANP+physics+T_max=150+Lookahead+compile+96sl+re-strat) transfers from TFP to TF
+- Best: Trial 1 (full stack) val=22.469 ep279, +5.2% vs 21.350 baseline. Re-run confirmed: 23.034
+- Trial 2 (ANP+T_max=150 only): 25.093. Trial 3 (arch+T_max=150 only): 25.621
+- **Key finding: T_max=150 is the decisive negative factor.** TF baseline uses T_max=10 (21.350). ANP contributes ~10% improvement WITHIN T_max=150 regime but can't overcome the schedule penalty.
+- **Conclusion: full noam stack dead for TF at T_max=150.** ANP at T_max=10 would be the valuable follow-up (untested).
+
 ## 2026-04-24 06:30 — PR #3218: AF GradNorm adaptive multi-task loss balancing (shouko) — CLOSED (dead end)
 
 - shouko/af-gradnorm, W&B runs: p5b6fgoa (α=1.5), 93rkwc57 (α=0.5)

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,14 @@
 # SENPAI Research Results
 
+## 2026-04-24 02:30 — PR #3214: DM auxiliary surface gradient prediction (kakashi) — CLOSED (dead end)
+
+- kakashi/dm-auxiliary-gradient, W&B group: dm-auxiliary-gradient
+- Hypothesis: supervise spatial pressure gradients (∂p/∂x,y,z via kNN finite-differences) as auxiliary regularization loss
+- Trial 1 (aux_weight=0.1, W&B: h611t6dg): best val=23.5% ep20, diverged ep22 — gradient explosion (norm 2.25→15.3)
+- Trial 2 (aux_weight=0.01, W&B: exbz0pb4): best val=5.485% ep191 (+43% worse than 3.833%), instability event ep192, degraded to 7.38%
+- **Root cause: kNN gradient targets are inherently noisy.** Once primary loss flattens in late training, the noisy auxiliary signal dominates and injects harmful variance. Even pre-divergence convergence trajectory was decelerating — would need ~137 more epochs just to reach baseline, far exceeding realistic budget.
+- **Conclusion: supervised gradient prediction dead for DM.** The model already learns appropriate gradient structure from the dense primary pressure loss. kNN noise > benefit.
+
 ## 2026-04-24 02:00 — PR #3212: AF PCGrad gradient surgery (jin) — CLOSED (dead end)
 
 - jin/af-pcgrad, W&B group: af-pcgrad

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,24 @@
 # SENPAI Research Results
 
+## 2026-04-24 10:45 — PR #3244: DM paper-facing full eval (faye) — SENT BACK (strategy change)
+
+- faye/dm-paper-facing-full-eval, W&B run: l7jxns6d, group: dm-paper-facing
+- Goal: get authoritative DM test metric over full evaluation set (no --max-eval-batches)
+- **Result: timeout at ep50, val=12.855%.** Full eval is 10x slower per epoch (~7min vs ~0.7min). Only 50/511 epochs completed.
+- **Sent back with two-phase strategy:** (1) train to convergence with --max-eval-batches 200, (2) load best checkpoint for a single full-eval pass.
+
+## 2026-04-24 10:45 — PR #3234: AF lower LR sweep (jin) — CLOSED (dead end)
+
+- jin/af-lower-lr-vol, W&B runs: yvct2fd1 (lr=5e-4), 9fv1p8bx (lr=4e-4), group: af-lower-lr-vol10x
+- Hypothesis: lower LR reduces gradient oscillations under vol-weight=10x
+
+| Trial | LR | surface_mse | vs baseline | vol_mse | vs baseline |
+|-------|-----|-------------|-------------|---------|-------------|
+| T1 | 5e-4 | 0.000492 | +66% | 0.004293 | +111% |
+| T2 | 4e-4 | 0.000408 | +38% | 0.003594 | +76% |
+
+- **Root cause:** lower LR → underfitting under vol-10x loss amplification. Both runs also diverged late (grad_norm → Infinity). lr=6e-4 now bracketed from below as optimum.
+
 ## 2026-04-24 10:15 — PR #3209: TFP cp_panel_prior_index bug fix + multi-seed reproducibility (sanji) — MERGED (bug fix)
 
 - sanji/bugfix/cp-panel-prior-index-tandemfoil-paper, W&B runs: hduq51jw (seed=0, 20ep), 9dodz26x (seed=42, 20ep), xgt4c9oc (seed=123, 20ep), xsk8r0rm (seed=0, 999ep stripped config)

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,9 @@
 # SENPAI Research Results
 
+## 2026-04-23 22:00 — PR #3171: DM LR warmup + EMA+gc (sanji) — CLOSED
+
+- 5-ep warmup: 11.325% ep31 then collapsed to 66.8% (W&B: `ulog3zq2`). 10-ep warmup: 3.918% ep496, plateaued (W&B: `5ltdja3j`) — 0.085pp worse than 3.833% baseline, no further descent trend (last 50 epochs mean 4.02%). Warmup is neutral-to-harmful when EMA+gc=0.5 already provides stability. Adding to dead ends.
+
 ## 2026-04-23 21:30 — PR #3168: TFP multi-seed variance (jin) — CLOSED — CRITICAL FINDING
 
 - Seed 42: field_mse=4.28e+26 (velocity OK, pressure diverged). Seed 123: Infinity from ep70. Seed 456: Infinity from ep200. Baseline (seed=0): 0.002383. **0/3 seeds reproduce the champion**. The TFP baseline is a SINGLE LUCKY SEED (seed=0/default), not a robust result. This redefines TFP as a stabilization problem — the pressure representation (asinh/sinh transforms) is extremely initialization-sensitive. Bug fix: primary_metric_key shadowing.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,32 @@
 # SENPAI Research Results
 
+## 2026-04-24 09:30 — PR #3238: AF WD=0 ablation on vol-10x+EMA champion (rei) — SENT BACK
+
+- rei/af-wd0-ablation, W&B runs: sqotwbxs (WD=0), cjcftqo8 (WD=5e-3), group: af-no-wd
+- Hypothesis: WD may be over-regularizing the AF model; removing or reducing it could unlock precision
+
+| Trial | WD | surface_mse | vs baseline | vol_mse (at best-surface ckpt) | vs baseline |
+|-------|------|-------------|-------------|-------------------------------|-------------|
+| T1 | 0 | 0.000384 | +29.7% | 0.002997 | +47.0% |
+| T2 | 5e-3 | **0.000249** | **-15.9% NEW BEST** | 0.002679 | +31.4% |
+
+- **WD=0 is a clear dead end** — both metrics regress substantially. EMA=0.999 insufficient implicit regularization for 2L/256d.
+- **WD=5e-3 reveals a genuine surface/volume tradeoff** — surface_mse=0.000249 is the best surface result in the entire AF programme. But vol_mse=0.002679 is far from 0.0017 target.
+- **Sent back for follow-up:** WD=5e-3 + vol-loss-weight=15x and 20x, testing whether increased vol emphasis can recover vol_mse while preserving the surface precision gain.
+
+## 2026-04-24 09:30 — PR #3233: DM stochastic depth/LayerDrop (gojo) — CLOSED (dead end)
+
+- gojo/dm-stochastic-depth, W&B runs: sx8t4fq8 (p=0.1), cs1l7yye (p=0.2), wwbkzvoy (p=0.3), group: dm-stochastic-depth
+- Hypothesis: stochastic depth (randomly dropping transformer layers) provides regularization against late-training divergence
+
+| Trial | Drop prob | val_pct | vs baseline |
+|-------|-----------|---------|-------------|
+| T1 | p=0.1 | 4.317% | +12.6% |
+| T2 | p=0.2 | 4.217% | +10.0% |
+| T3 | p=0.3 | 4.411% | +15.1% |
+
+- **Root cause:** Only 4 layers — dropping 1 removes 25% capacity. Stochastic depth designed for 50-110+ layer networks. Too coarse for shallow architecture. EMA+gc already handles stability.
+
 ## 2026-04-24 09:15 — PR #3199: DM EMA=0.9999/0.99995 upward sweep (megumi) — CLOSED (dead end)
 
 - megumi/dm-ema-0.9999, W&B runs: c168t4dq (EMA=0.9999), 26n0lcmg (EMA=0.99995)

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,9 @@
 # SENPAI Research Results
 
+## 2026-04-23 22:30 — PR #3161: DM eta_min=1e-5 cosine floor + EMA+gc (spike) — CLOSED
+
+- Best val=4.202% ep297, then diverged ep312 → 16.3% (W&B run from student report). Trough-smoothing effect confirmed — eta_min prevents hard zeros at cosine troughs, giving EMA smoother targets. But 4.202% is 9.6% worse than 3.833% baseline. Root cause: gc=0.5 relies on zero-LR trough damping as a natural stability reset; eta_min=1e-5 removes that reset, allowing gradient accumulation through troughs → eventual divergence. Triple confirmation: eta_min+gc is incompatible at any gc value (gc=1.0→6.311%, gc=0.5→8.617% prior, now gc=0.5+EMA→4.202% diverge). Added to dead ends.
+
 ## 2026-04-23 22:00 — PR #3171: DM LR warmup + EMA+gc (sanji) — CLOSED
 
 - 5-ep warmup: 11.325% ep31 then collapsed to 66.8% (W&B: `ulog3zq2`). 10-ep warmup: 3.918% ep496, plateaued (W&B: `5ltdja3j`) — 0.085pp worse than 3.833% baseline, no further descent trend (last 50 epochs mean 4.02%). Warmup is neutral-to-harmful when EMA+gc=0.5 already provides stability. Adding to dead ends.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,33 @@
 # SENPAI Research Results
 
+## 2026-04-24 09:00 — PR #3232: AF vol-weight warm-up schedule (nezuko) — CLOSED (dead end)
+
+- nezuko/af-vol-warmup, W&B runs: 9tc2udwf (200ep ramp), gp149j2g (100ep ramp), o8ifqyac (50ep ramp), group: af-vol-warmup
+- Hypothesis: linear vol-weight warm-up from 1x→10x over N epochs lets model learn surface first, then shift to volume (physics-motivated: BL must resolve before volume)
+
+| Trial | Warmup | surface_mse | vs baseline | vol_mse | vs baseline | Status |
+|-------|--------|-------------|-------------|---------|-------------|--------|
+| T1 | 200 ep | 0.000421 | +42% | 0.003456 | +70% | COLLAPSED ep600 |
+| T2 | 100 ep | 0.000379 | +28% | 0.003443 | +69% | stable |
+| T3 | 50 ep | 0.001098 | +271% | 0.010298 | +405% | COLLAPSED ep200 |
+
+- **Collapse mechanism:** Cosine LR restarts (T_max=50) inject LR peak at the moment vol_weight reaches 10x → destructive gradient spikes. T1/T3 collapse into degenerate constant predictions (Ux=Uy=nut≈0, p≈2.48). T2 survives but +28% surface / +69% volume.
+- **Conclusion: vol-weight warm-up dead for AF. Static 10x from epoch 0 is now TRIPLE-CONFIRMED optimal** (this + curriculum #3226 + vol>10x #3204). The optimizer needs to adapt to full 10x from the start.
+
+## 2026-04-24 09:00 — PR #3227: Focal-MSE loss for AF volume (casca) — CLOSED (dead end)
+
+- casca/af-focal-volume-loss, W&B runs: 332df4z1 (gamma=2), kasxtssl (gamma=1), group: af-focal-volume-loss
+- Hypothesis: focal weighting `(error/error_max)^gamma * error^2` on volume loss upweights hard cells (near-wall/wake), redistributing gradient signal toward physically important regions
+
+| Trial | gamma | surface_mse | vs baseline | vol_mse | vs baseline | Best epoch |
+|-------|-------|-------------|-------------|---------|-------------|------------|
+| T1 | 2.0 | 0.001456 | +392% | 0.08343 | +3993% | 198 |
+| T2 | 1.0 | 0.000952 | +222% | 0.008557 | +320% | 585 |
+
+- **Root cause (dual failure):** (1) Batch-max normalization makes loss landscape non-stationary — denominator shifts each step as predictions improve. (2) Freestream cells downweighted by focal serve as essential scaffolding for optimization trajectory. Stronger gamma = more aggressive scaffolding removal = earlier collapse.
+- **Monotonic gamma-degradation:** gamma=2 peaked ep198 (catastrophic), gamma=1 peaked ep585 (bad). Confirms focal redistribution is fundamentally wrong direction.
+- **Conclusion: focal-MSE dead for AF volume.** Any error-based per-point reweighting faces the non-stationarity problem. Would need EMA-smoothed normalization for ground-up reformulation.
+
 ## 2026-04-24 08:30 — PR #3231: DM pressure gradient smoothness reg (emma) — CLOSED (dead end)
 
 - emma/dm-pressure-gradient-reg, W&B runs: lqgwricr (λ=0.01), e2rko1vh (λ=0.1), xcynbcli (λ=1.0), group: dm-pressure-grad-reg

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,22 @@
 # SENPAI Research Results
 
+## 2026-04-24 03:45 — PR #3203: DM attention temperature annealing (vegeta) — CLOSED (dead end)
+
+- vegeta/dm-attn-temp-annealing, W&B run: ybh108ny
+- Hypothesis: linearly anneal attention temperature τ from 2.0→1.0 over training (soft→sharp attention)
+- Result: val=4.024% ep485 (+5.0% vs 3.833%), test=4.975% (+6.2% vs 4.685%)
+- **Root cause: external annealed τ compounded with Transolver's existing learnable per-head temperature parameter.** Double-τ created convoluted optimization, not intended soft→sharp progression.
+- **Conclusion: attn temp annealing dead for DM.** The -11% improvement on noam does not transfer — noam likely lacks the learnable τ or has different optimizer dynamics.
+
+## 2026-04-24 03:45 — PR #3204: AF vol-weight=15x/20x clean control (gilbert) — CLOSED (dead end)
+
+- gilbert/af-vol-15x-clean, W&B group: af-vol-15x-clean
+- Hypothesis: higher vol-weight (15x/20x) without extra features may improve vol_mse
+- Trial 1 (15x, W&B: o048z651): surface=0.000352 (+19%), vol=0.003402 (+67%), best vol=0.002378 at ep763 (still 16.6% above baseline but descending)
+- Trial 2 (20x, W&B: pne2413l): crashed ep381, NaN grad norms — beyond stability boundary
+- **Key finding: surface-anchored checkpoint selection HIDES vol improvements.** At ep763, vol_mse=0.002378 but surface_mse=0.000594. The best-checkpoint metric (surface_mse) doesn't capture the best volume state.
+- **Conclusion: vol-weight>10x worsens surface/volume Pareto from current operating point.** But joint checkpoint selection could unlock vol gains at moderate vol-weight (11x-13x). Added vol-15x/20x to AF dead ends.
+
 ## 2026-04-24 03:15 — PR #3220: DM Mixup regularization (nobara) — CLOSED (dead end)
 
 - nobara/dm-mixup, W&B group: dm-mixup

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,15 @@
 # SENPAI Research Results
 
+## 2026-04-24 17:30 — PR #3270: DrivAerML FiLM conditioning (brook) — CLOSED dead end
+
+- brook/dm-geometry-film-conditioning
+- Hypothesis: FiLM conditioning on global geometry stats (bounding box, centroid, std) helps the Transolver adapt per-point predictions to car shape
+- Trial 1 (gamma+beta): 5.221% val at ep135, diverged at ep150 (grad norm 0.5→53,000+). Trial 2 (additive-only beta): 5.369% val at ep174, diverged at ep178.
+- Both ~35-40% worse than baseline (3.833%). Catastrophic gradient explosion from FiLM MLP amplifying gradients through cosine LR restarts. Dead end — conditioning pathway interferes with Transolver routing.
+- **Brook assigned to Breakout 3 (#3301): domain-normalized volume auxiliary**
+
+---
+
 ## 2026-04-24 16:45 — PR #3284: Harness patches (vegeta) — MERGED (infrastructure)
 
 - vegeta/harness-patches-last-ditch, train.py +218/-53

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,25 @@
 # SENPAI Research Results
 
+## 2026-04-24 10:15 — PR #3209: TFP cp_panel_prior_index bug fix + multi-seed reproducibility (sanji) — MERGED (bug fix)
+
+- sanji/bugfix/cp-panel-prior-index-tandemfoil-paper, W&B runs: hduq51jw (seed=0, 20ep), 9dodz26x (seed=42, 20ep), xgt4c9oc (seed=123, 20ep), xsk8r0rm (seed=0, 999ep stripped config)
+- **Bug fix:** cp_panel_prior_index() returned non-None for tandemfoil_paper even though build_tandem_paper_bundle() never populates cp_panel → sinh() applied to Fourier feature column → Inf overflow. Fix: guard with dataset name check. Also fixes primary_metric_key shadowing.
+- **Multi-seed reproducibility CONFIRMED:** seeds 0/42/123 all produce finite metrics (cross-seed std ≈ 0.0016 at ep20). Pre-fix, seeds 42/123 diverged to Inf.
+- **999-ep stripped config result:** val_primary/field_mse = 0.003615 (ep353). Expected worse than 0.002383 baseline since champion flags were deliberately omitted.
+- **TFP STABILIZATION CRISIS RESOLVED.** Normal TFP experiments can resume. Next step: re-run with full champion config to confirm 0.002383 is recoverable.
+
+## 2026-04-24 10:15 — PR #3252: DM progressive surface point training (mitsuha) — CLOSED (dead end)
+
+- mitsuha/dm-progressive-resolution, W&B runs: u94n7qjo (25k→50k@200), 972xv0ty (30k→50k@100), group: dm-progressive-resolution
+- Hypothesis: train on fewer surface points initially, transition to 50k later for speed + curriculum effect
+
+| Trial | Config | best val_pct | vs baseline | Status |
+|-------|--------|-------------|-------------|--------|
+| T1 | 25k→50k@200 | 8.147% | +113% | Crashed ep112, grad explosion |
+| T2 | 30k→50k@100 | 4.711% | +23% | Stable but converging deficit |
+
+- **Root cause:** DM requires full 50k-point context from epoch 1. 30k warmup imposes ~0.6pp persistent deficit vs baseline at same epoch. Speed gain from fewer points doesn't compensate. Consistent with 50k being only viable surface count.
+
 ## 2026-04-24 10:00 — PR #3256: DM coordinate noise augmentation (alphonse) — CLOSED (dead end)
 
 - alphonse/dm-coord-noise-augmentation, W&B runs: hapy2g9k (σ=0.001), qfu1j89b (σ=0.005), group: dm-coord-noise-aug

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,22 @@
 # SENPAI Research Results
 
+## 2026-04-24 18:30 — PR #3301: DrivAerML Breakout 3 domain-normalized volume auxiliary (brook) — SENT BACK (round 2)
+
+- brook/dm-domain-normalized-volume-aux
+- Hypothesis: Fix volume target normalization bug (surface cp stats applied to 4-channel volume data caused 40,000:1 loss ratio in #3044), then use volume as auxiliary representation objective
+- **Normalization fix confirmed:** vol/surface loss ratio 0.95-0.98 at epoch 1 (was ~40,000:1 before). Also fixed pre-existing bug in core/features.py:augment_case_sample (surface_x 7-dim vs volume_x 4-dim concat crash).
+
+| Trial | vol_loss_weight | vol_pts | best val surface_rel_l2_pct | best ep | W&B | status |
+|-------|----------------|---------|---------------------------|---------|-----|--------|
+| A | 0.1 | 16k | 9.69% | 99 | pttzba44 | killed ep100 |
+| B | 0.03 | 16k | 9.63% | 100 | j5s3yre4 | killed ep100 |
+| C | 0.3 | 8k | 18.17% | 100 | dvbqs5bs | killed ep100 |
+
+- All killed by --kill-if-best-val-above 100:8.0, BUT champion was likely ~8-10% at ep100 too (reached 3.833% at ep511). Kill gate was too aggressive.
+- **Sent back:** Re-run Trial B (w=0.03) and new Trial E (w=0.01) with relaxed kill gate (250:7.0, no-improvement 200:0.05), plus surface-only control. Need 500+ epochs to evaluate properly.
+
+---
+
 ## 2026-04-24 17:30 — PR #3270: DrivAerML FiLM conditioning (brook) — CLOSED dead end
 
 - brook/dm-geometry-film-conditioning

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,18 @@
 # SENPAI Research Results
 
+## 2026-04-24 11:45 — PR #3263: DM Sparse MoE FFN (gojo) — CLOSED (dead end)
+
+- gojo/dm-moe-ffn, W&B runs: rei05zxk (K=4), hjkzjnn8 (K=8), group: dm-moe-ffn
+- Hypothesis: sparse MoE FFN allows regime-specific computation (different experts for stagnation/wake/underbody)
+
+| Trial | K experts | best val_pct | vs baseline | Epochs (vs 511) |
+|-------|-----------|-------------|-------------|-----------------|
+| T1 | 4 | 5.092% | +33% | 173 (timeout) |
+| T2 | 8 | 5.348% | +40% | 136 (timeout) |
+
+- **Dual failure:** (1) 1.7-2.2x throughput penalty — expert loop not compile-friendly → epoch starvation to 136-173 vs 511. (2) Routing collapse — balance_coeff=0.1 forces uniform routing (99-100% max entropy), preventing regime specialization. balance_coeff=0.01 causes full collapse at bs=1.
+- **Key finding:** Per-epoch learning curve is parallel to dense model — MoE adds zero sample-efficiency benefit. FFN is not the bottleneck for the 3.833% error floor. Any future DM modification MUST preserve throughput or show per-epoch quality gain.
+
 ## 2026-04-24 11:30 — PR #3264: DM Weight Standardization (vegeta) — CLOSED (dead end)
 
 - vegeta/dm-weight-standardization, W&B runs: x0biqh3s (lr=5e-4), i7nvv6gj (lr=6e-4), group: dm-weight-standardization

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,18 @@
 # SENPAI Research Results
 
+## 2026-04-24 11:15 — PR #3247: DM EMA periodic reset (brook) — CLOSED (dead end)
+
+- brook/dm-ema-periodic-reset, W&B runs: ltfotg72 (reset@100ep), q221x53o (reset@50ep), group: dm-ema-periodic-reset
+- Hypothesis: periodic EMA reset prevents multi-basin dilution from cosine restarts
+
+| Trial | Reset interval | best val_pct | vs baseline | Outcome |
+|-------|---------------|-------------|-------------|---------|
+| T1 | 100 ep | 4.426% | +15% | Cascade diverged ep335 after reset #3 |
+| T2 | 50 ep | 6.818% | +78% | Diverged ep108 after reset #2 |
+
+- **Key insight:** EMA=0.9995 on DM is the PRIMARY gradient stabilization mechanism. Model enters progressively sharper basins — by ep300, resetting EMA removes protective smoothing at highest-curvature point → immediate cascade. Multi-basin averaging IS the feature, not a bug.
+- **Constraint for future work:** Any EMA modification must preserve the continuous shadow trajectory.
+
 ## 2026-04-24 11:00 — PR #3258: DM auxiliary surface normal prediction (emma) — CLOSED (dead end)
 
 - emma/dm-aux-normal-prediction, W&B runs: fkiz67ki (w=0.1), g9zs1wsh (w=0.01), group: dm-aux-normal-prediction

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,33 @@
 # SENPAI Research Results
 
+## 2026-04-24 13:35 — PR #3273: DM Grouped Query Attention (gojo) — CLOSED (dead end)
+
+- gojo/dm-grouped-query-attention, W&B runs: rq2tz9hh (2KV), wbygalr3 (4KV), group: dm-gqa
+- Hypothesis: GQA reduces KV heads (8→2 or 4) for throughput gain, enabling more epochs within timeout
+
+| Trial | KV heads | best val_pct | Epochs | Outcome |
+|-------|----------|-------------|--------|---------|
+| 2KV | 2 | 12.882% (ep57) | ~131 | Crashed — gradient explosion |
+| 4KV | 4 | 6.884% (ep114) | ~128 | Crashed — gradient explosion |
+
+**Conclusion:** GQA is throughput-NEUTRAL on Transolver — the bottleneck is the 50k-token slice-routing einsums, not QKV projections (which only operate on 96 slice tokens). GQA also destabilizes per-head slice routing: KV sharing forces coupled routing dynamics that explode at cosine restart peaks. Both configs diverged before reaching 511 epochs. Key insight: future throughput experiments should target slice routing, not attention projections.
+
+---
+
+## 2026-04-24 13:35 — PR #3243: DM error-weighted surface sampling (jet) — CLOSED (dead end)
+
+- jet/dm-error-weighted-sampling, W&B runs: 7amzkwq3 (T=1.0), 62zxlf2x (T=0.5), group: dm-error-weighted-sampling
+- Hypothesis: importance-sample surface points by prediction error to focus on hard regions
+
+| Trial | Temperature | best val_pct | Epochs | Outcome |
+|-------|------------|-------------|--------|---------|
+| T=1.0 | 1.0 | 40.79% (ep5) | 6 | Crashed — distribution shift collapse |
+| T=0.5 | 0.5 | 39.31% (ep5) | 6 | Crashed — distribution shift collapse |
+
+**Conclusion:** Classic importance-sampling distribution-shift collapse. Both crashed on the first epoch where error-weighted sampling activated. Gradient norms exploded 15-29x as hard points got massively overweighted and smooth regions starved. Additional blockers: fp32 error-map computation costs 30-60 min/epoch (throughput-prohibitive), and weighted sampling creates train/eval mismatch (same as #3259). Student's suggestion of error-weighted LOSS (not sampling) avoids distribution shift but still faces train/eval mismatch.
+
+---
+
 ## 2026-04-24 13:15 — PR #3272: DM quadratic position features (vegeta) — CLOSED (dead end)
 
 - vegeta/dm-quadratic-pos-encoding, W&B runs: equlqwg4 (quad+Fourier), qm4gk9bi (quad-only)

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,9 @@
 # SENPAI Research Results
 
+## 2026-04-23 20:30 — PR #3134: AF vol-weight=30x (megumi) — CLOSED
+
+- Surface=0.001264 (4.3x worse than 0.000296 baseline), vol=0.006235 (3.1x worse than 0.002039 baseline) (W&B: `wupz6iuj`). 30x volume weighting massively overshoots — optimizer saturates on volume gradients and both metrics collapse. Model diverged post-ep400, terminal surface=0.621 vol=1.533. No Pareto improvement at any epoch. Sweet spot confirmed at 10x (#3135). Adding to dead ends: vol-weight≥30x catastrophic.
+
 ## 2026-04-23 20:00 — PR #3132: DM eta_min=5e-5 + gc compound (gohan) — CLOSED
 
 - gc=1.0+eta_min=5e-5: 6.311% ep149, diverged ep150 → 112.66% (W&B: `h6jblqjq`). gc=0.5+eta_min=5e-5: 8.617% ep70, diverged → 72% (W&B: `7fmjg0cu`). Third confirmation eta_min=5e-5 is dead — alone (#3126), +gc=1.0, +gc=0.5 all diverge catastrophically. Non-zero LR floor prevents gradient momentum dissipation at cosine troughs; gc delays but cannot prevent cumulative drift. gc=0.5 is counterproductive here — clips 288/394 batches (throttles signal), worse than gc=1.0 which clips only 73/394.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,17 @@
 # SENPAI Research Results
 
+## 2026-04-23 21:30 — PR #3168: TFP multi-seed variance (jin) — CLOSED — CRITICAL FINDING
+
+- Seed 42: field_mse=4.28e+26 (velocity OK, pressure diverged). Seed 123: Infinity from ep70. Seed 456: Infinity from ep200. Baseline (seed=0): 0.002383. **0/3 seeds reproduce the champion**. The TFP baseline is a SINGLE LUCKY SEED (seed=0/default), not a robust result. This redefines TFP as a stabilization problem — the pressure representation (asinh/sinh transforms) is extremely initialization-sensitive. Bug fix: primary_metric_key shadowing.
+
+## 2026-04-23 21:30 — PR #3154: DM monotonic cosine + EMA (historia) — CLOSED (wrong parameter)
+
+- Best val=4.392% ep308 (W&B: `we38omf3`), 14.6% worse than 3.833%. HOWEVER: T_max=999 is in STEPS not epochs — actually tested rapid 5-epoch cycling, not monotonic decay. True monotonic needs T_max=393606. Diverged ep336 via EMA cascade (corrupted online → 14+ epochs to flush from EMA buffer). Rapid cycling confirmed worse. True monotonic hypothesis remains untested — reassigning.
+
+## 2026-04-23 21:30 — PR #3083: DM 600 batches no gc (jet) — CLOSED
+
+- Best val=9.537% ep48, diverged to NaN ep266 (W&B: `s4kvc8oz`). 2.5x worse than baseline. 600 batches at 4L/512d WITHOUT gradient clipping is fundamentally unstable. Student correctly diagnosed: gc=0.5+EMA mandatory, T_max needs scaling to ~46. Reassigning with proper stabilization config.
+
 ## 2026-04-23 21:00 — PR #3190: TFP physics features isolation (brook) — CLOSED
 
 - Trial 1 (all physics): val=Infinity — cp_panel_prior_index() wrong index for tandemfoil_paper (W&B: `0eq5jqij`). Trial 2 (wake only): val=0.7396, diverged (W&B: `kqknlctz`). CRITICAL: TFP pipeline only supports enable_fourier/wake_deficit/wake_angle — other physics flags silently ignored.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,16 @@
 # SENPAI Research Results
 
+## 2026-04-24 22:45 — PR #3303: DrivAerML compile-mode champion recovery (faye) — CLOSED (critical bug finding)
+
+- faye/dm-compile-champion-recovery
+- **CRITICAL BUG:** torch.compile + FixedEMA is broken on PyTorch 2.10.0 + Blackwell GPUs. Compiled model caches parameter data — in-place param.data.copy_() from EMA swap NOT reflected in compiled forward pass. Val metrics frozen to 15+ decimal places. Training loss drops normally but eval never updates.
+- compile also incompatible with --skip-update-grad-norm 100 (compile grad norms 128-378 vs surface-only ~2-10)
+- Implication: ALL DM runs must use --no-compile-model with EMA. Original champion ncl1dh88 may have had incorrect EMA eval if it ran with compile default.
+- W&B runs: 89o7idav (v1 seed0, killed), scjbssye (v1 seed42, killed), v2 seed0/seed42 (broken eval), no-compile diagnostic (working)
+- **Faye assigned to #3305: champion recovery seed=13 + eval-interval=5**
+
+---
+
 ## 2026-04-24 19:30 — PR #3244: DrivAerML paper-facing full eval (faye) — CLOSED (critical finding)
 
 - faye/dm-paper-facing-champion-full-eval

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,31 @@
 # SENPAI Research Results
 
+## 2026-04-24 08:00 — PR #3236: AF Lookahead+compile ablation (gohan) — CLOSED (important finding)
+
+- gohan/af-lookahead-compile, W&B runs: dm5ykwmx (no features), bl5kty7w (Lookahead only), ejjf27ob (compile only)
+- Hypothesis: test whether Lookahead+compile (discovered to be default-on) help AF
+- **CRITICAL FINDING: Both features are DEFAULT ON in baseline.** Gohan correctly reframed as ablation study.
+- Trial A (no features): surface=0.000538 ep422 (still running, GPU-shared). Trial B (Lookahead only): 0.000826 (+53% worse). Trial C (compile only): 0.001104 (worst despite 49% more epochs).
+- **Lookahead hurts AF surface by 53% at equal epochs.** Compile hurts surface quality despite throughput gains. "Double averaging" (EMA + Lookahead) is harmful for AF.
+- **Ambiguity: baseline with both features = 0.000296@ep704 (better than all ablations).** Could be synergy at long training or just single-GPU vs GPU-sharing budget difference.
+- Follow-up assigned: gohan #3255 no-Lookahead/no-compile full single-GPU budget to resolve ambiguity.
+
+## 2026-04-24 08:00 — PR #3230: AF residual-prediction + re-stratified sampling no-asinh (alphonse) — CLOSED (dead end)
+
+- alphonse/af-residual-restrat, W&B runs: qrws45k4 (both features), 9t9k4w26 (residual only)
+- Hypothesis: residual prediction + re-stratified sampling (without toxic asinh) help AF
+- Trial 1 (both): surface=0.000459 (+55%), vol=0.002652 (+30%). Trial 2 (residual only): surface=0.000509 (+72%), vol=0.003256 (+60%)
+- **Residual prediction harmful for AF:** flow has large separated regions where "correction from freestream" IS the entire signal. Re-stratified sampling is a no-op (AF returns uniform sample weights).
+- **Conclusion: residual-prediction added to AF dead-end list alongside asinh-pressure.**
+
+## 2026-04-24 08:00 — PR #3226: AF vol-weight curriculum 20x→10x (chihiro) — CLOSED (dead end)
+
+- chihiro/af-volume-weight-curriculum, W&B runs: 75lpm3lz (20x→10x), 72xdp0o9 (15x→10x)
+- Hypothesis: decaying vol-weight curriculum — front-load volume emphasis then relax to 10x
+- Trial 1 (20x→10x): surface=0.001295 (4.4x worse), vol=0.005167 (2.5x worse). Collapsed ep335 (grad norms 200-500x normal)
+- Trial 2 (15x→10x): surface=0.000408 (+38%), vol=0.003097 (+52%). Stable but both metrics worse
+- **Conclusion: vol-weight curriculum dead. Static 10x validated as optimal operating point.** Any deviation above 10x (even temporary) costs surface without vol benefit.
+
 ## 2026-04-24 07:30 — PR #3225: DM self-distillation via EMA teacher (canute) — CLOSED (dead end)
 
 - canute/dm-self-distillation, W&B runs: 1df67nu8 (α=0.3), r8c2ztmm (α=0.1), group: dm-self-distillation

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,20 @@
 # SENPAI Research Results
 
+## 2026-04-24 08:30 — PR #3231: DM pressure gradient smoothness reg (emma) — CLOSED (dead end)
+
+- emma/dm-pressure-gradient-reg, W&B runs: lqgwricr (λ=0.01), e2rko1vh (λ=0.1), xcynbcli (λ=1.0), group: dm-pressure-grad-reg
+- Hypothesis: KNN-based smoothness penalty on surface pressure predictions encourages physically smooth predictions
+- λ=0.01: val=4.481% (+17%). λ=0.1: 4.876% (+27%). λ=1.0: 12.521% (+227%). All worse
+- **Two failures:** (1) KNN on 50k pts imposes ~30% throughput overhead, cutting epochs from 511 to ~355. At λ=0.01, degradation is mostly throughput-induced. (2) Car surfaces have legitimately sharp features that smoothness penalties destroy.
+- **Key insight from student:** remaining DM error is systematic bias, not high-freq noise. Smoothness priors are the wrong tool.
+
+## 2026-04-24 08:30 — PR #3196: TF EMA decay sweep 0.9999/0.99995 (zenitsu) — CLOSED (dead end)
+
+- zenitsu/tf-ema-decay-sweep, W&B runs: 8zpc9p92 (0.9999), ipgmi52n (0.99995), group: tf-ema-decay
+- EMA=0.9999: val=21.807 (+2.3% vs 21.319 baseline). EMA=0.99995: val=22.153 (+3.9%)
+- **Monotonic ordering confirmed: 0.999 > 0.9999 > 0.99995 for TF.** Matches AF finding — higher decay consistently harmful across both benchmarks.
+- TF is guardrail-only, no further EMA sweeps warranted.
+
 ## 2026-04-24 08:00 — PR #3236: AF Lookahead+compile ablation (gohan) — CLOSED (important finding)
 
 - gohan/af-lookahead-compile, W&B runs: dm5ykwmx (no features), bl5kty7w (Lookahead only), ejjf27ob (compile only)

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,13 @@
 # SENPAI Research Results
 
+## 2026-04-24 00:15 — PR #3185: TF full noam stack (fern) — MERGED ✓ NEW TF CHAMPION
+
+- Trial 1 (full stack: ANP+physics+T_max=150+96sl+Lookahead+compile+re-strat): val=21.319 ep277, test=22.868 (W&B: v05jt92n). Beats baseline 21.350/23.195 on both metrics (-0.15% val, -1.41% test). Trial 2 (ANP+physics only, T_max=10): val=22.276 ep233 (W&B: anluw1ab), diverged ep289. Key insight: full-stack extras (Lookahead, compile, 96 slices, re-stratified) only compound in late training (after ep200). T2 led for first 180 epochs. T_max=150 essential for full benefit. New TF config: Lion lr=1.25e-4, T_max=150, gc=0.2, EMA=0.999, 96 slices, ANP+full physics+asinh-scale=0.75+residual+Lookahead+compile+re-strat.
+
+## 2026-04-24 00:15 — PR #3186: TF T_max=150 alone (norman) — CLOSED (dead end)
+
+- gc=0.3+T_max=150: val=24.534 ep320 (+14.9% vs 21.350, W&B: ofq6mboa). gc=0.5+T_max=150: val=30.460 diverged ep87 (W&B: 5z8g5420). Both worse. T_max=150 alone doesn't help — benefit requires full noam feature stack (especially ANP + physics). T_max=10 with gc=0.3 remains load-bearing without features.
+
 ## 2026-04-24 00:00 — PR #3193: DM residual-prediction ablation (franky) — CLOSED (dead end)
 
 - Residual-only: best val=15.001% ep36 (W&B: uteqp5p4), crashed ep39 — catastrophic gradient explosion without asinh. Residual+asinh combined: best val=3.999% ep405 (W&B: 6eud1yyg), destabilized ep416 → 4.36%. Key finding: residual-prediction has a HARD dependency on asinh for stability on DM. Even paired, the combo gets to 3.999% (+0.17pp gap) but can't overtake champion. Asinh tames pressure gradients enough for residual to function, but added complexity still introduces late-training instability. Casca #3192 (asinh-only) will be the definitive single-feature test.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,9 @@
 # SENPAI Research Results
 
+## 2026-04-23 23:15 — PR #3213: DM surface normal input features (brook) — CLOSED (already implemented)
+
+- No trials ran. Brook discovered surface normals are ALREADY present in DrivAerML input tensor (columns 3-5 of SURFACE_X_DIM=7, loaded from surface_normals.npy in prepare_drivaerml.py). The champion already has full access to normals. Hypothesis moot. Pivot: Fourier encoding of normals (currently only xyz cols 0-2 get Fourier features, not normals) — reassigning brook to this follow-up.
+
 ## 2026-04-23 23:00 — PR #3208: TFP seed stability diagnostic — strip physics flags (brook) — CLOSED (diagnostic complete)
 
 - All 3 trials STABLE at seed=42 with no physics flags. Lion lr=1.25e-4: val=0.04931, test=0.04134 (W&B: confirmed). Lion lr=6.25e-5: val=0.04920, test=0.04302. AdamW lr=1e-4: val=0.08036, test=0.06962. Zero NaN/Inf at any point. **Definitive proof: physics transforms (asinh/sinh pressure) cause TFP instability, not seed sensitivity.** Stable floor ~0.047-0.049 across seeds and optimizers. Path forward: fix pressure transforms (sanji #3209), then reintroduce one at a time.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,25 @@
 # SENPAI Research Results
 
+## 2026-04-23 23:00 — PR #3208: TFP seed stability diagnostic — strip physics flags (brook) — CLOSED (diagnostic complete)
+
+- All 3 trials STABLE at seed=42 with no physics flags. Lion lr=1.25e-4: val=0.04931, test=0.04134 (W&B: confirmed). Lion lr=6.25e-5: val=0.04920, test=0.04302. AdamW lr=1e-4: val=0.08036, test=0.06962. Zero NaN/Inf at any point. **Definitive proof: physics transforms (asinh/sinh pressure) cause TFP instability, not seed sensitivity.** Stable floor ~0.047-0.049 across seeds and optimizers. Path forward: fix pressure transforms (sanji #3209), then reintroduce one at a time.
+
+## 2026-04-23 23:00 — PR #3205: TFP seed sensitivity — is seed=0 a lucky init? (jin) — CLOSED — CRITICAL: CODE REGRESSION
+
+- **Seed=0 no longer reproduces the champion.** All 4 trials produce Inf on pressure: T1 seed=0 control (W&B: 65q3qcbo), T2 seed=42 gc=0.3 (6hv5zqio), T3 seed=42 warmup=3 (g3hvoya7), T4 seed=42 asinh=0.5 (e2arojym). Velocity channels healthy (Ux~0.004, Uy~0.014) — pathology isolated to sinh inverse pressure transform at eval. This upgrades TFP crisis: it's not "one lucky seed" but a **code regression since PR #3025**. The champion config is BROKEN in the current codebase. No stabilization approach (gc/warmup/asinh-scale) helped. Waiting for sanji #3209 cp_panel bug fix.
+
+## 2026-04-23 23:00 — PR #3173: DM shorter cosine T_max=15/20 + EMA+gc (kakashi) — CLOSED (dead end)
+
+- T_max=15: best val=4.406% ep259, stable but plateaued (W&B: nufcf02f). T_max=20: best val=4.943% ep186, catastrophic divergence ep187 → 62.9% by ep259 (W&B: fqozs87o). Neither beats 3.833%. T_max=15 converges to higher plateau because shorter cycles reset LR before productive optimization completes. T_max=20 diverges at first restart. T_max=30 confirmed as DM sweet spot; T_max<30 added to dead ends.
+
+## 2026-04-23 23:00 — PR #3101: AF vol-weight=1.5x/3x (tanjiro) — CLOSED (dead end)
+
+- Vol-weight=3.0: surface=0.000381 (+29%), vol=0.003904 (+91%) vs champion (W&B: 2ebhl15x). Vol-weight=1.5: surface=0.000371 (+25%), vol=0.004224 (+107%) (W&B: ivwcw1xj, 5wv8vbas). Both diverged at cosine LR peaks. Completes vol-weight<10x dead end: 1.5x/2x/3x/5x/7x ALL confirmed worse. 10x+EMA=0.999 is the AF sweet spot.
+
+## 2026-04-23 23:00 — PR #3063: DM paper-facing full eval seed=42 (canute) — CLOSED (superseded)
+
+- Used outdated config (gc=1.0, no EMA) — champion has since evolved to gc=0.5+EMA=0.9995. Phase 1 diverged without gc, restarted with gc=1.0. Phase 2 full eval: val=5.25%, test=4.81% (W&B: typ76b0y). Not a valid paper-facing number due to config mismatch. Superseded by faye #3164 running proper champion config.
+
 ## 2026-04-23 22:30 — PR #3161: DM eta_min=1e-5 cosine floor + EMA+gc (spike) — CLOSED
 
 - Best val=4.202% ep297, then diverged ep312 → 16.3% (W&B run from student report). Trough-smoothing effect confirmed — eta_min prevents hard zeros at cosine troughs, giving EMA smoother targets. But 4.202% is 9.6% worse than 3.833% baseline. Root cause: gc=0.5 relies on zero-LR trough damping as a natural stability reset; eta_min=1e-5 removes that reset, allowing gradient accumulation through troughs → eventual divergence. Triple confirmation: eta_min+gc is incompatible at any gc value (gc=1.0→6.311%, gc=0.5→8.617% prior, now gc=0.5+EMA→4.202% diverge). Added to dead ends.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,13 @@
 # SENPAI Research Results
 
+## 2026-04-24 00:00 — PR #3193: DM residual-prediction ablation (franky) — CLOSED (dead end)
+
+- Residual-only: best val=15.001% ep36 (W&B: uteqp5p4), crashed ep39 — catastrophic gradient explosion without asinh. Residual+asinh combined: best val=3.999% ep405 (W&B: 6eud1yyg), destabilized ep416 → 4.36%. Key finding: residual-prediction has a HARD dependency on asinh for stability on DM. Even paired, the combo gets to 3.999% (+0.17pp gap) but can't overtake champion. Asinh tames pressure gradients enough for residual to function, but added complexity still introduces late-training instability. Casca #3192 (asinh-only) will be the definitive single-feature test.
+
+## 2026-04-24 00:00 — PR #3183: TFP ANP+T_max=150 noam combo (rei) — CLOSED (dead end — TFP crisis)
+
+- ANP alone (T_max=10): field_mse=Inf every epoch, 548 epochs (W&B: bpqbwp3g). ANP+T_max=150: field_mse=3.1e+30 at best ep215, grad norms→62K, then NaN from ep400+ (W&B: 7uq11zww). Velocity channels healthy in both (Ux~0.0013-0.0015) — pathology isolated to pressure. ANP corrections in asinh-transformed space amplify exponentially on sinh inverse transform. Another manifestation of TFP physics-flag instability pattern. Entire TFP optimization blocked on sanji #3209 cp_panel bug fix.
+
 ## 2026-04-23 23:45 — PR #3175: DM full noam stack + individual ablations (hinata) — CLOSED (dead end)
 
 - Full stack (asinh+residual+compile+96sl+srf): best val=4.447% ep342 (W&B: vddf3qle), diverged → 64%. Asinh-only (scale=0.75): best val=4.421% ep303 (W&B: 0ks1aaz5), diverged → 61%. Residual-only: best val=4.651% ep242 (W&B: xmx6y3ws), diverged → NaN. All 0.6-0.8pp worse than 3.833%. Root cause: noam features were tuned for T_max=150/3H/no-gc regime — cosine T_max=30 restarts amplify gradient instability through these features despite gc=0.5. Asinh least harmful, residual most harmful. Individual ablations (casca #3192, franky #3193) may find narrower windows. Bug fix: primary_metric_key scoping.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,22 @@
 # SENPAI Research Results
 
+## 2026-04-24 02:00 — PR #3212: AF PCGrad gradient surgery (jin) — CLOSED (dead end)
+
+- jin/af-pcgrad, W&B group: af-pcgrad
+- Hypothesis: PCGrad (Yu et al., 2020) resolves surface/volume gradient conflicts to improve vol_mse
+- Trial 1 (PCGrad vol-10x, W&B: p89omv2u): surface=0.001926 (+550%), vol=0.011321 (+455%) — 5-6x worse on both metrics
+- Trial 2 (PCGrad vol-15x, W&B: 8cq4fd0i): surface=0.001510 (+410%), vol=0.011741 (+476%) — 5-6x worse on both metrics
+- **Root cause:** PCGrad requires retain_graph=True which disables torch.compile, causing ~40% throughput loss. Gradient conflict rate ~30-40% per step provides persistent magnitude reduction. The gradient conflict between surface and volume is NOT the bottleneck.
+- **Conclusion: PCGrad dead for AF.** Multi-backward-pass methods are fundamentally incompatible with the compile-dependent training pipeline. Added to AF dead ends.
+
+## 2026-04-24 02:00 — PR #3197: TF residual-prediction alone (gojo) — CLOSED (dead end)
+
+- gojo/tf-residual-prediction, W&B group: tf-residual-pred
+- Hypothesis: isolate contribution of --residual-prediction on TF without full noam stack
+- Trial 1 (residual alone, W&B: ja9b5iih): val=24.522 ep318 — +14.9% worse than 21.319
+- Trial 2 (residual+asinh, W&B: spykkoka): val=22.491 ep293 — +5.5% worse than 21.319
+- **Conclusion: residual-prediction is necessary but not sufficient for TF.** Adding asinh closes ~40% of the gap to champion but the full compound stack (ANP+physics+T_max=150+Lookahead+compile+96sl+re-strat) is required. Noam features don't decompose into independently useful TF components.
+
 ## 2026-04-24 01:15 — PR #3191: AF noam features (asinh+residual+re-strat) on base and vol-10x (alphonse) — CLOSED (dead end)
 
 - alphonse/af-noam-features, W&B group: af-noam-features-base

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,14 @@
 # SENPAI Research Results
 
+## 2026-04-24 16:45 — PR #3284: Harness patches (vegeta) — MERGED (infrastructure)
+
+- vegeta/harness-patches-last-ditch, train.py +218/-53
+- Merged after bug fix: double best-tracking consolidated into single atomic chain, min_delta applied in kill_if_no_improvement
+- **Patches now live:** --load-checkpoint (eval-only), --eval-interval N, --ema-mode fixed|warmup, --skip-update-grad-norm, --save-checkpoint, kill gates (--kill-if-best-val-above, --kill-if-no-improvement, --kill-if-grad-nonfinite-steps)
+- All subsequent DM champion recovery runs should use: --save-checkpoint --skip-update-grad-norm 100 --ema-mode fixed --ema-start-step 50
+
+---
+
 ## 2026-04-24 16:15 — PR #3276: DM cosine similarity auxiliary loss (zenitsu) — CLOSED (dead end)
 
 - zenitsu/dm-cosine-sim-aux-loss, W&B runs: ry1lq2vw (w=0.1), flnnss55 (w=0.5), group: dm-cosine-sim-loss

--- a/target/icml2026/instructions/experiment-vegeta-dm-attn-temp-annealing.md
+++ b/target/icml2026/instructions/experiment-vegeta-dm-attn-temp-annealing.md
@@ -1,0 +1,7 @@
+# Experiment: DrivAerML Attention Temperature Annealing
+
+Student: vegeta
+Branch: vegeta/dm-attn-temp-annealing
+Dataset: DrivAerML
+
+See PR for full instructions.

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -10,6 +10,7 @@ import json
 import math
 import os
 import random
+import sys
 import time
 from contextlib import nullcontext
 from dataclasses import asdict, dataclass
@@ -30,7 +31,7 @@ from core.features import (
     compute_vortex_panel_velocity,
     compute_wake_deficit_features,
 )
-from core.optim import Lion, Lookahead
+from core.optim import EMA as FixedEMA, Lion, Lookahead
 
 
 class EMAWithWarmup:
@@ -168,6 +169,14 @@ class TrainConfig:
     grad_accum_steps: int = 1
     volume_loss_weight: float = 1.0
     save_checkpoint: bool = False
+    load_checkpoint: str = ""
+    eval_interval: int = 1
+    skip_update_grad_norm: float = 0.0
+    ema_mode: str = "warmup"
+    ema_start_step: int = 50
+    kill_if_best_val_above: str = ""
+    kill_if_no_improvement: str = ""
+    kill_if_grad_nonfinite_steps: int = 0
     seed: int = 0
 
 
@@ -489,6 +498,12 @@ def build_bundle(config: TrainConfig) -> DatasetBundle:
 
 def cp_panel_prior_index(config: TrainConfig, bundle: DatasetBundle) -> int | None:
     if not config.enable_cp_panel or not config.enable_pressure_prior_addition:
+        return None
+    # Only tandemfoilset and airfrans bundles actually include cp_panel features
+    # in their tensors.  Other datasets (tandemfoilset_paper, drivaerml) silently
+    # ignore the enable_cp_panel flag, so computing an index would point to a
+    # wrong column (e.g. a Fourier feature) and cause numeric overflow.
+    if bundle.spec.name not in {"tandemfoilset", "airfrans"}:
         return None
     base_dim = bundle.spec.surface_input_dim
     if config.enable_vortex_panel_velocity:
@@ -1271,6 +1286,7 @@ def train_one_epoch(
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
     volume_loss_weight: float = 1.0,
+    skip_update_grad_norm: float = 0.0,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1339,18 +1355,32 @@ def train_one_epoch(
         if anp_head is not None:
             all_params += list(anp_head.parameters())
         grad_norm = torch.nn.utils.clip_grad_norm_(all_params, max_norm=grad_clip if grad_clip > 0 else float("inf"))
+        grad_norm_val = float(grad_norm)
         running.setdefault("grad_norm_mean", 0.0)
-        running["grad_norm_mean"] += float(grad_norm)
-        if grad_clip > 0 and float(grad_norm) > grad_clip:
+        running["grad_norm_mean"] += grad_norm_val
+        if grad_clip > 0 and grad_norm_val > grad_clip:
             running.setdefault("grad_clip_events", 0.0)
             running["grad_clip_events"] += 1.0
-        optimizer.step()
+        if not math.isfinite(grad_norm_val):
+            running.setdefault("grad_nonfinite", 0.0)
+            running["grad_nonfinite"] += 1.0
+        skip_step = skip_update_grad_norm > 0 and (not math.isfinite(grad_norm_val) or grad_norm_val > skip_update_grad_norm)
+        if skip_step:
+            optimizer.zero_grad(set_to_none=True)
+            running.setdefault("skipped_updates", 0.0)
+            running["skipped_updates"] += 1.0
+        else:
+            optimizer.step()
         if scheduler is not None:
             scheduler.step()
-        if ema is not None:
+        if ema is not None and not skip_step:
             ema.update(model)
-            running["ema_decay_actual"] = min(ema.decay, (1 + ema.step_counter) / (10 + ema.step_counter))
-        if anp_head is not None and anp_ema is not None:
+        if ema is not None:
+            if isinstance(ema, FixedEMA):
+                running["ema_decay_actual"] = ema.decay if ema.step_counter >= ema.start_step else 0.0
+            else:
+                running["ema_decay_actual"] = min(ema.decay, (1 + ema.step_counter) / (10 + ema.step_counter))
+        if anp_head is not None and anp_ema is not None and not skip_step:
             anp_ema.update(anp_head)
         running["loss"] += accum_loss / micro_count
         micro_batches_total += micro_count
@@ -1632,18 +1662,29 @@ def main() -> None:
         base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
         scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
 
-    ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
-    anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
+    if not config.use_ema:
+        ema = None
+    elif config.ema_mode == "fixed":
+        ema = FixedEMA(model, decay=config.ema_decay, start_step=config.ema_start_step)
+    else:
+        ema = EMAWithWarmup(model, decay=config.ema_decay)
+    if not config.use_ema or anp_head is None:
+        anp_ema = None
+    elif config.ema_mode == "fixed":
+        anp_ema = FixedEMA(anp_head, decay=config.ema_decay, start_step=config.ema_start_step)
+    else:
+        anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay)
     history: list[dict[str, float]] = []
     best_epoch: int | None = None
     best_val_primary_metric_name = primary_metric_key(bundle, phase="val")
+    if bundle.spec.name == "tandemfoilset":
+        val_primary_key = "val_primary/surface_pressure_mae"
+    else:
+        val_primary_key = f"val_primary/{bundle.spec.default_metric}"
+    best_val_metric = float("inf")
     best_val_primary_metric: float | None = None
     best_val_metrics: dict[str, float] = {}
-    best_model_state: dict[str, torch.Tensor] | None = None
-    best_anp_state: dict[str, torch.Tensor] | None = None
-
-    best_val_metric = float("inf")
-    best_epoch = 0
+    best_epoch: int = 0
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
     best_ema_shadow: dict[str, torch.Tensor] | None = None
@@ -1662,8 +1703,36 @@ def main() -> None:
             tags=[config.dataset, config.model],
         )
 
+    if config.load_checkpoint:
+        ckpt = torch.load(config.load_checkpoint, map_location=device, weights_only=True)
+        state = ckpt.get("model_state_dict", ckpt)
+        model.load_state_dict(state, strict=False)
+        print(f"[LoadCheckpoint] Loaded from {config.load_checkpoint}")
+        for phase, loaders in [("val", val_loaders), ("test", test_loaders)]:
+            if not loaders:
+                continue
+            metrics = evaluate_phase_metrics(
+                bundle=bundle, config=config, forward_model=forward_model,
+                anp_head=anp_head, loaders=loaders, transform=transform,
+                metric_transform=metric_transform, device=device, phase=phase,
+            )
+            print(json.dumps({f"load_checkpoint_{phase}": metrics}, sort_keys=True), flush=True)
+            if run is not None:
+                wandb.log(metrics)
+                run.summary.update(metrics)
+        if run is not None:
+            wandb.finish()
+        return
+
     start_time = time.monotonic()
     timeout_seconds = None if not timeout_env else float(timeout_env) * 60.0
+    grad_nonfinite_count = 0
+    last_eval_epoch = 0
+    kill_patience, kill_min_delta = 0, 0.0
+    kill_ref_metric, kill_ref_epoch = float("inf"), 0
+    if config.kill_if_no_improvement:
+        _p, _d = config.kill_if_no_improvement.split(":")
+        kill_patience, kill_min_delta = int(_p), float(_d)
 
     for epoch in range(1, config.epochs + 1):
         if timeout_seconds is not None and epoch > 1 and (time.monotonic() - start_time) >= timeout_seconds:
@@ -1684,53 +1753,102 @@ def main() -> None:
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
             volume_loss_weight=config.volume_loss_weight,
+            skip_update_grad_norm=config.skip_update_grad_norm,
         )
 
-        if ema is not None:
-            ema.store(model)
-            ema.copy_to(model)
-        if anp_head is not None and anp_ema is not None:
-            anp_ema.store(anp_head)
-            anp_ema.copy_to(anp_head)
+        grad_nonfinite_count += int(train_metrics.get("grad_nonfinite", 0))
 
-        eval_metrics = evaluate_phase_metrics(
-            bundle=bundle,
-            config=config,
-            forward_model=forward_model,
-            anp_head=anp_head,
-            loaders=val_loaders,
-            transform=transform,
-            metric_transform=metric_transform,
-            device=device,
-            phase="val",
-        )
-
-        current_primary_metric = eval_metrics.get(best_val_primary_metric_name)
-        if current_primary_metric is not None and (
-            best_val_primary_metric is None or current_primary_metric < best_val_primary_metric
-        ):
-            best_epoch = epoch
-            best_val_primary_metric = current_primary_metric
-            best_val_metrics = dict(eval_metrics)
-            best_model_state = snapshot_module_state(model)
-            best_anp_state = snapshot_module_state(anp_head)
-
-        current_val = eval_metrics.get(best_val_primary_metric_name)
-        if current_val is not None and current_val < best_val_metric:
-            best_val_metric = current_val
-            best_epoch = epoch
-            best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
-            if anp_head is not None:
-                best_anp_state = {k: v.cpu().clone() for k, v in anp_head.state_dict().items()}
+        should_eval = (epoch == 1 or epoch % config.eval_interval == 0 or epoch == config.epochs)
+        if should_eval:
             if ema is not None:
-                best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
-            if anp_ema is not None:
-                best_anp_ema_shadow = {k: v.cpu().clone() for k, v in anp_ema.shadow.items()}
+                ema.store(model)
+                ema.copy_to(model)
+            if anp_head is not None and anp_ema is not None:
+                anp_ema.store(anp_head)
+                anp_ema.copy_to(anp_head)
 
-        if ema is not None:
-            ema.restore(model)
-        if anp_head is not None and anp_ema is not None:
-            anp_ema.restore(anp_head)
+            eval_metrics = evaluate_phase_metrics(
+                bundle=bundle,
+                config=config,
+                forward_model=forward_model,
+                anp_head=anp_head,
+                loaders=val_loaders,
+                transform=transform,
+                metric_transform=metric_transform,
+                device=device,
+                phase="val",
+            )
+
+            current_val = eval_metrics.get(val_primary_key)
+            if current_val is not None and current_val < best_val_metric:
+                best_val_metric = current_val
+                best_val_primary_metric = current_val
+                best_val_metrics = dict(eval_metrics)
+                best_epoch = epoch
+                best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
+                best_anp_state = snapshot_module_state(anp_head)
+                if ema is not None:
+                    best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
+                if anp_ema is not None:
+                    best_anp_ema_shadow = {k: v.cpu().clone() for k, v in anp_ema.shadow.items()}
+
+            if current_val is not None and current_val < kill_ref_metric - kill_min_delta:
+                kill_ref_metric = current_val
+                kill_ref_epoch = epoch
+
+            kill_reason = None
+            if config.kill_if_best_val_above and best_val_metric is not None:
+                gate_epoch_str, gate_threshold_str = config.kill_if_best_val_above.split(":")
+                gate_epoch, gate_threshold = int(gate_epoch_str), float(gate_threshold_str)
+                if epoch >= gate_epoch and best_val_metric > gate_threshold:
+                    kill_reason = (
+                        f"best_val {best_val_metric:.4f} exceeded kill gate {gate_threshold} "
+                        f"after epoch {gate_epoch}"
+                    )
+            if kill_reason is None and config.kill_if_no_improvement:
+                if epoch - kill_ref_epoch >= kill_patience:
+                    kill_reason = (
+                        f"no significant improvement (>{kill_min_delta}) for "
+                        f"{epoch - kill_ref_epoch} epochs (patience={kill_patience})"
+                    )
+            if kill_reason is None and config.kill_if_grad_nonfinite_steps > 0:
+                if grad_nonfinite_count >= config.kill_if_grad_nonfinite_steps:
+                    kill_reason = (
+                        f"grad nonfinite for {grad_nonfinite_count} cumulative steps "
+                        f"(threshold={config.kill_if_grad_nonfinite_steps})"
+                    )
+
+            if ema is not None:
+                ema.restore(model)
+            if anp_head is not None and anp_ema is not None:
+                anp_ema.restore(anp_head)
+
+            if kill_reason is not None:
+                wandb_info = f"group={config.wandb_group or 'none'} name={config.wandb_name or 'none'}"
+                kill_msg = (
+                    f"EXPERIMENT_KILLED: dataset={config.dataset} {wandb_info} "
+                    f"epoch={epoch} best_val={best_val_metric:.4f} "
+                    f"best_epoch={best_epoch} reason={kill_reason}"
+                )
+                epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
+                epoch_metrics["best_val_metric"] = best_val_metric
+                epoch_metrics["best_epoch"] = float(best_epoch)
+                epoch_metrics["kill_reason"] = kill_reason
+                history.append(epoch_metrics)
+                if run is not None:
+                    wandb.log(epoch_metrics, step=epoch)
+                    run.summary["kill_reason"] = kill_reason
+                    run.summary["kill_epoch"] = epoch
+                    run.finish()
+                kill_output_dir = Path(config.output_dir)
+                kill_output_dir.mkdir(parents=True, exist_ok=True)
+                (kill_output_dir / "KILLED.md").write_text(kill_msg + "\n")
+                print(kill_msg, file=sys.stderr, flush=True)
+                raise RuntimeError(kill_msg)
+
+            last_eval_epoch = epoch
+        else:
+            eval_metrics = {}
 
         epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
         epoch_metrics["best_val_metric"] = best_val_metric
@@ -1742,6 +1860,42 @@ def main() -> None:
             run.summary["best_epoch"] = best_epoch
             run.summary["best_val_metric"] = best_val_metric
         print(json.dumps(epoch_metrics, sort_keys=True), flush=True)
+
+    if config.eval_interval > 1 and history and last_eval_epoch < int(history[-1]["epoch"]):
+        final_trained_epoch = int(history[-1]["epoch"])
+        if ema is not None:
+            ema.store(model)
+            ema.copy_to(model)
+        if anp_head is not None and anp_ema is not None:
+            anp_ema.store(anp_head)
+            anp_ema.copy_to(anp_head)
+        eval_metrics = evaluate_phase_metrics(
+            bundle=bundle, config=config, forward_model=forward_model,
+            anp_head=anp_head, loaders=val_loaders, transform=transform,
+            metric_transform=metric_transform, device=device, phase="val",
+        )
+        current_val = eval_metrics.get(val_primary_key)
+        if current_val is not None and current_val < best_val_metric:
+            best_val_metric = current_val
+            best_val_primary_metric = current_val
+            best_val_metrics = dict(eval_metrics)
+            best_epoch = final_trained_epoch
+            best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
+            best_anp_state = snapshot_module_state(anp_head)
+            if ema is not None:
+                best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
+            if anp_ema is not None:
+                best_anp_ema_shadow = {k: v.cpu().clone() for k, v in anp_ema.shadow.items()}
+        if ema is not None:
+            ema.restore(model)
+        if anp_head is not None and anp_ema is not None:
+            anp_ema.restore(anp_head)
+        final_eval_log = {"epoch": float(final_trained_epoch), **eval_metrics,
+                          "best_val_metric": best_val_metric, "best_epoch": float(best_epoch)}
+        history[-1].update(eval_metrics)
+        if run is not None:
+            wandb.log(final_eval_log, step=final_trained_epoch)
+        print(json.dumps({"final_epoch_eval": final_eval_log}, sort_keys=True), flush=True)
 
     if best_epoch is not None:
         print(
@@ -1857,15 +2011,36 @@ def main() -> None:
             torch.save(terminal_model_state, output_dir / f"{config.dataset}_{config.model}.pt")
         else:
             torch.save(model.state_dict(), output_dir / f"{config.dataset}_{config.model}.pt")
+        best_ckpt_path = output_dir / f"{config.dataset}_{config.model}_best.pt"
         if best_model_state is not None:
-            torch.save(best_model_state, output_dir / f"{config.dataset}_{config.model}_best.pt")
+            ckpt_payload = {
+                "model_state_dict": best_model_state,
+                "epoch": best_epoch,
+                "val_metric": best_val_metric,
+                "val_primary_metric_name": best_val_primary_metric_name,
+                "val_primary_metric": best_val_primary_metric,
+                "config": {k: v for k, v in vars(config).items() if not k.startswith("_")},
+            }
+            if best_anp_state is not None:
+                ckpt_payload["anp_state_dict"] = best_anp_state
+            if best_ema_shadow is not None:
+                ckpt_payload["ema_shadow"] = best_ema_shadow
+            if best_anp_ema_shadow is not None:
+                ckpt_payload["anp_ema_shadow"] = best_anp_ema_shadow
+            torch.save(ckpt_payload, best_ckpt_path)
+            print(f"[SaveCheckpoint] Best model saved to {best_ckpt_path} (epoch={best_epoch}, val={best_val_metric:.6f})")
+            if run is not None:
+                artifact = wandb.Artifact(
+                    f"best-checkpoint-{config.dataset}", type="model",
+                    metadata={"epoch": best_epoch, "val_metric": best_val_metric},
+                )
+                artifact.add_file(str(best_ckpt_path))
+                run.log_artifact(artifact)
         if anp_head is not None:
             if terminal_anp_state is not None:
                 torch.save(terminal_anp_state, output_dir / f"{config.dataset}_{config.model}_anp.pt")
             else:
                 torch.save(anp_head.state_dict(), output_dir / f"{config.dataset}_{config.model}_anp.pt")
-            if best_anp_state is not None:
-                torch.save(best_anp_state, output_dir / f"{config.dataset}_{config.model}_anp_best.pt")
     if run is not None:
         run.finish()
 

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -10,7 +10,6 @@ import json
 import math
 import os
 import random
-import sys
 import time
 from contextlib import nullcontext
 from dataclasses import asdict, dataclass
@@ -31,7 +30,7 @@ from core.features import (
     compute_vortex_panel_velocity,
     compute_wake_deficit_features,
 )
-from core.optim import EMA as FixedEMA, Lion, Lookahead
+from core.optim import Lion, Lookahead
 
 
 class EMAWithWarmup:
@@ -169,14 +168,6 @@ class TrainConfig:
     grad_accum_steps: int = 1
     volume_loss_weight: float = 1.0
     save_checkpoint: bool = False
-    load_checkpoint: str = ""
-    eval_interval: int = 1
-    skip_update_grad_norm: float = 0.0
-    ema_mode: str = "warmup"
-    ema_start_step: int = 50
-    kill_if_best_val_above: str = ""
-    kill_if_no_improvement: str = ""
-    kill_if_grad_nonfinite_steps: int = 0
     seed: int = 0
 
 
@@ -498,12 +489,6 @@ def build_bundle(config: TrainConfig) -> DatasetBundle:
 
 def cp_panel_prior_index(config: TrainConfig, bundle: DatasetBundle) -> int | None:
     if not config.enable_cp_panel or not config.enable_pressure_prior_addition:
-        return None
-    # Only tandemfoilset and airfrans bundles actually include cp_panel features
-    # in their tensors.  Other datasets (tandemfoilset_paper, drivaerml) silently
-    # ignore the enable_cp_panel flag, so computing an index would point to a
-    # wrong column (e.g. a Fourier feature) and cause numeric overflow.
-    if bundle.spec.name not in {"tandemfoilset", "airfrans"}:
         return None
     base_dim = bundle.spec.surface_input_dim
     if config.enable_vortex_panel_velocity:
@@ -1286,7 +1271,6 @@ def train_one_epoch(
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
     volume_loss_weight: float = 1.0,
-    skip_update_grad_norm: float = 0.0,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1355,32 +1339,18 @@ def train_one_epoch(
         if anp_head is not None:
             all_params += list(anp_head.parameters())
         grad_norm = torch.nn.utils.clip_grad_norm_(all_params, max_norm=grad_clip if grad_clip > 0 else float("inf"))
-        grad_norm_val = float(grad_norm)
         running.setdefault("grad_norm_mean", 0.0)
-        running["grad_norm_mean"] += grad_norm_val
-        if grad_clip > 0 and grad_norm_val > grad_clip:
+        running["grad_norm_mean"] += float(grad_norm)
+        if grad_clip > 0 and float(grad_norm) > grad_clip:
             running.setdefault("grad_clip_events", 0.0)
             running["grad_clip_events"] += 1.0
-        if not math.isfinite(grad_norm_val):
-            running.setdefault("grad_nonfinite", 0.0)
-            running["grad_nonfinite"] += 1.0
-        skip_step = skip_update_grad_norm > 0 and (not math.isfinite(grad_norm_val) or grad_norm_val > skip_update_grad_norm)
-        if skip_step:
-            optimizer.zero_grad(set_to_none=True)
-            running.setdefault("skipped_updates", 0.0)
-            running["skipped_updates"] += 1.0
-        else:
-            optimizer.step()
+        optimizer.step()
         if scheduler is not None:
             scheduler.step()
-        if ema is not None and not skip_step:
-            ema.update(model)
         if ema is not None:
-            if isinstance(ema, FixedEMA):
-                running["ema_decay_actual"] = ema.decay if ema.step_counter >= ema.start_step else 0.0
-            else:
-                running["ema_decay_actual"] = min(ema.decay, (1 + ema.step_counter) / (10 + ema.step_counter))
-        if anp_head is not None and anp_ema is not None and not skip_step:
+            ema.update(model)
+            running["ema_decay_actual"] = min(ema.decay, (1 + ema.step_counter) / (10 + ema.step_counter))
+        if anp_head is not None and anp_ema is not None:
             anp_ema.update(anp_head)
         running["loss"] += accum_loss / micro_count
         micro_batches_total += micro_count
@@ -1662,29 +1632,18 @@ def main() -> None:
         base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
         scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
 
-    if not config.use_ema:
-        ema = None
-    elif config.ema_mode == "fixed":
-        ema = FixedEMA(model, decay=config.ema_decay, start_step=config.ema_start_step)
-    else:
-        ema = EMAWithWarmup(model, decay=config.ema_decay)
-    if not config.use_ema or anp_head is None:
-        anp_ema = None
-    elif config.ema_mode == "fixed":
-        anp_ema = FixedEMA(anp_head, decay=config.ema_decay, start_step=config.ema_start_step)
-    else:
-        anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay)
+    ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
+    anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
     history: list[dict[str, float]] = []
     best_epoch: int | None = None
     best_val_primary_metric_name = primary_metric_key(bundle, phase="val")
-    if bundle.spec.name == "tandemfoilset":
-        val_primary_key = "val_primary/surface_pressure_mae"
-    else:
-        val_primary_key = f"val_primary/{bundle.spec.default_metric}"
-    best_val_metric = float("inf")
     best_val_primary_metric: float | None = None
     best_val_metrics: dict[str, float] = {}
-    best_epoch: int = 0
+    best_model_state: dict[str, torch.Tensor] | None = None
+    best_anp_state: dict[str, torch.Tensor] | None = None
+
+    best_val_metric = float("inf")
+    best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
     best_ema_shadow: dict[str, torch.Tensor] | None = None
@@ -1703,36 +1662,8 @@ def main() -> None:
             tags=[config.dataset, config.model],
         )
 
-    if config.load_checkpoint:
-        ckpt = torch.load(config.load_checkpoint, map_location=device, weights_only=True)
-        state = ckpt.get("model_state_dict", ckpt)
-        model.load_state_dict(state, strict=False)
-        print(f"[LoadCheckpoint] Loaded from {config.load_checkpoint}")
-        for phase, loaders in [("val", val_loaders), ("test", test_loaders)]:
-            if not loaders:
-                continue
-            metrics = evaluate_phase_metrics(
-                bundle=bundle, config=config, forward_model=forward_model,
-                anp_head=anp_head, loaders=loaders, transform=transform,
-                metric_transform=metric_transform, device=device, phase=phase,
-            )
-            print(json.dumps({f"load_checkpoint_{phase}": metrics}, sort_keys=True), flush=True)
-            if run is not None:
-                wandb.log(metrics)
-                run.summary.update(metrics)
-        if run is not None:
-            wandb.finish()
-        return
-
     start_time = time.monotonic()
     timeout_seconds = None if not timeout_env else float(timeout_env) * 60.0
-    grad_nonfinite_count = 0
-    last_eval_epoch = 0
-    kill_patience, kill_min_delta = 0, 0.0
-    kill_ref_metric, kill_ref_epoch = float("inf"), 0
-    if config.kill_if_no_improvement:
-        _p, _d = config.kill_if_no_improvement.split(":")
-        kill_patience, kill_min_delta = int(_p), float(_d)
 
     for epoch in range(1, config.epochs + 1):
         if timeout_seconds is not None and epoch > 1 and (time.monotonic() - start_time) >= timeout_seconds:
@@ -1753,102 +1684,53 @@ def main() -> None:
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
             volume_loss_weight=config.volume_loss_weight,
-            skip_update_grad_norm=config.skip_update_grad_norm,
         )
 
-        grad_nonfinite_count += int(train_metrics.get("grad_nonfinite", 0))
+        if ema is not None:
+            ema.store(model)
+            ema.copy_to(model)
+        if anp_head is not None and anp_ema is not None:
+            anp_ema.store(anp_head)
+            anp_ema.copy_to(anp_head)
 
-        should_eval = (epoch == 1 or epoch % config.eval_interval == 0 or epoch == config.epochs)
-        if should_eval:
+        eval_metrics = evaluate_phase_metrics(
+            bundle=bundle,
+            config=config,
+            forward_model=forward_model,
+            anp_head=anp_head,
+            loaders=val_loaders,
+            transform=transform,
+            metric_transform=metric_transform,
+            device=device,
+            phase="val",
+        )
+
+        current_primary_metric = eval_metrics.get(best_val_primary_metric_name)
+        if current_primary_metric is not None and (
+            best_val_primary_metric is None or current_primary_metric < best_val_primary_metric
+        ):
+            best_epoch = epoch
+            best_val_primary_metric = current_primary_metric
+            best_val_metrics = dict(eval_metrics)
+            best_model_state = snapshot_module_state(model)
+            best_anp_state = snapshot_module_state(anp_head)
+
+        current_val = eval_metrics.get(best_val_primary_metric_name)
+        if current_val is not None and current_val < best_val_metric:
+            best_val_metric = current_val
+            best_epoch = epoch
+            best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
+            if anp_head is not None:
+                best_anp_state = {k: v.cpu().clone() for k, v in anp_head.state_dict().items()}
             if ema is not None:
-                ema.store(model)
-                ema.copy_to(model)
-            if anp_head is not None and anp_ema is not None:
-                anp_ema.store(anp_head)
-                anp_ema.copy_to(anp_head)
+                best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
+            if anp_ema is not None:
+                best_anp_ema_shadow = {k: v.cpu().clone() for k, v in anp_ema.shadow.items()}
 
-            eval_metrics = evaluate_phase_metrics(
-                bundle=bundle,
-                config=config,
-                forward_model=forward_model,
-                anp_head=anp_head,
-                loaders=val_loaders,
-                transform=transform,
-                metric_transform=metric_transform,
-                device=device,
-                phase="val",
-            )
-
-            current_val = eval_metrics.get(val_primary_key)
-            if current_val is not None and current_val < best_val_metric:
-                best_val_metric = current_val
-                best_val_primary_metric = current_val
-                best_val_metrics = dict(eval_metrics)
-                best_epoch = epoch
-                best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
-                best_anp_state = snapshot_module_state(anp_head)
-                if ema is not None:
-                    best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
-                if anp_ema is not None:
-                    best_anp_ema_shadow = {k: v.cpu().clone() for k, v in anp_ema.shadow.items()}
-
-            if current_val is not None and current_val < kill_ref_metric - kill_min_delta:
-                kill_ref_metric = current_val
-                kill_ref_epoch = epoch
-
-            kill_reason = None
-            if config.kill_if_best_val_above and best_val_metric is not None:
-                gate_epoch_str, gate_threshold_str = config.kill_if_best_val_above.split(":")
-                gate_epoch, gate_threshold = int(gate_epoch_str), float(gate_threshold_str)
-                if epoch >= gate_epoch and best_val_metric > gate_threshold:
-                    kill_reason = (
-                        f"best_val {best_val_metric:.4f} exceeded kill gate {gate_threshold} "
-                        f"after epoch {gate_epoch}"
-                    )
-            if kill_reason is None and config.kill_if_no_improvement:
-                if epoch - kill_ref_epoch >= kill_patience:
-                    kill_reason = (
-                        f"no significant improvement (>{kill_min_delta}) for "
-                        f"{epoch - kill_ref_epoch} epochs (patience={kill_patience})"
-                    )
-            if kill_reason is None and config.kill_if_grad_nonfinite_steps > 0:
-                if grad_nonfinite_count >= config.kill_if_grad_nonfinite_steps:
-                    kill_reason = (
-                        f"grad nonfinite for {grad_nonfinite_count} cumulative steps "
-                        f"(threshold={config.kill_if_grad_nonfinite_steps})"
-                    )
-
-            if ema is not None:
-                ema.restore(model)
-            if anp_head is not None and anp_ema is not None:
-                anp_ema.restore(anp_head)
-
-            if kill_reason is not None:
-                wandb_info = f"group={config.wandb_group or 'none'} name={config.wandb_name or 'none'}"
-                kill_msg = (
-                    f"EXPERIMENT_KILLED: dataset={config.dataset} {wandb_info} "
-                    f"epoch={epoch} best_val={best_val_metric:.4f} "
-                    f"best_epoch={best_epoch} reason={kill_reason}"
-                )
-                epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
-                epoch_metrics["best_val_metric"] = best_val_metric
-                epoch_metrics["best_epoch"] = float(best_epoch)
-                epoch_metrics["kill_reason"] = kill_reason
-                history.append(epoch_metrics)
-                if run is not None:
-                    wandb.log(epoch_metrics, step=epoch)
-                    run.summary["kill_reason"] = kill_reason
-                    run.summary["kill_epoch"] = epoch
-                    run.finish()
-                kill_output_dir = Path(config.output_dir)
-                kill_output_dir.mkdir(parents=True, exist_ok=True)
-                (kill_output_dir / "KILLED.md").write_text(kill_msg + "\n")
-                print(kill_msg, file=sys.stderr, flush=True)
-                raise RuntimeError(kill_msg)
-
-            last_eval_epoch = epoch
-        else:
-            eval_metrics = {}
+        if ema is not None:
+            ema.restore(model)
+        if anp_head is not None and anp_ema is not None:
+            anp_ema.restore(anp_head)
 
         epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
         epoch_metrics["best_val_metric"] = best_val_metric
@@ -1860,42 +1742,6 @@ def main() -> None:
             run.summary["best_epoch"] = best_epoch
             run.summary["best_val_metric"] = best_val_metric
         print(json.dumps(epoch_metrics, sort_keys=True), flush=True)
-
-    if config.eval_interval > 1 and history and last_eval_epoch < int(history[-1]["epoch"]):
-        final_trained_epoch = int(history[-1]["epoch"])
-        if ema is not None:
-            ema.store(model)
-            ema.copy_to(model)
-        if anp_head is not None and anp_ema is not None:
-            anp_ema.store(anp_head)
-            anp_ema.copy_to(anp_head)
-        eval_metrics = evaluate_phase_metrics(
-            bundle=bundle, config=config, forward_model=forward_model,
-            anp_head=anp_head, loaders=val_loaders, transform=transform,
-            metric_transform=metric_transform, device=device, phase="val",
-        )
-        current_val = eval_metrics.get(val_primary_key)
-        if current_val is not None and current_val < best_val_metric:
-            best_val_metric = current_val
-            best_val_primary_metric = current_val
-            best_val_metrics = dict(eval_metrics)
-            best_epoch = final_trained_epoch
-            best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
-            best_anp_state = snapshot_module_state(anp_head)
-            if ema is not None:
-                best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
-            if anp_ema is not None:
-                best_anp_ema_shadow = {k: v.cpu().clone() for k, v in anp_ema.shadow.items()}
-        if ema is not None:
-            ema.restore(model)
-        if anp_head is not None and anp_ema is not None:
-            anp_ema.restore(anp_head)
-        final_eval_log = {"epoch": float(final_trained_epoch), **eval_metrics,
-                          "best_val_metric": best_val_metric, "best_epoch": float(best_epoch)}
-        history[-1].update(eval_metrics)
-        if run is not None:
-            wandb.log(final_eval_log, step=final_trained_epoch)
-        print(json.dumps({"final_epoch_eval": final_eval_log}, sort_keys=True), flush=True)
 
     if best_epoch is not None:
         print(
@@ -2011,36 +1857,15 @@ def main() -> None:
             torch.save(terminal_model_state, output_dir / f"{config.dataset}_{config.model}.pt")
         else:
             torch.save(model.state_dict(), output_dir / f"{config.dataset}_{config.model}.pt")
-        best_ckpt_path = output_dir / f"{config.dataset}_{config.model}_best.pt"
         if best_model_state is not None:
-            ckpt_payload = {
-                "model_state_dict": best_model_state,
-                "epoch": best_epoch,
-                "val_metric": best_val_metric,
-                "val_primary_metric_name": best_val_primary_metric_name,
-                "val_primary_metric": best_val_primary_metric,
-                "config": {k: v for k, v in vars(config).items() if not k.startswith("_")},
-            }
-            if best_anp_state is not None:
-                ckpt_payload["anp_state_dict"] = best_anp_state
-            if best_ema_shadow is not None:
-                ckpt_payload["ema_shadow"] = best_ema_shadow
-            if best_anp_ema_shadow is not None:
-                ckpt_payload["anp_ema_shadow"] = best_anp_ema_shadow
-            torch.save(ckpt_payload, best_ckpt_path)
-            print(f"[SaveCheckpoint] Best model saved to {best_ckpt_path} (epoch={best_epoch}, val={best_val_metric:.6f})")
-            if run is not None:
-                artifact = wandb.Artifact(
-                    f"best-checkpoint-{config.dataset}", type="model",
-                    metadata={"epoch": best_epoch, "val_metric": best_val_metric},
-                )
-                artifact.add_file(str(best_ckpt_path))
-                run.log_artifact(artifact)
+            torch.save(best_model_state, output_dir / f"{config.dataset}_{config.model}_best.pt")
         if anp_head is not None:
             if terminal_anp_state is not None:
                 torch.save(terminal_anp_state, output_dir / f"{config.dataset}_{config.model}_anp.pt")
             else:
                 torch.save(anp_head.state_dict(), output_dir / f"{config.dataset}_{config.model}_anp.pt")
+            if best_anp_state is not None:
+                torch.save(best_anp_state, output_dir / f"{config.dataset}_{config.model}_anp_best.pt")
     if run is not None:
         run.finish()
 

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -10,6 +10,7 @@ import json
 import math
 import os
 import random
+import sys
 import time
 from contextlib import nullcontext
 from dataclasses import asdict, dataclass
@@ -30,7 +31,7 @@ from core.features import (
     compute_vortex_panel_velocity,
     compute_wake_deficit_features,
 )
-from core.optim import Lion, Lookahead
+from core.optim import EMA as FixedEMA, Lion, Lookahead
 
 
 class EMAWithWarmup:
@@ -168,6 +169,14 @@ class TrainConfig:
     grad_accum_steps: int = 1
     volume_loss_weight: float = 1.0
     save_checkpoint: bool = False
+    load_checkpoint: str = ""
+    eval_interval: int = 1
+    skip_update_grad_norm: float = 0.0
+    ema_mode: str = "warmup"
+    ema_start_step: int = 50
+    kill_if_best_val_above: str = ""
+    kill_if_no_improvement: str = ""
+    kill_if_grad_nonfinite_steps: int = 0
     seed: int = 0
 
 
@@ -1277,6 +1286,7 @@ def train_one_epoch(
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
     volume_loss_weight: float = 1.0,
+    skip_update_grad_norm: float = 0.0,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1345,18 +1355,32 @@ def train_one_epoch(
         if anp_head is not None:
             all_params += list(anp_head.parameters())
         grad_norm = torch.nn.utils.clip_grad_norm_(all_params, max_norm=grad_clip if grad_clip > 0 else float("inf"))
+        grad_norm_val = float(grad_norm)
         running.setdefault("grad_norm_mean", 0.0)
-        running["grad_norm_mean"] += float(grad_norm)
-        if grad_clip > 0 and float(grad_norm) > grad_clip:
+        running["grad_norm_mean"] += grad_norm_val
+        if grad_clip > 0 and grad_norm_val > grad_clip:
             running.setdefault("grad_clip_events", 0.0)
             running["grad_clip_events"] += 1.0
-        optimizer.step()
+        if not math.isfinite(grad_norm_val):
+            running.setdefault("grad_nonfinite", 0.0)
+            running["grad_nonfinite"] += 1.0
+        skip_step = skip_update_grad_norm > 0 and (not math.isfinite(grad_norm_val) or grad_norm_val > skip_update_grad_norm)
+        if skip_step:
+            optimizer.zero_grad(set_to_none=True)
+            running.setdefault("skipped_updates", 0.0)
+            running["skipped_updates"] += 1.0
+        else:
+            optimizer.step()
         if scheduler is not None:
             scheduler.step()
-        if ema is not None:
+        if ema is not None and not skip_step:
             ema.update(model)
-            running["ema_decay_actual"] = min(ema.decay, (1 + ema.step_counter) / (10 + ema.step_counter))
-        if anp_head is not None and anp_ema is not None:
+        if ema is not None:
+            if isinstance(ema, FixedEMA):
+                running["ema_decay_actual"] = ema.decay if ema.step_counter >= ema.start_step else 0.0
+            else:
+                running["ema_decay_actual"] = min(ema.decay, (1 + ema.step_counter) / (10 + ema.step_counter))
+        if anp_head is not None and anp_ema is not None and not skip_step:
             anp_ema.update(anp_head)
         running["loss"] += accum_loss / micro_count
         micro_batches_total += micro_count
@@ -1638,22 +1662,29 @@ def main() -> None:
         base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
         scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
 
-    ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
-    anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
+    if not config.use_ema:
+        ema = None
+    elif config.ema_mode == "fixed":
+        ema = FixedEMA(model, decay=config.ema_decay, start_step=config.ema_start_step)
+    else:
+        ema = EMAWithWarmup(model, decay=config.ema_decay)
+    if not config.use_ema or anp_head is None:
+        anp_ema = None
+    elif config.ema_mode == "fixed":
+        anp_ema = FixedEMA(anp_head, decay=config.ema_decay, start_step=config.ema_start_step)
+    else:
+        anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay)
     history: list[dict[str, float]] = []
     best_epoch: int | None = None
     best_val_primary_metric_name = primary_metric_key(bundle, phase="val")
-    best_val_primary_metric: float | None = None
-    best_val_metrics: dict[str, float] = {}
-    best_model_state: dict[str, torch.Tensor] | None = None
-    best_anp_state: dict[str, torch.Tensor] | None = None
-
     if bundle.spec.name == "tandemfoilset":
         val_primary_key = "val_primary/surface_pressure_mae"
     else:
         val_primary_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
-    best_epoch = 0
+    best_val_primary_metric: float | None = None
+    best_val_metrics: dict[str, float] = {}
+    best_epoch: int = 0
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
     best_ema_shadow: dict[str, torch.Tensor] | None = None
@@ -1672,8 +1703,36 @@ def main() -> None:
             tags=[config.dataset, config.model],
         )
 
+    if config.load_checkpoint:
+        ckpt = torch.load(config.load_checkpoint, map_location=device, weights_only=True)
+        state = ckpt.get("model_state_dict", ckpt)
+        model.load_state_dict(state, strict=False)
+        print(f"[LoadCheckpoint] Loaded from {config.load_checkpoint}")
+        for phase, loaders in [("val", val_loaders), ("test", test_loaders)]:
+            if not loaders:
+                continue
+            metrics = evaluate_phase_metrics(
+                bundle=bundle, config=config, forward_model=forward_model,
+                anp_head=anp_head, loaders=loaders, transform=transform,
+                metric_transform=metric_transform, device=device, phase=phase,
+            )
+            print(json.dumps({f"load_checkpoint_{phase}": metrics}, sort_keys=True), flush=True)
+            if run is not None:
+                wandb.log(metrics)
+                run.summary.update(metrics)
+        if run is not None:
+            wandb.finish()
+        return
+
     start_time = time.monotonic()
     timeout_seconds = None if not timeout_env else float(timeout_env) * 60.0
+    grad_nonfinite_count = 0
+    last_eval_epoch = 0
+    kill_patience, kill_min_delta = 0, 0.0
+    kill_ref_metric, kill_ref_epoch = float("inf"), 0
+    if config.kill_if_no_improvement:
+        _p, _d = config.kill_if_no_improvement.split(":")
+        kill_patience, kill_min_delta = int(_p), float(_d)
 
     for epoch in range(1, config.epochs + 1):
         if timeout_seconds is not None and epoch > 1 and (time.monotonic() - start_time) >= timeout_seconds:
@@ -1694,53 +1753,102 @@ def main() -> None:
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
             volume_loss_weight=config.volume_loss_weight,
+            skip_update_grad_norm=config.skip_update_grad_norm,
         )
 
-        if ema is not None:
-            ema.store(model)
-            ema.copy_to(model)
-        if anp_head is not None and anp_ema is not None:
-            anp_ema.store(anp_head)
-            anp_ema.copy_to(anp_head)
+        grad_nonfinite_count += int(train_metrics.get("grad_nonfinite", 0))
 
-        eval_metrics = evaluate_phase_metrics(
-            bundle=bundle,
-            config=config,
-            forward_model=forward_model,
-            anp_head=anp_head,
-            loaders=val_loaders,
-            transform=transform,
-            metric_transform=metric_transform,
-            device=device,
-            phase="val",
-        )
-
-        current_primary_metric = eval_metrics.get(best_val_primary_metric_name)
-        if current_primary_metric is not None and (
-            best_val_primary_metric is None or current_primary_metric < best_val_primary_metric
-        ):
-            best_epoch = epoch
-            best_val_primary_metric = current_primary_metric
-            best_val_metrics = dict(eval_metrics)
-            best_model_state = snapshot_module_state(model)
-            best_anp_state = snapshot_module_state(anp_head)
-
-        current_val = eval_metrics.get(val_primary_key)
-        if current_val is not None and current_val < best_val_metric:
-            best_val_metric = current_val
-            best_epoch = epoch
-            best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
-            if anp_head is not None:
-                best_anp_state = {k: v.cpu().clone() for k, v in anp_head.state_dict().items()}
+        should_eval = (epoch == 1 or epoch % config.eval_interval == 0 or epoch == config.epochs)
+        if should_eval:
             if ema is not None:
-                best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
-            if anp_ema is not None:
-                best_anp_ema_shadow = {k: v.cpu().clone() for k, v in anp_ema.shadow.items()}
+                ema.store(model)
+                ema.copy_to(model)
+            if anp_head is not None and anp_ema is not None:
+                anp_ema.store(anp_head)
+                anp_ema.copy_to(anp_head)
 
-        if ema is not None:
-            ema.restore(model)
-        if anp_head is not None and anp_ema is not None:
-            anp_ema.restore(anp_head)
+            eval_metrics = evaluate_phase_metrics(
+                bundle=bundle,
+                config=config,
+                forward_model=forward_model,
+                anp_head=anp_head,
+                loaders=val_loaders,
+                transform=transform,
+                metric_transform=metric_transform,
+                device=device,
+                phase="val",
+            )
+
+            current_val = eval_metrics.get(val_primary_key)
+            if current_val is not None and current_val < best_val_metric:
+                best_val_metric = current_val
+                best_val_primary_metric = current_val
+                best_val_metrics = dict(eval_metrics)
+                best_epoch = epoch
+                best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
+                best_anp_state = snapshot_module_state(anp_head)
+                if ema is not None:
+                    best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
+                if anp_ema is not None:
+                    best_anp_ema_shadow = {k: v.cpu().clone() for k, v in anp_ema.shadow.items()}
+
+            if current_val is not None and current_val < kill_ref_metric - kill_min_delta:
+                kill_ref_metric = current_val
+                kill_ref_epoch = epoch
+
+            kill_reason = None
+            if config.kill_if_best_val_above and best_val_metric is not None:
+                gate_epoch_str, gate_threshold_str = config.kill_if_best_val_above.split(":")
+                gate_epoch, gate_threshold = int(gate_epoch_str), float(gate_threshold_str)
+                if epoch >= gate_epoch and best_val_metric > gate_threshold:
+                    kill_reason = (
+                        f"best_val {best_val_metric:.4f} exceeded kill gate {gate_threshold} "
+                        f"after epoch {gate_epoch}"
+                    )
+            if kill_reason is None and config.kill_if_no_improvement:
+                if epoch - kill_ref_epoch >= kill_patience:
+                    kill_reason = (
+                        f"no significant improvement (>{kill_min_delta}) for "
+                        f"{epoch - kill_ref_epoch} epochs (patience={kill_patience})"
+                    )
+            if kill_reason is None and config.kill_if_grad_nonfinite_steps > 0:
+                if grad_nonfinite_count >= config.kill_if_grad_nonfinite_steps:
+                    kill_reason = (
+                        f"grad nonfinite for {grad_nonfinite_count} cumulative steps "
+                        f"(threshold={config.kill_if_grad_nonfinite_steps})"
+                    )
+
+            if ema is not None:
+                ema.restore(model)
+            if anp_head is not None and anp_ema is not None:
+                anp_ema.restore(anp_head)
+
+            if kill_reason is not None:
+                wandb_info = f"group={config.wandb_group or 'none'} name={config.wandb_name or 'none'}"
+                kill_msg = (
+                    f"EXPERIMENT_KILLED: dataset={config.dataset} {wandb_info} "
+                    f"epoch={epoch} best_val={best_val_metric:.4f} "
+                    f"best_epoch={best_epoch} reason={kill_reason}"
+                )
+                epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
+                epoch_metrics["best_val_metric"] = best_val_metric
+                epoch_metrics["best_epoch"] = float(best_epoch)
+                epoch_metrics["kill_reason"] = kill_reason
+                history.append(epoch_metrics)
+                if run is not None:
+                    wandb.log(epoch_metrics, step=epoch)
+                    run.summary["kill_reason"] = kill_reason
+                    run.summary["kill_epoch"] = epoch
+                    run.finish()
+                kill_output_dir = Path(config.output_dir)
+                kill_output_dir.mkdir(parents=True, exist_ok=True)
+                (kill_output_dir / "KILLED.md").write_text(kill_msg + "\n")
+                print(kill_msg, file=sys.stderr, flush=True)
+                raise RuntimeError(kill_msg)
+
+            last_eval_epoch = epoch
+        else:
+            eval_metrics = {}
 
         epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
         epoch_metrics["best_val_metric"] = best_val_metric
@@ -1752,6 +1860,42 @@ def main() -> None:
             run.summary["best_epoch"] = best_epoch
             run.summary["best_val_metric"] = best_val_metric
         print(json.dumps(epoch_metrics, sort_keys=True), flush=True)
+
+    if config.eval_interval > 1 and history and last_eval_epoch < int(history[-1]["epoch"]):
+        final_trained_epoch = int(history[-1]["epoch"])
+        if ema is not None:
+            ema.store(model)
+            ema.copy_to(model)
+        if anp_head is not None and anp_ema is not None:
+            anp_ema.store(anp_head)
+            anp_ema.copy_to(anp_head)
+        eval_metrics = evaluate_phase_metrics(
+            bundle=bundle, config=config, forward_model=forward_model,
+            anp_head=anp_head, loaders=val_loaders, transform=transform,
+            metric_transform=metric_transform, device=device, phase="val",
+        )
+        current_val = eval_metrics.get(val_primary_key)
+        if current_val is not None and current_val < best_val_metric:
+            best_val_metric = current_val
+            best_val_primary_metric = current_val
+            best_val_metrics = dict(eval_metrics)
+            best_epoch = final_trained_epoch
+            best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
+            best_anp_state = snapshot_module_state(anp_head)
+            if ema is not None:
+                best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
+            if anp_ema is not None:
+                best_anp_ema_shadow = {k: v.cpu().clone() for k, v in anp_ema.shadow.items()}
+        if ema is not None:
+            ema.restore(model)
+        if anp_head is not None and anp_ema is not None:
+            anp_ema.restore(anp_head)
+        final_eval_log = {"epoch": float(final_trained_epoch), **eval_metrics,
+                          "best_val_metric": best_val_metric, "best_epoch": float(best_epoch)}
+        history[-1].update(eval_metrics)
+        if run is not None:
+            wandb.log(final_eval_log, step=final_trained_epoch)
+        print(json.dumps({"final_epoch_eval": final_eval_log}, sort_keys=True), flush=True)
 
     if best_epoch is not None:
         print(
@@ -1867,15 +2011,36 @@ def main() -> None:
             torch.save(terminal_model_state, output_dir / f"{config.dataset}_{config.model}.pt")
         else:
             torch.save(model.state_dict(), output_dir / f"{config.dataset}_{config.model}.pt")
+        best_ckpt_path = output_dir / f"{config.dataset}_{config.model}_best.pt"
         if best_model_state is not None:
-            torch.save(best_model_state, output_dir / f"{config.dataset}_{config.model}_best.pt")
+            ckpt_payload = {
+                "model_state_dict": best_model_state,
+                "epoch": best_epoch,
+                "val_metric": best_val_metric,
+                "val_primary_metric_name": best_val_primary_metric_name,
+                "val_primary_metric": best_val_primary_metric,
+                "config": {k: v for k, v in vars(config).items() if not k.startswith("_")},
+            }
+            if best_anp_state is not None:
+                ckpt_payload["anp_state_dict"] = best_anp_state
+            if best_ema_shadow is not None:
+                ckpt_payload["ema_shadow"] = best_ema_shadow
+            if best_anp_ema_shadow is not None:
+                ckpt_payload["anp_ema_shadow"] = best_anp_ema_shadow
+            torch.save(ckpt_payload, best_ckpt_path)
+            print(f"[SaveCheckpoint] Best model saved to {best_ckpt_path} (epoch={best_epoch}, val={best_val_metric:.6f})")
+            if run is not None:
+                artifact = wandb.Artifact(
+                    f"best-checkpoint-{config.dataset}", type="model",
+                    metadata={"epoch": best_epoch, "val_metric": best_val_metric},
+                )
+                artifact.add_file(str(best_ckpt_path))
+                run.log_artifact(artifact)
         if anp_head is not None:
             if terminal_anp_state is not None:
                 torch.save(terminal_anp_state, output_dir / f"{config.dataset}_{config.model}_anp.pt")
             else:
                 torch.save(anp_head.state_dict(), output_dir / f"{config.dataset}_{config.model}_anp.pt")
-            if best_anp_state is not None:
-                torch.save(best_anp_state, output_dir / f"{config.dataset}_{config.model}_anp_best.pt")
     if run is not None:
         run.finish()
 

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1643,9 +1643,9 @@ def main() -> None:
     best_anp_state: dict[str, torch.Tensor] | None = None
 
     if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
+        val_primary_key = "val_primary/surface_pressure_mae"
     else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+        val_primary_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1719,7 +1719,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(val_primary_key)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -490,6 +490,12 @@ def build_bundle(config: TrainConfig) -> DatasetBundle:
 def cp_panel_prior_index(config: TrainConfig, bundle: DatasetBundle) -> int | None:
     if not config.enable_cp_panel or not config.enable_pressure_prior_addition:
         return None
+    # Only tandemfoilset and airfrans bundles actually include cp_panel features
+    # in their tensors.  Other datasets (tandemfoilset_paper, drivaerml) silently
+    # ignore the enable_cp_panel flag, so computing an index would point to a
+    # wrong column (e.g. a Fourier feature) and cause numeric overflow.
+    if bundle.spec.name not in {"tandemfoilset", "airfrans"}:
+        return None
     base_dim = bundle.spec.surface_input_dim
     if config.enable_vortex_panel_velocity:
         base_dim -= 4


### PR DESCRIPTION
## Hypothesis

The DrivAerML LR optimum under the EMA+gc champion config (EMA=0.9995, gc=0.5) may be **above** 5e-4, not at it. Evidence from PR #3158 shows a steep, monotonic degradation *below* lr=5e-4:

- lr=4.5e-4: +7.9% worse than baseline
- lr=4e-4: +54.5% worse than baseline

This asymmetric LR basin strongly suggests the loss landscape has more headroom above 5e-4 that has never been probed. The grad-clip at 0.5 may be providing enough stability to tolerate a modestly higher peak LR.

## Instructions

Run two full trials under the champion config, changing only `--lr`:

**Trial 1 — lr=5.5e-4 (conservative upward step — run this first)**

Start with a 3-epoch smoke test. Report `val_primary/surface_rel_l2_pct` after epoch 3. Target: beat 3.833% (baseline) or be meaningfully on track. If the smoke test looks healthy, let it run to convergence (epochs=999, SENPAI_MAX_EPOCHS=9999).

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5.5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --wandb_group dm-higher-lr
```

**Trial 2 — lr=6e-4 (aggressive upward step)**

Run Trial 2 in parallel (or immediately after Trial 1's smoke test passes). Do NOT wait for Trial 1 to fully converge before starting Trial 2.

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 6e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --wandb_group dm-higher-lr
```

**Stop early if:** either run diverges (val loss spikes >2x baseline by epoch 5). Report best `val_primary/surface_rel_l2_pct` for each trial at convergence.

## Baseline

Current best metrics (DrivAerML, PR #3072 — eren/dm-ema-9995-gc05):
- **val_primary/surface_rel_l2_pct: 3.833%** (epoch 511)
- test surface_rel_l2_pct: 4.685%
- Baseline W&B run: `ncl1dh88` (eren/dm-ema-9995-gc05)
- External target: <3.71% (AB-UPT, gap = 0.123 pp, 1.03x)

Reproduce baseline:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --grad-clip 0.5 --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 --ema-decay 0.9995
```