### PR TITLE
TFP: seed sensitivity diagnostic — is seed=0 a lucky init?

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -159,6 +159,7 @@ class TrainConfig:
     asinh_scale: float = 0.75
     residual_prediction: bool = False
     re_stratified_sampling: bool = False
+    warmup_epochs: int = 0
     cosine_t_max: int = 150
     geometry_points: int = 25_000
     geometry_supernodes: int = 4_096
@@ -1628,24 +1629,33 @@ def main() -> None:
         params.extend(list(anp_head.parameters()))
     optimizer = build_optimizer(params, config)
     scheduler = None
+    base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
     if config.cosine_t_max > 0:
-        base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
-        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
+        cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
+        if config.warmup_epochs > 0:
+            steps_per_epoch = max(1, len(train_loader) // config.grad_accum_steps)
+            warmup_steps = config.warmup_epochs * steps_per_epoch
+            warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_optimizer, start_factor=1e-6, total_iters=warmup_steps)
+            scheduler = torch.optim.lr_scheduler.SequentialLR(base_optimizer, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[warmup_steps])
+        else:
+            scheduler = cosine_scheduler
+    elif config.warmup_epochs > 0:
+        steps_per_epoch = max(1, len(train_loader) // config.grad_accum_steps)
+        warmup_steps = config.warmup_epochs * steps_per_epoch
+        scheduler = torch.optim.lr_scheduler.LinearLR(base_optimizer, start_factor=1e-6, total_iters=warmup_steps)
 
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
     history: list[dict[str, float]] = []
-    best_epoch: int | None = None
+
+    if bundle.spec.name == "tandemfoilset":
+        primary_metric_key_str = "val_primary/surface_pressure_mae"
+    else:
+        primary_metric_key_str = f"val_primary/{bundle.spec.default_metric}"
+
     best_val_primary_metric_name = primary_metric_key(bundle, phase="val")
     best_val_primary_metric: float | None = None
     best_val_metrics: dict[str, float] = {}
-    best_model_state: dict[str, torch.Tensor] | None = None
-    best_anp_state: dict[str, torch.Tensor] | None = None
-
-    if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
-    else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1719,7 +1729,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(primary_metric_key_str)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

The TFP champion (val_primary/field_mse = 0.002383, PR #3025, seed=0) may be a lucky initialization. Seeds 42, 123, and 456 all diverged to infinity (issue #3168), raising the question of whether the baseline is reproducible or an outlier. This diagnostic maps the failure mechanism before we build further on this config.

Four cheap 20-epoch trials test whether the divergence is due to the seed itself, gradient norm explosion at init, missing warmup, or pressure-target scaling sensitivity.

## Instructions

All trials use the TFP champion config as the mandatory base:
Lion lr=1.25e-4, T_max=10, gc=0.5, WD=1e-2, EMA=0.999, 3L/192d, Fourier+physics, 360-min budget.

**For each trial, report:**
1. Finite or NaN/inf (and at which epoch divergence occurs if it diverges)
2. val_primary/field_mse at epoch 20 (or last finite epoch)
3. Grad norm behavior — stable, growing, or spiking

Use `--wandb_group tfp-seed-sensitivity` for all runs.

---

**Trial 1 — Control: verify seed=0 still converges (20 epochs)**
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion --lr 1.25e-4 \
  --cosine-t-max 10 --grad-clip 0.5 \
  --weight-decay 1e-2 --ema-decay 0.999 \
  --enable-fourier --model-layers 3 \
  --model-hidden-dim 192 --model-heads 3 \
  --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition \
  --epochs 20 --seed 0 \
  --wandb_group tfp-seed-sensitivity \
  --wandb_run_name tfp-seed0-control
```

---

**Trial 2 — Tighter gradient clipping: seed=42, gc=0.3**
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion --lr 1.25e-4 \
  --cosine-t-max 10 --grad-clip 0.3 \
  --weight-decay 1e-2 --ema-decay 0.999 \
  --enable-fourier --model-layers 3 \
  --model-hidden-dim 192 --model-heads 3 \
  --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition \
  --epochs 20 --seed 42 \
  --wandb_group tfp-seed-sensitivity \
  --wandb_run_name tfp-seed42-gc0.3
```

---

**Trial 3 — Warmup: seed=42, --warmup-epochs 3**
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion --lr 1.25e-4 \
  --cosine-t-max 10 --grad-clip 0.5 \
  --weight-decay 1e-2 --ema-decay 0.999 \
  --enable-fourier --model-layers 3 \
  --model-hidden-dim 192 --model-heads 3 \
  --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition \
  --epochs 20 --seed 42 \
  --warmup-epochs 3 \
  --wandb_group tfp-seed-sensitivity \
  --wandb_run_name tfp-seed42-warmup3
```

---

**Trial 4 — Pressure transform: seed=42, --asinh-scale 0.5**
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion --lr 1.25e-4 \
  --cosine-t-max 10 --grad-clip 0.5 \
  --weight-decay 1e-2 --ema-decay 0.999 \
  --enable-fourier --model-layers 3 \
  --model-hidden-dim 192 --model-heads 3 \
  --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only \
  --asinh-pressure --asinh-scale 0.5 \
  --residual-prediction \
  --enable-pressure-prior-addition \
  --epochs 20 --seed 42 \
  --wandb_group tfp-seed-sensitivity \
  --wandb_run_name tfp-seed42-asinh0.5
```

---

**Goal:** Understand the divergence mechanism, not beat the baseline. If Trial 1 itself diverges, that is the most important finding — the champion is not reproducible even on seed=0.

If any seed=42 trial stays finite at epoch 20, note whether val_primary/field_mse is within 2x of 0.002383 — that would suggest the config is recoverable with a stabilization fix.

## Baseline

| Metric | Value |
|---|---|
| val_primary/field_mse | **0.002383** |
| Epoch | 443 |
| PR | #3025 (haku/tfp-lion-champion-config) |
| W&B run | d1xh0o1p |
| Seed | 0 |

Known: divergence at ep462 due to T_max=10 cosine instability; EMA=0.999 preserved ep443 best.

Reproduce command:
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion --lr 1.25e-4 \
  --cosine-t-max 10 --grad-clip 0.5 \
  --weight-decay 1e-2 --enable-fourier \
  --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition \
  --epochs 999 --ema-decay 0.999
```