### PR TITLE
TF: residual-prediction in isolation (gc=0.3 ablation)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1643,9 +1643,9 @@ def main() -> None:
     best_anp_state: dict[str, torch.Tensor] | None = None
 
     if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
+        _primary_metric_str = "val_primary/surface_pressure_mae"
     else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+        _primary_metric_str = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1719,7 +1719,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(_primary_metric_str)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

The current TF champion (PR #3140) uses `--residual-prediction` as part of a full physics stack (asinh-pressure, TE coord frame, Cp panel, pressure-prior-addition). No experiment has yet tested `--residual-prediction` **alone** — stripped of all other physics flags. This is the missing noam ablation.

If residual-prediction alone can beat the baseline (val=21.350), it simplifies the stack and confirms it as a standalone driver of improvement. If it requires the compound physics stack, that tells us something important about feature interactions.

In-flight experiments do **not** cover this gap: chopper=#3180 (ANP), fern=#3185 (full noam stack), norman=#3186 (T_max=150), emma=#3189 (asinh+physics). This is a clean single-variable ablation.

## Instructions

**Please run a 3-epoch smoke test of Trial 1 first. Report `val_primary/surface_pressure_mae` before continuing.**

### Trial 1 — Residual-prediction alone (smoke test first, then full run)

**Step 1: 3-epoch smoke test**
```bash
cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.3 --weight-decay 1e-2 --enable-fourier --model-layers 3 --model-hidden-dim 192 --model-heads 3 --epochs 3 --ema-decay 0.999 --residual-prediction --wandb_group tf-residual-pred
```

Report `val_primary/surface_pressure_mae` from the smoke test. If the 3-epoch val loss is in a reasonable range (not diverging), proceed to Step 2.

**Step 2: Full Trial 1 run (999 epochs)**
```bash
cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.3 --weight-decay 1e-2 --enable-fourier --model-layers 3 --model-hidden-dim 192 --model-heads 3 --epochs 999 --ema-decay 0.999 --residual-prediction --wandb_group tf-residual-pred
```

### Trial 2 — Residual-prediction + asinh compound

Only run after Trial 1 completes. Tests whether pairing residual-prediction with asinh pressure scaling compounds further.

```bash
cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.3 --weight-decay 1e-2 --enable-fourier --model-layers 3 --model-hidden-dim 192 --model-heads 3 --epochs 999 --ema-decay 0.999 --residual-prediction --asinh-pressure --asinh-scale 0.75 --wandb_group tf-residual-pred
```

**Note on gc=0.3:** Using gc=0.3 (previous champion, PR #3108) rather than gc=0.2 (current champion) to keep this a clean single-variable ablation — we are isolating `--residual-prediction` only.

### Reporting

For each trial report:
- `val_primary/surface_pressure_mae` (best across all epochs)
- W&B run ID and link
- Best epoch number

## Baseline

Current best metrics (PR #3140):
- `val_primary/surface_pressure_mae`: **21.350** (epoch 331)
- `test_primary/surface_pressure_mae`: 23.195
- Config: Lion lr=1.25e-4, T_max=10, gc=0.2, WD=1e-2, EMA=0.999, 3L/192d/3h, Fourier + full physics stack
- Baseline W&B run: `9g11l7tm`
- Reproduce:
  ```bash
  cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.2 --weight-decay 1e-2 --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --ema-decay 0.999
  ```

Previous champion gc=0.3 (PR #3108): val=21.909, W&B run `kzg626hf`.
**Target to beat: val_primary/surface_pressure_mae < 21.350**