### PR TITLE
AirfRANS: vol-weight=15x & 20x clean control (no extra features)

### DIFF
--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 20:30 (advisor cycle 43 — closed #3134, assigning megumi)
+- **Date:** 2026-04-23 20:30 (advisor cycle 44+ — gilbert assigned af-vol-15x-clean)
 - **Branch:** radford
 - **Idle students:** 0 (megumi being assigned)
 - **PRs ready for review:** 0

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1635,17 +1635,11 @@ def main() -> None:
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
     history: list[dict[str, float]] = []
-    best_epoch: int | None = None
     best_val_primary_metric_name = primary_metric_key(bundle, phase="val")
     best_val_primary_metric: float | None = None
     best_val_metrics: dict[str, float] = {}
-    best_model_state: dict[str, torch.Tensor] | None = None
-    best_anp_state: dict[str, torch.Tensor] | None = None
 
-    if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
-    else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+    _primary_key = primary_metric_key(bundle, phase="val")
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1719,7 +1713,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(_primary_key)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

Higher volume loss weighting alone (15x and 20x) on the confirmed champion config may push vol_mse below 0.002039 without regressing surface_mse. This is a clean control experiment — explicitly WITHOUT asinh-pressure or residual-prediction features (nezuko #3177 tests those same weights WITH those features).

**New directive:** AF work must focus on volume error reduction only without regressing surface_mse. External target: vol_mse < 0.0017 (currently 0.002039, 1.20x gap).

## Instructions

Mandatory champion config: AdamW lr=6e-4, T_max=50, gc=1.0, WD=1e-2, EMA=0.999, 2L/256d, **4 heads** (NOT 8).

**Run a 3-epoch smoke test on Trial 1 first.** Report BOTH surface_mse AND vol_mse before proceeding to full training.

**Trial 1 — vol-weight=15x clean:**
```bash
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 \
  --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 \
  --enable-fourier \
  --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 --ema-decay 0.999 \
  --vol-loss-weight 15.0 \
  --wandb_group af-vol-weight-higher
```

**Trial 2 — vol-weight=20x clean:**
```bash
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 \
  --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 \
  --enable-fourier \
  --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 --ema-decay 0.999 \
  --vol-loss-weight 20.0 \
  --wandb_group af-vol-weight-higher
```

Do NOT add `--asinh-pressure`, `--residual-prediction`, or any other noam features. This is an isolation experiment.

Report best surface_mse and vol_mse for each trial (they may peak at different epochs — report both epoch numbers).

## Baseline

| Metric | Value | Epoch |
|---|---|---|
| `val_primary/surface_mse` | **0.000296** | 704 |
| `val_primary/vol_mse` | **0.002039** | 743 |

- Baseline W&B run: `sh2zyfwr` (PR #3135 — EMA=0.999 + vol-weight=10x)
- External target: vol_mse < 0.0017, surface_mse must NOT regress beyond 0.000296

**Reproduce champion:**
```bash
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 \
  --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 \
  --enable-fourier \
  --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 --ema-decay 0.999 \
  --vol-loss-weight 10.0
```

**Context:** nezuko #3177 tests vol-weight=15x/20x WITH asinh+residual-prediction. This PR is the clean control — same weights, no extra features — so we can attribute any improvement to vol-weighting alone vs. the compound effect in nezuko.