### PR TITLE
DrivAerML: EMA=0.9999 sweep — upward from champion 0.9995

### DIFF
--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,8 +1,8 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 20:00 (advisor cycle 42 — closed #3132, assigning gohan)
+- **Date:** 2026-04-23 20:30 (advisor cycle 43 — closed #3134, assigning megumi)
 - **Branch:** radford
-- **Idle students:** 0 (gohan being assigned)
+- **Idle students:** 0 (megumi being assigned)
 - **PRs ready for review:** 0
 
 ## Fleet Status (56 active PRs → 59 after assignments)
@@ -82,7 +82,7 @@
 - `#3166` vegeta: vol-weight=5.0/7.0+EMA=0.999
 - `#3156` edward: softer gc=0.5
 - `#3144` violet: vol-weight=2.0+EMA=0.999
-- `#3134` megumi: vol-weight=30x
+- `#NEW` megumi: DM EMA=0.9999/0.99995 (noam optimal decay) — BEING ASSIGNED
 - `#3129` chrome: 4L/256d deeper
 - `#3101` tanjiro: vol-loss-weight=1.5 (SENT BACK)
 
@@ -189,6 +189,7 @@
 - EMA<0.999 (0.99, 0.995 both worse)
 - T_max≠50 (30 and 100 both worse)
 - Vol-weight=10x: worse on both metrics
+- Vol-weight=30x: catastrophic — surface 4.3x worse, vol 3.1x worse
 
 **TandemFoil:**
 - gc≥0.5: monotonically worse than gc=0.3

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,9 @@
 # SENPAI Research Results
 
+## 2026-04-23 20:30 — PR #3134: AF vol-weight=30x (megumi) — CLOSED
+
+- Surface=0.001264 (4.3x worse than 0.000296 baseline), vol=0.006235 (3.1x worse than 0.002039 baseline) (W&B: `wupz6iuj`). 30x volume weighting massively overshoots — optimizer saturates on volume gradients and both metrics collapse. Model diverged post-ep400, terminal surface=0.621 vol=1.533. No Pareto improvement at any epoch. Sweet spot confirmed at 10x (#3135). Adding to dead ends: vol-weight≥30x catastrophic.
+
 ## 2026-04-23 20:00 — PR #3132: DM eta_min=5e-5 + gc compound (gohan) — CLOSED
 
 - gc=1.0+eta_min=5e-5: 6.311% ep149, diverged ep150 → 112.66% (W&B: `h6jblqjq`). gc=0.5+eta_min=5e-5: 8.617% ep70, diverged → 72% (W&B: `7fmjg0cu`). Third confirmation eta_min=5e-5 is dead — alone (#3126), +gc=1.0, +gc=0.5 all diverge catastrophically. Non-zero LR floor prevents gradient momentum dissipation at cosine troughs; gc delays but cannot prevent cumulative drift. gc=0.5 is counterproductive here — clips 288/394 batches (throttles signal), worse than gc=1.0 which clips only 73/394.

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1635,17 +1635,14 @@ def main() -> None:
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
     history: list[dict[str, float]] = []
-    best_epoch: int | None = None
-    best_val_primary_metric_name = primary_metric_key(bundle, phase="val")
-    best_val_primary_metric: float | None = None
-    best_val_metrics: dict[str, float] = {}
-    best_model_state: dict[str, torch.Tensor] | None = None
-    best_anp_state: dict[str, torch.Tensor] | None = None
 
     if bundle.spec.name == "tandemfoilset":
         primary_metric_key = "val_primary/surface_pressure_mae"
     else:
         primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+    best_val_primary_metric_name = primary_metric_key
+    best_val_primary_metric: float | None = None
+    best_val_metrics: dict[str, float] = {}
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None


### PR DESCRIPTION
## Hypothesis

The DM champion (PR #3072) uses EMA=0.9995 and sits at 3.833% val — 0.123pp above the AB-UPT external target of 3.710%. The noam branch found EMA=0.9999 optimal on AirfRANS, but nobody has tested the upward direction on DrivAerML. PR #3152 (eren) is already sweeping downward (EMA=0.999, 0.9995), so this PR covers the complementary upward direction.

Hypothesis: higher EMA decay (0.9999 or 0.99995) may produce a smoother weight trajectory that reduces surface error on DrivAerML's larger 4L/512d architecture, closing or narrowing the 0.123pp gap to AB-UPT. The gc=0.5 gradient clip (which prevents EMA divergence at LR peaks) makes this sweep safe to run at higher decay values.

Note: AirfRANS found EMA=0.999 optimal (higher EMA hurt on 2L/256d). DrivAerML's larger model may have different EMA dynamics — this is an open question.

## Instructions

**Run a 3-epoch smoke test of Trial 1 first.** Confirm training is stable and metrics are not NaN before launching the full run.

### Trial 1 — EMA=0.9999 (primary)

```bash
cd target/icml2026
SENPAI_MAX_EPOCHS=9999 python train.py \
    --dataset drivaerml \
    --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 \
    --enable-fourier \
    --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
    --epochs 999 \
    --batch-size 1 \
    --drivaerml-train-surface-points 50000 \
    --drivaerml-eval-surface-points 50000 \
    --max-train-batches 394 \
    --max-eval-batches 200 \
    --ema-decay 0.9999 \
    --wandb_group dm-ema-decay-sweep
```

### Trial 2 — EMA=0.99995 (if Trial 1 is stable and promising)

Only run Trial 2 if Trial 1 reaches at least epoch 50 without divergence. Use all remaining GPUs.

```bash
cd target/icml2026
SENPAI_MAX_EPOCHS=9999 python train.py \
    --dataset drivaerml \
    --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 \
    --enable-fourier \
    --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
    --epochs 999 \
    --batch-size 1 \
    --drivaerml-train-surface-points 50000 \
    --drivaerml-eval-surface-points 50000 \
    --max-train-batches 394 \
    --max-eval-batches 200 \
    --ema-decay 0.99995 \
    --wandb_group dm-ema-decay-sweep
```

Report best `val_primary/surface_rel_l2_pct` and the epoch at which it was achieved for each trial. Note any divergence or instability (especially near LR peaks at multiples of T_max=30 epochs).

## Baseline

Current best metrics from BASELINE.md:

- **Primary metric:** `val_primary/surface_rel_l2_pct` (lower is better)
- **Current best val:** 3.833% at epoch 511
- **External target:** <3.710% (AB-UPT, ~500 epochs) — gap: 0.123pp
- **Best PR:** #3072 (eren — EMA=0.9995 + gc=0.5, 4L/512d/8H, AdamW lr=5e-4, T_max=30)
- **Baseline W&B run:** `ncl1dh88` (eren/dm-ema-9995-gc05)
- **Reproduce command:**
  ```bash
  cd target/icml2026
  SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml \
      --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 --enable-fourier \
      --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 \
      --batch-size 1 --drivaerml-train-surface-points 50000 \
      --drivaerml-eval-surface-points 50000 --max-train-batches 394 \
      --max-eval-batches 200 --ema-decay 0.9995
  ```