### PR TITLE
DrivAerML: 600 batches + gc=0.5 + EMA=0.9995 stabilized

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1643,9 +1643,9 @@ def main() -> None:
     best_anp_state: dict[str, torch.Tensor] | None = None
 
     if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
+        best_tracking_metric_key = "val_primary/surface_pressure_mae"
     else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+        best_tracking_metric_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1719,7 +1719,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(best_tracking_metric_key)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

PR #3083 showed that 600 batches/epoch (+52% over baseline's 394) diverged at epoch 28 with NaN loss. Root cause: EMA=0.9995 alone is insufficient for DrivAerML stability at higher batch counts — gradient clipping (gc=0.5) is mandatory alongside EMA.

This PR retests the data-efficiency hypothesis with the full stabilization combo: 600 batches + gc=0.5 + EMA=0.9995. More batches per epoch exposes the model to a greater diversity of car configurations per epoch, potentially finding a deeper basin faster.

Two T_max variants to explore the cosine schedule interaction:
- **Trial 1**: T_max=46 (proportionally scaled from baseline T_max=30 @ 394 batches → T_max=46 @ 600 batches; same epoch-length schedule shape)
- **Trial 2**: T_max=30 (same schedule as baseline; more data per cosine cycle)

Prior failure context: #3083 (jet, 600 batches, no gc) → 9.537% val then NaN divergence ep28.

## Instructions

**IMPORTANT: Run a 3-epoch smoke test on Trial 1 first before committing to a full run. Report `val_primary/surface_rel_l2_pct` at epoch 3. If it has not diverged and loss is trending down, proceed with the full run. If it diverges or looks unstable, stop and report immediately.**

### Trial 1 — 600 batches + gc=0.5 + EMA=0.9995, T_max=46 (proportional schedule)

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 46 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 600 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --wandb_group dm-data-efficiency
```

### Trial 2 — 600 batches + gc=0.5 + EMA=0.9995, T_max=30 (baseline schedule, more data per cycle)

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 600 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --wandb_group dm-data-efficiency
```

**Report**: For each trial, report `val_primary/surface_rel_l2_pct` at best epoch. Target: beat **3.833%**.

## Baseline

Current best DrivAerML metrics (PR #3072, eren/dm-ema-9995-gc05):
- `val_primary/surface_rel_l2_pct`: **3.833%** at epoch 511
- test: 4.685%
- W&B run: `ncl1dh88` (https://wandb.ai/runs/ncl1dh88)
- Config: AdamW lr=5e-4, gc=0.5, no WD, 4L/512d/8H, EMA=0.9995, T_max=30, 394 batches/epoch

Reproduce baseline:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995
```

External target: <3.71% (AB-UPT, ~500 epochs). Current gap: ~0.123 pp.