### PR TITLE
TFP seed stability diagnostic: strip physics flags, test LR/optimizer

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1643,9 +1643,9 @@ def main() -> None:
     best_anp_state: dict[str, torch.Tensor] | None = None
 
     if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
+        _checkpoint_metric_key = "val_primary/surface_pressure_mae"
     else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+        _checkpoint_metric_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1719,7 +1719,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(_checkpoint_metric_key)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

The TFP champion (PR #3025, val_primary/field_mse=0.002383) only works with seed=0. Seeds 42/123/456 all diverge to ±∞, discovered in PR #3168. The culprit is almost certainly the pressure representation: `--asinh-pressure`, `--residual-prediction`, and `--enable-pressure-prior-addition` use sinh-like transforms that amplify small initialization differences into unbounded values.

Three cheap 20-epoch diagnostics at seed=42 to find the stability floor:

- **T1 (strip physics flags):** Does the base Lion config stay finite without any pressure transforms?
- **T2 (halved LR):** Does Lion become stable with a more conservative step size?
- **T3 (AdamW swap):** Is Lion's aggressive sign-based update itself the sensitivity source?

Goal: find at least one modification that keeps seed=42 finite. Once we have a finite seed=42 baseline, we can re-introduce physics flags one by one to recover accuracy.

## Instructions

Run all three trials on dataset `tandemfoil_paper` with `seed=42`, 20 epochs each. Use `--wandb_group tfp-pressure-stabilization` on all runs.

**Trial 1 — Base champion, no physics flags, Lion lr=1.25e-4, seed=42:**
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion --lr 1.25e-4 \
  --cosine-t-max 10 --grad-clip 0.5 --weight-decay 1e-2 \
  --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier \
  --ema-decay 0.999 \
  --epochs 20 \
  --seed 42 \
  --wandb_group tfp-pressure-stabilization \
  --wandb_run_name tfp-stab-t1-lion-125e4-nophysics-s42
```
(Intentionally omits: `--asinh-pressure`, `--residual-prediction`, `--enable-pressure-prior-addition`, `--enable-te-coord-frame`, `--enable-cp-panel`, `--enable-cp-panel-tandem-only`)

**Trial 2 — Half LR (6.25e-5), no physics flags, Lion, seed=42:**
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion --lr 6.25e-5 \
  --cosine-t-max 10 --grad-clip 0.5 --weight-decay 1e-2 \
  --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier \
  --ema-decay 0.999 \
  --epochs 20 \
  --seed 42 \
  --wandb_group tfp-pressure-stabilization \
  --wandb_run_name tfp-stab-t2-lion-625e5-nophysics-s42
```

**Trial 3 — AdamW instead of Lion, lr=1e-4, no physics flags, seed=42:**
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer adamw --lr 1e-4 \
  --cosine-t-max 10 --grad-clip 0.5 --weight-decay 1e-2 \
  --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier \
  --ema-decay 0.999 \
  --epochs 20 \
  --seed 42 \
  --wandb_group tfp-pressure-stabilization \
  --wandb_run_name tfp-stab-t3-adamw-1e4-nophysics-s42
```

**Per-trial reporting (required):**
For each trial, report:
1. **Finite or NaN/inf?** — did training stay finite through epoch 20?
2. **val_primary/field_mse at epoch 20** (or earliest epoch it diverged)
3. **Per-component status:** which of Ux, Uy, pressure are finite vs diverged?

Report results as a table in a PR comment:

| Trial | Optimizer | LR | Finite? | field_mse@ep20 | Ux | Uy | P |
|---|---|---|---|---|---|---|---|
| T1 | Lion | 1.25e-4 | ? | ? | ? | ? | ? |
| T2 | Lion | 6.25e-5 | ? | ? | ? | ? | ? |
| T3 | AdamW | 1e-4 | ? | ? | ? | ? | ? |

If any trial stays finite, also report val/surface_mse, val/surface_mse_p, val/volume_mse at epoch 20.

## Baseline

Current TFP champion — **seed=0 only**:
- **val_primary/field_mse: 0.002383** (epoch 443)
- val/surface_mse: 0.001517
- val/surface_mse_p: 4.81e-05
- val/volume_mse: 0.002397
- PR #3025 (haku), W&B run: `d1xh0o1p`
- Reproduce: `cd target/icml2026 && python train.py --dataset tandemfoil_paper --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.5 --weight-decay 1e-2 --enable-fourier --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --ema-decay 0.999`

**The success criterion for this PR is NOT beating 0.002383.** It is: at least one trial stays finite at seed=42. The stability mechanism we discover here will be applied in a subsequent PR at full training length.