### PR TITLE
DrivAerML: true monotonic cosine decay (T_max=393606 steps)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1642,14 +1642,7 @@ def main() -> None:
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
 
-    if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
-    else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
-    best_epoch = 0
-    best_model_state: dict[str, torch.Tensor] | None = None
-    best_anp_state: dict[str, torch.Tensor] | None = None
     best_ema_shadow: dict[str, torch.Tensor] | None = None
     best_anp_ema_shadow: dict[str, torch.Tensor] | None = None
 
@@ -1719,7 +1712,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(best_val_primary_metric_name)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

Previous experiment #3154 (historia) intended to test true monotonic cosine decay over the full 999-epoch training run on the DM champion config, but accidentally used `T_max=999` which — since the cosine scheduler operates in **steps**, not epochs — resulted in rapid 999-step (~2.5 epoch) mini-cycles rather than a single monotonic decay. This experiment corrects that mistake.

The correct value for a single half-cosine decay from lr=5e-4 to 0 over the full 999-epoch run is:

```
T_max = 999 epochs × 394 steps/epoch = 393,606 steps
```

**Why this may help:** The current DM champion (PR #3072, T_max=30 = ~13 steps/epoch) uses rapid cosine restarts, which introduce periodic gradient spikes at each restart boundary. With EMA=0.9995 (very slow decay — remembers ~2000 steps of history), these restarts create regular disruptions to the EMA weights. A true monotonic decay eliminates restart boundaries entirely, allowing smoother long-horizon convergence and potentially letting EMA accumulate cleaner model weight averages over the full training.

Reference: cosine annealing without restarts (Loshchilov & Hutter, 2016, SGDR) — the "WR" (warm restarts) variant dominates practice, but the monotonic form can outperform when the training budget is fixed and long.

## Instructions

**3-epoch smoke test first.** Confirm no divergence and surface_rel_l2_pct is reasonable (< 10%). Then run the full trial.

**Trial 1 — True monotonic cosine (T_max=393606 steps = full 999 epochs):**

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 393606 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --wandb_group dm-monotonic-cosine
```

**Key parameter notes:**
- `--cosine-t-max 393606` = 999 epochs × 394 steps/epoch = single half-cosine decay from lr=5e-4 to 0 over full training (no restarts)
- `--ema-decay 0.9995` = DM champion EMA (requires gc=0.5 for stability — already included)
- `SENPAI_MAX_EPOCHS=9999` = allow full 999-epoch run
- All other flags are identical to the DM champion config (#3072)
- Do NOT change `--grad-clip 0.5` — this is the stability guard for EMA on DrivAerML

**What to report:**
- Best `val_primary/surface_rel_l2_pct` and at which epoch
- Final epoch `val_primary/surface_rel_l2_pct`
- W&B run ID
- Whether the LR schedule looks correct in W&B (should be a smooth monotonic decay from 5e-4 to ~0 at epoch 999, no restarts/spikes)

## Baseline

- **Dataset:** DrivAerML
- **Primary metric:** `val_primary/surface_rel_l2_pct` (lower is better)
- **Current best:** 3.833% at epoch 511 (PR #3072)
- **Config:** AdamW lr=5e-4, T_max=30 (rapid cycling ~13 steps/epoch), gc=0.5, EMA=0.9995, 4L/512d/8H, Fourier, no WD
- **W&B run:** ncl1dh88 (eren/dm-ema-9995-gc05)
- **External target:** <3.71% (AB-UPT) — gap: 0.123 pp
- **Reproduce baseline:**
  ```bash
  cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --ema-decay 0.9995
  ```

**Target:** Beat 3.833%. The hypothesis is that removing cosine restart boundaries allows smoother long-horizon convergence with EMA=0.9995.