### PR TITLE
DrivAerML: GLU preprocess MLP — gated input feature selection

### DIFF
--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,11 +1,11 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 20:30 (advisor cycle 43 — closed #3134, assigning megumi)
+- **Date:** 2026-04-23 21:00 (advisor cycle 44 — closed #3190/#3167/#3166/#3165, assigning 5 students)
 - **Branch:** radford
-- **Idle students:** 0 (megumi being assigned)
+- **Idle students:** 0 (brook/gilbert/senku/vegeta/jet being assigned)
 - **PRs ready for review:** 0
 
-## Fleet Status (56 active PRs → 59 after assignments)
+## Fleet Status (55 active PRs + 5 pending)
 
 ### DrivAerML WIP (30 PRs)
 **Noam-pivot experiments (highest priority):**
@@ -14,10 +14,14 @@
 - `#3181` himmel: asinh+residual on champion — NOAM ABLATION
 - `#3175` hinata: full noam stack on champion — NOAM ABLATION
 
+**Innovation track (code ports from noam — new directive):**
+- `#NEW` senku: DM GLU preprocess MLP — INNOVATION TRACK
+- `#NEW` vegeta: DM attention temperature annealing — INNOVATION TRACK
+- `#NEW` jet: DM DomainLayerNorm — INNOVATION TRACK
+
 **Pre-pivot champion tuning:**
 - `#3173` kakashi: shorter cosine T_max=15/20
 - `#3171` sanji: LR warmup (5-ep/10-ep) on champion
-- `#3165` senku: 4H heads (128d/head)
 - `#3164` faye: paper-facing full eval (two-phase) — PAPER-FACING
 - `#3163` shouko: attn dropout=0.05
 - `#3161` spike: eta_min=1e-5 (cosine floor)

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,21 @@
 # SENPAI Research Results
 
+## 2026-04-23 21:00 — PR #3190: TFP physics features isolation (brook) — CLOSED
+
+- Trial 1 (all physics): val=Infinity — cp_panel_prior_index() returns wrong index for tandemfoil_paper, applies sinh(Fourier_value) → overflow. Ux/Uy learn normally but pressure permanently broken (W&B: `0eq5jqij`). Trial 2 (wake only): val=0.7396 ep98, diverged via unbounded dx_norm/dy_norm (W&B: `kqknlctz`). CRITICAL FINDING: build_tandemfoil_paper_bundle only supports enable_fourier/wake_deficit/wake_angle — TE coord, cp_panel, vortex flags silently ignored. primary_metric_key bug fix noted.
+
+## 2026-04-23 21:00 — PR #3167: AF higher LR 8e-4/1e-3 (gilbert) — CLOSED
+
+- lr=8e-4: surface=0.000623 (+110%), vol=0.003850 (+89%) vs baseline (W&B: `dfed8vam`). lr=1e-3: catastrophic divergence, surface=0.000979 best → 0.621 terminal (W&B: `tb2h5odt`). 8H vs champion's 4H confound noted. LR=6e-4 confirmed AF sweet spot — boundary between stable/unstable is 6e-4 to 8e-4.
+
+## 2026-04-23 21:00 — PR #3166: AF vol-weight=5x/7x (vegeta) — CLOSED
+
+- 5x: surface=0.000432 (+46%), vol=0.003094 (+52%) (W&B: `dxna9k23`). 7x: surface=0.000438 (+48%), vol=0.005187 (+154%), diverged ep322 (W&B: `20nl7euu`). Both used 8H (wrong, champion is 4H). vol-weight sweep complete: 2x/5x/7x all worse, 10x+EMA=0.999 champion, 30x catastrophic.
+
+## 2026-04-23 21:00 — PR #3165: DM 4H heads EMA+gc (senku) — CLOSED
+
+- Best val=6.650% ep123, then diverged ep133 via gradient explosion (grad_norm→22.73) despite gc=0.5 (W&B: `o5mcbmp9`). EMA+gc delayed divergence (ep123 vs ep28 for gojo #3079) but 4H fundamentally unstable at 4L/512d. DM heads sweep complete: 8H champion > 4H (crashed) > 16H.
+
 ## 2026-04-23 20:30 — PR #3134: AF vol-weight=30x (megumi) — CLOSED
 
 - Surface=0.001264 (4.3x worse than 0.000296 baseline), vol=0.006235 (3.1x worse than 0.002039 baseline) (W&B: `wupz6iuj`). 30x volume weighting massively overshoots — optimizer saturates on volume gradients and both metrics collapse. Model diverged post-ep400, terminal surface=0.621 vol=1.533. No Pareto improvement at any epoch. Sweet spot confirmed at 10x (#3135). Adding to dead ends: vol-weight≥30x catastrophic.

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -169,6 +169,7 @@ class TrainConfig:
     volume_loss_weight: float = 1.0
     save_checkpoint: bool = False
     seed: int = 0
+    glu_preprocess: bool = False
 
 
 @dataclass
@@ -499,6 +500,19 @@ def cp_panel_prior_index(config: TrainConfig, bundle: DatasetBundle) -> int | No
     return None
 
 
+class GLUProjection(torch.nn.Module):
+    def __init__(self, input_dim: int, output_dim: int):
+        super().__init__()
+        self.value = torch.nn.Linear(input_dim, output_dim)
+        self.gate = torch.nn.Linear(input_dim, output_dim)
+        for lin in (self.value, self.gate):
+            torch.nn.init.trunc_normal_(lin.weight, std=0.02)
+            torch.nn.init.zeros_(lin.bias)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.value(x) * torch.sigmoid(self.gate(x))
+
+
 def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
     transolver_kwargs = {
         "n_layers": config.model_layers,
@@ -519,7 +533,7 @@ def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
         )
     if config.model == "senpai_transolver":
         prior_idx = cp_panel_prior_index(config, bundle)
-        return SenpaiTransolver(
+        model = SenpaiTransolver(
             space_dim=bundle.spec.space_dim,
             surface_input_dim=bundle.spec.surface_input_dim,
             surface_output_dim=bundle.spec.surface_output_dim,
@@ -533,6 +547,11 @@ def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
             volume_pressure_prior_idx=prior_idx,
             **transolver_kwargs,
         )
+        if config.glu_preprocess and model.project_surface_features is not None:
+            model.project_surface_features = GLUProjection(
+                model.surface_extra_dim, config.model_hidden_dim,
+            )
+        return model
     if config.model == "reference_abupt":
         return ABUPTReference(
             space_dim=bundle.spec.space_dim,
@@ -1643,9 +1662,9 @@ def main() -> None:
     best_anp_state: dict[str, torch.Tensor] | None = None
 
     if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
+        val_metric_key = "val_primary/surface_pressure_mae"
     else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+        val_metric_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1719,7 +1738,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(val_metric_key)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

The standard input projection in the surface MLP is `x = Linear(in_features, hidden_dim)`. Replacing this with a Gated Linear Unit (GLU) preprocess — `value = Linear(in_features, hidden_dim); gate = Linear(in_features, hidden_dim); x = value * sigmoid(gate)` — allows the model to selectively amplify or suppress input features before they propagate through the network.

This is the \"second innovation track\" for DrivAerML: a genuinely new physics-aware architectural idea rather than local hyperparameter retuning. The gate mechanism may be particularly valuable because DrivAerML inputs include Fourier positional encodings and geometric features (normals, curvature) with very different scales and information content. The gate learns which features are relevant at each point, acting as a soft, learned feature selection layer.

The noam branch reportedly has an existing GLU preprocess implementation — port that first rather than writing from scratch.

**Why this may beat baseline:** The current DM champion (3.833%) already uses 4L/512d with EMA + gc stability. The remaining gap to AB-UPT (<3.71%) is 0.123 pp. Architectural improvements to input representation are one of the few levers not yet pulled on this configuration.

## Instructions

**Step 1: Check noam branch for existing implementation**

```bash
git fetch origin noam
git diff radford...origin/noam -- target/icml2026/train.py | grep -A 20 -B 5 -i "glu\|gate\|preprocess"
```

If a GLU preprocess implementation exists on noam, port it. Otherwise implement from scratch as described below.

**Step 2: Implement GLU preprocess in `target/icml2026/train.py`**

Find the surface MLP input projection (likely something like `self.input_proj = nn.Linear(in_features, hidden_dim)`). Replace it with a GLU preprocess:

```python
# Replace:
#   self.input_proj = nn.Linear(in_features, hidden_dim)
# With:
self.input_proj_value = nn.Linear(in_features, hidden_dim)
self.input_proj_gate  = nn.Linear(in_features, hidden_dim)

# Replace:
#   x = self.input_proj(x)
# With:
x = self.input_proj_value(x) * torch.sigmoid(self.input_proj_gate(x))
```

**Step 3: Add CLI flag**

Add `--glu-preprocess` boolean flag (default `False`) and thread it through to the model constructor. The standard MLP path must remain unchanged when the flag is absent.

**Step 4: 3-epoch smoke test before full run**

```bash
cd target/icml2026 && python train.py --dataset drivaerml --optimizer adamw \
  --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 3 \
  --batch-size 1 --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 --max-train-batches 394 \
  --max-eval-batches 200 --ema-decay 0.9995 --glu-preprocess
```

Verify it runs without error and val metrics are finite before launching the full run.

**Step 5: Full experiment**

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --glu-preprocess \
  --wandb_group dm-innovation-track
```

**Critical config notes:**
- Do NOT add weight decay — WD hurts DrivAerML
- EMA=0.9995 requires gc=0.5 as a stability guard — EMA alone diverges at ep28 without it
- Use `--cosine-t-max 30` with per-batch stepping (T_max in batches, not epochs)
- Use `--wandb_group dm-innovation-track` to group with future innovation-track runs

**Report:** `val_primary/surface_rel_l2_pct` at the best validation checkpoint, plus W&B run ID.

## Baseline

Current DrivAerML best (radford branch):

| Metric | Value |
|--------|-------|
| `val_primary/surface_rel_l2_pct` | **3.833%** |
| Best epoch | 511 |
| Test surface_rel_l2_pct | 4.685% |

- W&B run: `ncl1dh88` (eren/dm-ema-9995-gc05, PR #3072)
- External target: AB-UPT < 3.71% (~500 epochs); gap = 0.123 pp

Reproduce command:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --grad-clip 0.5 --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 --ema-decay 0.9995
```