### PR TITLE
TFP: Fix cp_panel_prior_index() bug + multi-seed reproducibility

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -490,6 +490,12 @@ def build_bundle(config: TrainConfig) -> DatasetBundle:
 def cp_panel_prior_index(config: TrainConfig, bundle: DatasetBundle) -> int | None:
     if not config.enable_cp_panel or not config.enable_pressure_prior_addition:
         return None
+    # Only tandemfoilset and airfrans bundles actually include cp_panel features
+    # in their tensors.  Other datasets (tandemfoilset_paper, drivaerml) silently
+    # ignore the enable_cp_panel flag, so computing an index would point to a
+    # wrong column (e.g. a Fourier feature) and cause numeric overflow.
+    if bundle.spec.name not in {"tandemfoilset", "airfrans"}:
+        return None
     base_dim = bundle.spec.surface_input_dim
     if config.enable_vortex_panel_velocity:
         base_dim -= 4


### PR DESCRIPTION
## Hypothesis

The `cp_panel_prior_index()` function returns the wrong index for the `tandemfoil_paper` dataset — it points to a Fourier feature column instead of the actual Cp panel feature column. This causes `_apply_pressure_prior_addition` to apply `sinh(Fourier_value)` to pressure, which overflows to infinity. This bug is likely the root cause of the TFP reproducibility crisis: the baseline of 0.002383 (PR #3025, seed=0) cannot be reproduced with seeds 42/123/456 (0/3 seeds succeeded). Fixing the index bug should restore finite training for all seeds.

**CRITICAL:** This is the #1 TFP priority. The human directive puts TFP in stabilization-first crisis mode. Jin (#3205) and Brook (#3208) are running diagnostic probes, but fixing the actual bug is the direct path to reproducibility.

## Instructions

### Step 1 — Investigate the bug

Read `train.py` and find `cp_panel_prior_index()`. The function returns an index into the input tensor, but for `tandemfoil_paper` it returns the WRONG index — pointing to a Fourier feature column instead of the Cp panel column. The root cause: `build_tandemfoil_paper_bundle` does not add the Cp panel feature, so the index calculation is stale/incorrect relative to the actual tensor layout.

### Step 2 — Fix the bug

Choose ONE of:
- Make `cp_panel_prior_index()` return `None` when `enable_cp_panel` features are not actually present in the dataset bundle (safest, ensures no-op when feature is absent)
- Or correctly map the index to the actual Cp panel column when it IS present in the bundle

After fixing, verify that `_apply_pressure_prior_addition` correctly handles `None` (i.e. skips the prior addition when no valid index is returned).

### Step 3 — Multi-seed diagnostic runs (20 epochs each)

Run all three trials in parallel using the fixed code:

**Trial 1 — seed=0 (verify baseline still works):**
```
cd target/icml2026 && python train.py --dataset tandemfoil_paper --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.5 --weight-decay 1e-2 --enable-fourier --model-layers 3 --model-hidden-dim 192 --model-heads 3 --epochs 20 --ema-decay 0.999 --seed 0 --wandb_group tfp-bugfix-retest
```

**Trial 2 — seed=42:**
```
cd target/icml2026 && python train.py --dataset tandemfoil_paper --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.5 --weight-decay 1e-2 --enable-fourier --model-layers 3 --model-hidden-dim 192 --model-heads 3 --epochs 20 --ema-decay 0.999 --seed 42 --wandb_group tfp-bugfix-retest
```

**Trial 3 — seed=123:**
```
cd target/icml2026 && python train.py --dataset tandemfoil_paper --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.5 --weight-decay 1e-2 --enable-fourier --model-layers 3 --model-hidden-dim 192 --model-heads 3 --epochs 20 --ema-decay 0.999 --seed 123 --wandb_group tfp-bugfix-retest
```

### Step 4 — Full run if diagnostic passes

If all 3 seeds produce **finite** `val_primary/field_mse` at epoch 20, extend **seed=0** to the full 999 epochs:
```
cd target/icml2026 && python train.py --dataset tandemfoil_paper --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.5 --weight-decay 1e-2 --enable-fourier --model-layers 3 --model-hidden-dim 192 --model-heads 3 --epochs 999 --ema-decay 0.999 --seed 0 --wandb_group tfp-bugfix-retest
```

### Step 5 — Report

In your PR comment, answer:
1. What was the bug exactly and how did you fix it? (paste the relevant code diff)
2. Are all 3 seeds now finite after 20 epochs?
3. `val_primary/field_mse` at epoch 20 for each seed (seeds 0, 42, 123)
4. If extended to 999 epochs: best `val_primary/field_mse` for seed=0 vs baseline 0.002383

## Baseline

**Dataset:** TandemFoil Paper (`tandemfoil_paper`)
**Primary metric:** `val_primary/field_mse` (lower is better)
**Current best:** 0.002383 at epoch 443 (PR #3025, seed=0 only — unreproducible with seeds 42/123/456)
**W&B run:** d1xh0o1p (haku/tfp-lion-champion-config)

| Metric | Value |
|---|---|
| val_primary/field_mse | 0.002383 |
| val/surface_mse | 0.001517 |
| val/surface_mse_p | 4.81e-05 |
| val/volume_mse | 0.002397 |

**Reproduce baseline:**
```
cd target/icml2026 && python train.py --dataset tandemfoil_paper --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.5 --weight-decay 1e-2 --enable-fourier --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --ema-decay 0.999
```

**NOTE:** The above reproduce command includes `--enable-cp-panel` and `--enable-pressure-prior-addition` which trigger the buggy code path. After your fix, this command should either work correctly or your fix should clarify which flags are safe to use for `tandemfoil_paper`.