### PR TITLE
TFP: asinh pressure scale ablation (0.75, 0.5) — isolation test

### DIFF
--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,8 +1,8 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 19:30 (advisor cycle 41 — closed #3142/#3115/#3079, assigning zenitsu/gojo/piccolo)
+- **Date:** 2026-04-23 20:00 (advisor cycle 42 — closed #3132, assigning gohan)
 - **Branch:** radford
-- **Idle students:** 0 (zenitsu/gojo/piccolo being assigned)
+- **Idle students:** 0 (gohan being assigned)
 - **PRs ready for review:** 0
 
 ## Fleet Status (56 active PRs → 59 after assignments)
@@ -29,7 +29,7 @@
 - `#3152` eren: EMA decay sweep (0.999 vs 0.9995)
 - `#3146` taki: top-5 checkpoint averaging
 - `#3143` thorfinn: Lookahead(AdamW)
-- `#3132` gohan: eta_min=5e-5+gc=1.0
+- `#NEW` gohan: TFP asinh-pressure isolation — BEING ASSIGNED
 - `#3121` levi: dropout regularization sweep
 - `#3195` piccolo: AF re-stratified sampling alone — NOAM ABLATION
 - `#3110` einar: beta2=0.99/0.995
@@ -168,6 +168,7 @@
 - Bilateral symmetry aug, torch.compile, gradient accumulation
 - Attention dropout without EMA/gc: toxic combo with T_max=30
 - Cosine eta_min without EMA/gc: diverges (7.255-7.918%)
+- eta_min=5e-5+gc (any value): gc=1.0→6.311%, gc=0.5→8.617%, both diverge — 3rd confirmation
 - Surface points ≠50k: 16k=11.672%, 32k=7.558%, 64k=12.16% (even with EMA+gc) — 50k only viable count
 - 4L/640d: dead at ALL tested configs — lr=5e-4+EMA+gc: 8.636% diverge ep82 (#3159); lr=5e-4 no-EMA: 4.516%/6.457%/5.724% all diverge (#3079). Width amplifies gradients beyond gc containment.
 - lr<5e-4 under EMA: steep monotonic cliff (4.5e-4=4.134%, 4e-4=5.924%)

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,9 @@
 # SENPAI Research Results
 
+## 2026-04-23 20:00 — PR #3132: DM eta_min=5e-5 + gc compound (gohan) — CLOSED
+
+- gc=1.0+eta_min=5e-5: 6.311% ep149, diverged ep150 → 112.66% (W&B: `h6jblqjq`). gc=0.5+eta_min=5e-5: 8.617% ep70, diverged → 72% (W&B: `7fmjg0cu`). Third confirmation eta_min=5e-5 is dead — alone (#3126), +gc=1.0, +gc=0.5 all diverge catastrophically. Non-zero LR floor prevents gradient momentum dissipation at cosine troughs; gc delays but cannot prevent cumulative drift. gc=0.5 is counterproductive here — clips 288/394 batches (throttles signal), worse than gc=1.0 which clips only 73/394.
+
 ## 2026-04-23 19:30 — PR #3142: TF gc=0.3 longer budget 480-min (zenitsu) — CLOSED
 
 - Best val=22.016 ep460 (W&B: `w0wlkumg`). Doesn't beat 21.350 baseline (#3140). Extra 120min budget provides no benefit — cosine T_max=10 cycling means more epochs are independent LR-cycle draws, not monotone descent. Three gc=0.3 runs span 0.7 MAE variance (21.909, 21.350, 22.016). gc=0.3 clips rarely (44 events/467 epochs, grad_norm_mean=0.1884) — functionally equivalent to gc=0.2. geom_camber_rc ~30.9 MAE remains persistent architectural bottleneck.

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1643,9 +1643,9 @@ def main() -> None:
     best_anp_state: dict[str, torch.Tensor] | None = None
 
     if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
+        checkpoint_metric_key = "val_primary/surface_pressure_mae"
     else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+        checkpoint_metric_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1719,7 +1719,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(checkpoint_metric_key)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

Asinh pressure normalization (`--asinh-pressure`) has not been tested in isolation on the TandemFoil Paper dataset. The noam baseline (PR #3025) folds `--asinh-pressure` into the full physics stack (`--enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --residual-prediction --enable-pressure-prior-addition`), making it impossible to attribute how much asinh contributes alone. Historical data shows asinh was -8% on noam's OOD metrics in an earlier ablation, but the open question is whether it independently helps TFP's `val_primary/field_mse`.

This experiment tests two asinh scale values (0.75 and 0.5) against the TFP champion config with `--enable-fourier` only — stripping the full physics stack to isolate the asinh effect. This fills the only missing cell in the asinh isolation matrix: emma (#3189) tests asinh on TF, casca (#3192) tests asinh on DM, but nobody tests asinh alone on TFP.

## Instructions

Use the TFP champion config throughout (Lion lr=1.25e-4, T_max=10, gc=0.5, WD=1e-2, EMA=0.999, 3L/192d/3H, Fourier enabled). Do **not** add `--enable-te-coord-frame`, `--enable-cp-panel`, `--enable-cp-panel-tandem-only`, `--residual-prediction`, or `--enable-pressure-prior-addition` — this is a clean single-variable ablation.

**Step 0 — 3-epoch smoke test (run first):**

```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.5 --weight-decay 1e-2 \
  --enable-fourier \
  --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --ema-decay 0.999 \
  --asinh-pressure --asinh-scale 0.75 \
  --epochs 3 \
  --wandb_group tfp-asinh-ablation
```

Report `val_primary/field_mse` at epoch 3. If it diverges or is clearly worse than ~0.010, stop and comment before proceeding.

**Trial 1 — asinh-scale 0.75 (full run):**

```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.5 --weight-decay 1e-2 \
  --enable-fourier \
  --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --ema-decay 0.999 \
  --asinh-pressure --asinh-scale 0.75 \
  --epochs 999 \
  --wandb_group tfp-asinh-ablation
```

**Trial 2 — asinh-scale 0.5 (full run):**

```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.5 --weight-decay 1e-2 \
  --enable-fourier \
  --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --ema-decay 0.999 \
  --asinh-pressure --asinh-scale 0.5 \
  --epochs 999 \
  --wandb_group tfp-asinh-ablation
```

Report best `val_primary/field_mse` for each trial (from best-validation checkpoint, not terminal epoch). Include W&B run IDs for both.

## Baseline

Current best metrics from BASELINE.md (PR #3025 — haku/tfp-lion-champion-config):

| Metric | Value |
|--------|-------|
| val_primary/field_mse | **0.002383** (epoch 443) |
| val/surface_mse | 0.001517 |
| val/surface_mse_p | 4.81e-05 |
| val/volume_mse | 0.002397 |

- Baseline W&B run: d1xh0o1p (haku/tfp-lion-champion-config)
- Reproduce command:
```bash
cd target/icml2026 && python train.py --dataset tandemfoil_paper --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.5 --weight-decay 1e-2 --enable-fourier --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --ema-decay 0.999
```

Target to beat: `val_primary/field_mse < 0.002383`