### PR TITLE
TandemFoil: EMA decay sweep — 0.9999 and 0.99995 vs champion 0.999

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1635,18 +1635,14 @@ def main() -> None:
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
     history: list[dict[str, float]] = []
-    best_epoch: int | None = None
-    best_val_primary_metric_name = primary_metric_key(bundle, phase="val")
+    if bundle.spec.name == "tandemfoilset":
+        val_primary_key = "val_primary/surface_pressure_mae"
+    else:
+        val_primary_key = f"val_primary/{bundle.spec.default_metric}"
+    best_val_primary_metric_name = val_primary_key
+    best_val_metric = float("inf")
     best_val_primary_metric: float | None = None
     best_val_metrics: dict[str, float] = {}
-    best_model_state: dict[str, torch.Tensor] | None = None
-    best_anp_state: dict[str, torch.Tensor] | None = None
-
-    if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
-    else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
-    best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
@@ -1709,23 +1705,14 @@ def main() -> None:
             phase="val",
         )
 
-        current_primary_metric = eval_metrics.get(best_val_primary_metric_name)
-        if current_primary_metric is not None and (
-            best_val_primary_metric is None or current_primary_metric < best_val_primary_metric
-        ):
-            best_epoch = epoch
-            best_val_primary_metric = current_primary_metric
-            best_val_metrics = dict(eval_metrics)
-            best_model_state = snapshot_module_state(model)
-            best_anp_state = snapshot_module_state(anp_head)
-
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(val_primary_key)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
+            best_val_primary_metric = current_val
+            best_val_metrics = dict(eval_metrics)
             best_epoch = epoch
-            best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
-            if anp_head is not None:
-                best_anp_state = {k: v.cpu().clone() for k, v in anp_head.state_dict().items()}
+            best_model_state = snapshot_module_state(model)
+            best_anp_state = snapshot_module_state(anp_head)
             if ema is not None:
                 best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
             if anp_ema is not None:


### PR DESCRIPTION
## Hypothesis

The TandemFoil champion (PR #3140) uses EMA=0.999. The noam branch default is 0.9999. On AirfRANS, higher EMA (0.9995/0.9999) was monotonically worse — but TandemFoil trains with Lion + cosine T_max=10 cycling, which creates very different weight-update dynamics. A higher EMA decay may provide better smoothing of the Lion optimizer's noisier trajectory and improve the final EMA checkpoint quality on TF.

We test two values above the champion:
- **Trial 1:** EMA=0.9999 (noam default)
- **Trial 2:** EMA=0.99995 (midpoint between champion and noam default)

Both trials use gc=0.3 (the safe champion guard — gc=0.2 showed marginal gain in #3140 but gc=0.3 is the reference). AirfRANS results do not apply here because Lion + cosine T_max=10 cycle dynamics are fundamentally different from AdamW.

## Instructions

**Step 0 — Smoke test (3 epochs) before full run:**

Run Trial 1 for 3 epochs only and report `val_primary/surface_pressure_mae`. This validates the config is working before committing to a full run. Do not proceed to full runs until the smoke test confirms the run is healthy.

**Trial 1 — EMA=0.9999 (full run after smoke test passes):**

```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil \
  --optimizer lion \
  --lr 1.25e-4 \
  --cosine-t-max 10 \
  --grad-clip 0.3 \
  --weight-decay 1e-2 \
  --enable-fourier \
  --model-layers 3 \
  --model-hidden-dim 192 \
  --model-heads 3 \
  --epochs 999 \
  --ema-decay 0.9999 \
  --wandb_group tf-ema-decay
```

**Trial 2 — EMA=0.99995 (run in parallel with or after Trial 1):**

```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil \
  --optimizer lion \
  --lr 1.25e-4 \
  --cosine-t-max 10 \
  --grad-clip 0.3 \
  --weight-decay 1e-2 \
  --enable-fourier \
  --model-layers 3 \
  --model-hidden-dim 192 \
  --model-heads 3 \
  --epochs 999 \
  --ema-decay 0.99995 \
  --wandb_group tf-ema-decay
```

**Report for each trial:**
- W&B run ID and link
- Best `val_primary/surface_pressure_mae` and at which epoch
- `test_primary/surface_pressure_mae` from best val checkpoint
- Any training instability or divergence observed

**Target:** Beat `val_primary/surface_pressure_mae` < 21.350

## Baseline

Current TandemFoil best (PR #3140):
- `val_primary/surface_pressure_mae`: **21.350** at epoch 331
- `test_primary/surface_pressure_mae`: 23.195
- Config: Lion lr=1.25e-4, T_max=10, gc=0.2, WD=1e-2, EMA=0.999, 3L/192d, Fourier+physics
- W&B run: `9g11l7tm` (usopp/tf-gc-02-sweep)
- Reproduce:
```bash
cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.2 --weight-decay 1e-2 --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --ema-decay 0.999
```

Previous gc=0.3 champion for reference (PR #3108): `val_primary/surface_pressure_mae` = 21.909, W&B run `kzg626hf` (zenitsu/tf-gc03-ema999).