### PR TITLE
AirfRANS: Re-stratified sampling for Reynolds number OOD robustness

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -454,6 +454,29 @@ def parse_args() -> TrainConfig:
     return TrainConfig(**vars(namespace))
 
 
+def _compute_airfrans_re_stratified_weights(bundle: DatasetBundle, n_bins: int = 10) -> torch.Tensor:
+    """Compute inverse-frequency weights binned by freestream velocity (Re proxy)."""
+    case_ids = bundle.train_dataset.base.case_ids
+    velocities = []
+    for cid in case_ids:
+        parts = cid.split("_")
+        try:
+            velocities.append(float(parts[2]))
+        except (IndexError, ValueError):
+            velocities.append(0.0)
+    v_min, v_max = min(velocities), max(velocities)
+    bin_width = (v_max - v_min + 1e-6) / n_bins
+    bin_indices = [int((v - v_min) / bin_width) for v in velocities]
+    bin_indices = [min(b, n_bins - 1) for b in bin_indices]
+    from collections import Counter
+    bin_counts = Counter(bin_indices)
+    weights = torch.tensor(
+        [1.0 / bin_counts[b] for b in bin_indices],
+        dtype=torch.float32,
+    )
+    return weights
+
+
 def build_bundle(config: TrainConfig) -> DatasetBundle:
     bundle_kwargs = {
         "dataset_name": config.dataset,
@@ -1577,6 +1600,8 @@ def main() -> None:
         _ds.TandemFoilCaseDataset.__init__ = _patched_init
 
     bundle = build_bundle(config)
+    if config.re_stratified_sampling and bundle.spec.name == "airfrans":
+        bundle.sample_weights = _compute_airfrans_re_stratified_weights(bundle)
     resolved_num_workers = resolve_num_workers(config, bundle.spec.name)
     if bundle.spec.name == "tandemfoilset":
         phys_stats = compute_tandem_phys_stats(
@@ -1635,17 +1660,10 @@ def main() -> None:
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
     history: list[dict[str, float]] = []
-    best_epoch: int | None = None
     best_val_primary_metric_name = primary_metric_key(bundle, phase="val")
     best_val_primary_metric: float | None = None
     best_val_metrics: dict[str, float] = {}
-    best_model_state: dict[str, torch.Tensor] | None = None
-    best_anp_state: dict[str, torch.Tensor] | None = None
-
-    if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
-    else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+    val_primary_key = best_val_primary_metric_name
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1719,7 +1737,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(val_primary_key)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

Re-stratified sampling (--re-stratified-sampling) ensures balanced Reynolds number (Re) representation across training batches. AirfRANS spans a wide Re range and random mini-batch sampling can under-represent low/high-Re regimes, biasing the model toward the mean-Re distribution. By ensuring each batch covers the Re spectrum uniformly, we expect improved OOD robustness — particularly on the scarce/extreme-Re validation cases that drive surface_mse.

This flag comes from the noam branch stack, but has never been tested in isolation on AF. Multiple in-flight PRs (#3184 wolfwood, #3187 stark, #3191 alphonse, #3177 nezuko) all test aspects of the noam stack bundled together. This PR isolates re-stratified sampling alone to determine its individual contribution.

## Instructions

Run two trials sequentially. Start with a 3-epoch smoke test on Trial 1 to verify training is stable, then report val_primary/surface_mse and val_primary/vol_mse.

**Trial 1 — Re-stratified on AF base champion (no vol-weight):**
```bash
cd target/icml2026 && python train.py \
  --dataset airfrans \
  --optimizer adamw \
  --lr 6e-4 \
  --cosine-t-max 50 \
  --grad-clip 1.0 \
  --weight-decay 1e-2 \
  --enable-fourier \
  --model-layers 2 \
  --model-hidden-dim 256 \
  --model-heads 8 \
  --epochs 999 \
  --ema-decay 0.999 \
  --re-stratified-sampling \
  --wandb_group af-re-stratified
```

**Trial 2 — Re-stratified on AF vol-weight=10x champion:**
```bash
cd target/icml2026 && python train.py \
  --dataset airfrans \
  --optimizer adamw \
  --lr 6e-4 \
  --cosine-t-max 50 \
  --grad-clip 1.0 \
  --weight-decay 1e-2 \
  --enable-fourier \
  --model-layers 2 \
  --model-hidden-dim 256 \
  --model-heads 8 \
  --epochs 999 \
  --ema-decay 0.999 \
  --re-stratified-sampling \
  --vol-loss-weight 10.0 \
  --wandb_group af-re-stratified
```

Note: --model-heads 8 (vs baseline --model-heads 4). If --model-heads 8 is not supported or causes issues, revert to --model-heads 4 to match the exact baseline config.

**Smoke test:** Run Trial 1 for 3 epochs first. Confirm training is stable (no NaN loss) then proceed to full runs.

## Baseline

- **val_primary/surface_mse:** 0.000296 (epoch 704) — beat this
- **val_primary/vol_mse:** 0.002039 (epoch 743) — beat this
- **Best PR:** #3135 (nezuko — EMA=0.999 + vol-weight=10x, 2L/256d/4H, AdamW lr=6e-4, T_max=50, gc=1.0, WD=1e-2, Fourier)
- **W&B run:** sh2zyfwr (nezuko/af-ema-vol-weight-10x)
- **Reproduce baseline:** cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --ema-decay 0.999 --vol-loss-weight 10.0

## Expected outcome

Re-stratified sampling may improve OOD generalization across Re regimes. Possible outcomes:
- Improves surface_mse (primary win): Re-balanced batches reduce overfitting to mean-Re cases
- Improves vol_mse (secondary win): Reynolds-aware sampling may regularize volume predictions too
- No effect or regression: If the model already generalizes well across Re, the rebalancing may hurt by under-sampling the dominant regime

Report best val_primary/surface_mse and val_primary/vol_mse for each trial, and the epoch each best was achieved.