### PR TITLE
Improve wandb-primary training diagnostics adoption

### DIFF
--- a/.agents/skills/wandb-primary/SKILL.md
+++ b/.agents/skills/wandb-primary/SKILL.md
@@ -22,11 +22,11 @@ Once you know the environment, **write your finding into this skill** by replaci
 
 <!-- AGENT: Replace the content between the ENVIRONMENT markers with the detected environment -->
 <!-- ENVIRONMENT_START -->
-**Detected Python environment:** _not yet detected_
+**Detected Python environment:** `uv` with a local `.venv`
 
 ```
-# Run command: <not yet detected>
-# Install command: <not yet detected>
+# Run command: uv run script.py
+# Install command: uv pip install <pkg>
 ```
 <!-- ENVIRONMENT_END -->
 
@@ -121,6 +121,27 @@ from curve_plots import (
 )
 ```
 
+### One-shot curve diagnostics CLI
+
+Use `scripts/curve_diagnostics_cli.py` when you want the default training-curve workflow without hand-writing a temporary script. It confirms the `step_key` (or refuses if ambiguous), prints helper-derived tables, and writes the standard PNGs.
+
+Run it with the command runner from the environment section above.
+
+```bash
+# Replace `python` with the runner from the environment section above if needed.
+python .agents/skills/wandb-primary/scripts/curve_diagnostics_cli.py \
+  --entity "$WANDB_ENTITY" \
+  --project "$WANDB_PROJECT" \
+  --run <run_id>
+
+python .agents/skills/wandb-primary/scripts/curve_diagnostics_cli.py \
+  --entity "$WANDB_ENTITY" \
+  --project "$WANDB_PROJECT" \
+  --run <run_id_a> \
+  --run <run_id_b> \
+  --metric <metric_key>
+```
+
 ### Reference docs
 
 Read these as needed — they contain full API surfaces and recipes:
@@ -183,17 +204,24 @@ This converts everything to plain Python dicts/lists that work with json, pandas
 
 ## Environment setup
 
-The sandbox has `wandb`, `weave`, `pandas`, and `numpy` pre-installed.
+The sandbox often has `wandb`, `weave`, `numpy`, and plotting/data packages available, but you should verify imports in the detected project environment before relying on them. In this repo's current `uv` environment, `pandas` was missing during audit-time verification even though the diagnostics helpers import it.
 
 ```python
 import os
+import importlib
+
 entity  = os.environ["WANDB_ENTITY"]
 project = os.environ["WANDB_PROJECT"]
+
+for module_name in ["wandb", "weave", "numpy", "matplotlib", "pandas"]:
+    importlib.import_module(module_name)
 ```
 
 ### Installing extra packages and running scripts
 
 Use whichever run/install commands you wrote in the **Python environment detection** section above. If you haven't detected the environment yet, go back and do that first.
+
+If one of the imports above fails, install the missing package before using `training_diagnostics`, `curve_plots`, or the CLI wrapper. The diagnostics stack imports `pandas` and `matplotlib` at module import time, so a missing dependency will fail fast.
 
 ---
 
@@ -339,6 +367,8 @@ Use `expr.Config("lr")`, `expr.Summary("loss")`, `expr.Tags().isin([...])` for r
 
 Use this when the user asks whether a run is healthy, why training diverged, whether a run overfit, or which run has the best training dynamics.
 
+This workflow is the default for curve-health questions. A raw W&B query plus hand-written curve narration is not enough unless the user explicitly asked for a quick scalar-only check.
+
 Keep the inline workflow short and load detail on demand:
 
 1. Confirm `step_key` before doing any curve work. Never assume `_step`.
@@ -347,6 +377,30 @@ Keep the inline workflow short and load detail on demand:
 4. Load `references/TRAINING_DIAGNOSTICS.md` while you interpret the results.
 5. End with a verdict, evidence tied to step ranges, and concrete next actions.
 
+### Stop signs
+
+If you catch yourself writing any of these phrases before running the helpers, stop and switch to the workflow or the CLI:
+
+- "trough envelope plateaued/regressed"
+- "gradient storm"
+- "restart disruption"
+- "spikes at cosine peaks"
+- "still descending at cutoff"
+- "best checkpoint not final"
+
+Those are exactly the cases the diagnostics helpers are meant to standardize.
+
+### Completion gate
+
+A curve-analysis answer is incomplete until it includes all of:
+
+1. The chosen `step_key` and why it was chosen.
+2. At least one helper-derived table (`curve_features`, `compare_runs_curves`, `lr_schedule_features`, or `grad_norm_features`).
+3. At least one rendered PNG (`plot_single_run_overview`, `plot_run_comparison`, `plot_grad_histogram_heatmap`, or `plot_grad_norm_by_layer`) unless the run truly lacks the required metrics.
+4. A verdict tied to specific steps, step ranges, or checkpoints.
+
+If you skip one of these, say why.
+
 ### Required sequence
 
 Use `list_candidate_step_keys()`, `guess_step_key_from_workspace()`, and `format_step_candidates()` to confirm the x-axis. If there is one obvious candidate and it matches the workspace guess, say which `step_key` you picked. Otherwise, ask the user to choose before plotting or comparing runs.
@@ -354,6 +408,20 @@ Use `list_candidate_step_keys()`, `guess_step_key_from_workspace()`, and `format
 For a single run, compute a compact feature table from the metrics that actually exist, then render `plot_single_run_overview(run, step_key=step_key)`. If gradient histograms or per-layer scalar norms are logged, add `plot_grad_histogram_heatmap()` or `plot_grad_norm_by_layer()`.
 
 For multi-run comparisons, use `compare_runs_curves()` for the ranking table and `plot_run_comparison()` for the overlay. Keep overlays to at most 6 runs; if there are more, rank first and then plot the shortlist.
+
+### Phrase-to-helper mapping
+
+| If you're about to say... | Compute / inspect first |
+|---|---|
+| "trough envelope plateaued/regressed" | `curve_features(...)[["final_10pct_mean", "final_10pct_std", "smoothness", "checkpoint_slopes"]]` |
+| "still descending at cutoff" | `curve_features` tail slope / final segment + `compare_runs_curves` ranking table |
+| "gradient storm" or "spikes at cosine peaks" | `grad_norm_features`, `lr_schedule_features`, and the LR + grad-norm panels in `plot_single_run_overview` |
+| "restart disruption" | `lr_schedule_features()["restart_steps"]` plus the comparison plot around the restart window |
+| "best checkpoint not final" or "late overfit" | `curve_features`, then the overfitting section of `references/TRAINING_DIAGNOSTICS.md` |
+
+### Fastest default path
+
+If the user wants the standard curve-analysis loop and you already know the run IDs, use the CLI above instead of building a throwaway script. It exists to lower the activation energy from "I know the heuristics" to "I actually ran the helpers".
 
 ### Output shape
 

--- a/.agents/skills/wandb-primary/references/TRAINING_DIAGNOSTICS.md
+++ b/.agents/skills/wandb-primary/references/TRAINING_DIAGNOSTICS.md
@@ -10,6 +10,22 @@ Use this as reference material while interpreting training curves. It captures t
 
 Recommended order: confirm the real `step_key`, compute features with `training_diagnostics.py`, open the PNGs from `curve_plots.py`, then use the heuristics below to write a verdict with step-indexed evidence.
 
+Before you narrate the curve:
+
+- Do not trust epoch-based trough timing until you confirm the real `step_key`. Many schedulers step per batch rather than per epoch, so "the trough should happen every N epochs" can be nonsense if you guessed the x-axis.
+- If you are about to describe "trough envelope plateau," "gradient storm," "restart disruption," or "late overfit" from memory alone, stop and compute the helper outputs first.
+
+## 0. Manual Phrase -> Helper Check
+
+| If you're about to say... | Verify with... |
+|---|---|
+| "trough envelope plateaued/regressed" | `curve_features`: `checkpoint_slopes`, `final_10pct_mean`, `final_10pct_std`, `smoothness` |
+| "still descending at cutoff" | `curve_features` tail slope and the final checkpoint segments |
+| "gradient storm" | `grad_norm_features` + LR panel from `plot_single_run_overview` |
+| "restart disruption" | `lr_schedule_features()["restart_steps"]` plus post-restart recovery on the plot |
+| "best checkpoint not final" | Overfitting signatures below + compare best checkpoint vs final tail |
+| "single best epoch wins" | `compare_runs_curves` with final mean, smoothness, slope, and spike count |
+
 ---
 
 ## 1. What a healthy loss curve looks like
@@ -54,6 +70,7 @@ Look at `checkpoint_slopes`. If the last 3 segments all sit near zero and the va
 - **Linear decay**: straight line from peak to final. Verify `decay_shape == "linear"`.
 - **Flat tail** (LR pinned at a small value for the final segment): often good; lets the model settle.
 - **Restarts**: `restart_steps` non-empty means LR went back up after its global peak. Intentional (SGDR) or a bug — ask before assuming.
+- **Restart spike triage**: a brief eval-loss blip right after a restart can be normal if the run quickly recovers to a new best and grad norms stay contained. Repeated worse troughs, rising clip counts, or a sustained grad-norm surge after the restart is real instability.
 - **Mismatch with loss**: if loss starts diverging right at the LR peak step, the peak is too high. If loss flatlines as soon as LR enters the decay segment, decay may be too aggressive.
 
 ## 6. Grad-norm intuition
@@ -61,6 +78,7 @@ Look at `checkpoint_slopes`. If the last 3 segments all sit near zero and the va
 - Early grad-norm **high and dropping** is normal — the model is adjusting large weights.
 - Stable mid-run grad-norm is good.
 - **Late-training grad-norm spikes** indicate instability. A single spike that recovers is fine; repeated spikes in the last 30% → lower LR or clip more aggressively.
+- **Gradient storm** is the informal name for repeated late spikes that coincide with worse troughs, rising clipping, or disrupted forward progress. If you use that phrase, tie it back to `grad_norm_features`, spike timing, and the LR schedule.
 - **Sudden drop to ~zero** (`dead_flag` in `grad_norm_features`) often means a layer died (ReLU collapse) or the schedule drove LR to zero prematurely.
 - **Kurtosis** > ~3 indicates heavy-tailed update distribution — often a sign of rare catastrophic updates that gradient clipping would catch.
 
@@ -89,6 +107,7 @@ Rules of thumb when ranking:
 
 - Prefer **smoother + slightly higher final** over **noisier + slightly lower final** when the gap is within 2× the final-10%-std.
 - A run that is still descending at 100% is evidence to **train longer**, not evidence that the hyperparameters are bad.
+- Do not rank by a single best epoch alone. Single-epoch bests are easy to overstate when the curve is noisy or cyclic.
 - If two runs tie on final metric but one has 10× more spikes, the stable one is the better policy for future work.
 - A run with lower peak-grad-norm at the same final metric is generally more robust.
 

--- a/.agents/skills/wandb-primary/scripts/curve_diagnostics_cli.py
+++ b/.agents/skills/wandb-primary/scripts/curve_diagnostics_cli.py
@@ -1,0 +1,317 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: skills
+
+"""One-shot CLI for the training-curve diagnostics workflow.
+
+This wrapper is intentionally opinionated:
+
+- it confirms or refuses `step_key` rather than silently guessing
+- it prints helper-derived tables instead of raw history rows
+- it writes the standard PNGs so the caller can inspect them visually
+
+Examples:
+    python .agents/skills/wandb-primary/scripts/curve_diagnostics_cli.py \
+        --entity "$WANDB_ENTITY" \
+        --project "$WANDB_PROJECT" \
+        --run abc123
+
+    python .agents/skills/wandb-primary/scripts/curve_diagnostics_cli.py \
+        --entity "$WANDB_ENTITY" \
+        --project "$WANDB_PROJECT" \
+        --run abc123 \
+        --run def456 \
+        --metric val_loss
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import sys
+from typing import Any
+
+pd = None
+wandb = None
+DEFAULT_OVERVIEW_METRICS = None
+plot_run_comparison = None
+plot_single_run_overview = None
+format_step_candidates = None
+guess_step_key_from_workspace = None
+list_candidate_step_keys = None
+compare_runs_curves = None
+curve_features = None
+grad_norm_features = None
+lr_schedule_features = None
+fast_scan_history = None
+
+
+def _import_runtime_deps() -> None:
+    global pd
+    global wandb
+    global DEFAULT_OVERVIEW_METRICS
+    global plot_run_comparison
+    global plot_single_run_overview
+    global format_step_candidates
+    global guess_step_key_from_workspace
+    global list_candidate_step_keys
+    global compare_runs_curves
+    global curve_features
+    global grad_norm_features
+    global lr_schedule_features
+    global fast_scan_history
+
+    required = ["pandas", "wandb", "numpy", "matplotlib"]
+    for module_name in required:
+        try:
+            importlib.import_module(module_name)
+        except ModuleNotFoundError as exc:
+            raise RuntimeError(
+                f"Missing dependency `{exc.name}`. Install it in the detected project "
+                "environment before using this CLI."
+            ) from exc
+
+    import pandas as pandas_module
+    import wandb as wandb_module
+    from curve_plots import DEFAULT_OVERVIEW_METRICS as overview_metrics
+    from curve_plots import plot_run_comparison as plot_comparison
+    from curve_plots import plot_single_run_overview as plot_overview
+    from step_axis import format_step_candidates as render_step_candidates
+    from step_axis import guess_step_key_from_workspace as workspace_step_guess
+    from step_axis import list_candidate_step_keys as candidate_step_keys
+    from training_diagnostics import compare_runs_curves as compare_curves
+    from training_diagnostics import curve_features as one_curve_features
+    from training_diagnostics import grad_norm_features as one_grad_norm_features
+    from training_diagnostics import lr_schedule_features as one_lr_schedule_features
+    from wandb_helpers import fast_scan_history as fast_history
+
+    pd = pandas_module
+    wandb = wandb_module
+    DEFAULT_OVERVIEW_METRICS = overview_metrics
+    plot_run_comparison = plot_comparison
+    plot_single_run_overview = plot_overview
+    format_step_candidates = render_step_candidates
+    guess_step_key_from_workspace = workspace_step_guess
+    list_candidate_step_keys = candidate_step_keys
+    compare_runs_curves = compare_curves
+    curve_features = one_curve_features
+    grad_norm_features = one_grad_norm_features
+    lr_schedule_features = one_lr_schedule_features
+    fast_scan_history = fast_history
+
+
+def _load_history_frame(run: Any, keys: list[str], step_key: str, samples: int = 2000) -> pd.DataFrame:
+    try:
+        df = run.history(samples=samples, keys=keys, x_axis=step_key, pandas=True)
+    except Exception:
+        df = None
+    if df is None or len(df) == 0 or step_key not in df.columns:
+        df = pd.DataFrame(list(fast_scan_history(run, keys=keys)))
+    return df
+
+
+def _resolve_metric(df_columns: set[str], candidates: list[str]) -> str | None:
+    for candidate in candidates:
+        if candidate in df_columns:
+            return candidate
+    return None
+
+
+def _choose_step_key(
+    runs: list[Any],
+    entity: str,
+    project: str,
+    explicit_step_key: str | None,
+) -> tuple[str, list[str], str | None]:
+    candidate_lists = [list_candidate_step_keys(run) for run in runs]
+    common_candidates = set(candidate_lists[0]) if candidate_lists else set()
+    for candidates in candidate_lists[1:]:
+        common_candidates &= set(candidates)
+
+    ordered_common = [c for c in candidate_lists[0] if c in common_candidates] if candidate_lists else []
+    workspace_guess = guess_step_key_from_workspace(entity, project)
+
+    if explicit_step_key:
+        missing = [run.id for run, candidates in zip(runs, candidate_lists) if explicit_step_key not in candidates]
+        if missing:
+            raise ValueError(
+                f"`{explicit_step_key}` is not a detected candidate for run(s): {', '.join(missing)}"
+            )
+        return explicit_step_key, ordered_common, workspace_guess
+
+    if len(ordered_common) == 1:
+        return ordered_common[0], ordered_common, workspace_guess
+
+    if workspace_guess and workspace_guess in ordered_common and len(ordered_common) == 1:
+        return workspace_guess, ordered_common, workspace_guess
+
+    rendered = format_step_candidates(ordered_common or candidate_lists[0], workspace_guess)
+    raise ValueError(
+        "Ambiguous step_key. Re-run with `--step-key` after checking these candidates:\n"
+        f"{rendered}"
+    )
+
+
+def _single_run_tables(run: Any, step_key: str) -> tuple[pd.DataFrame, pd.DataFrame]:
+    core_panels = [
+        ("train_loss", DEFAULT_OVERVIEW_METRICS["train_loss"]["keys"], "decreasing"),
+        ("val_loss", DEFAULT_OVERVIEW_METRICS["val_loss"]["keys"], "decreasing"),
+        ("grad_norm", DEFAULT_OVERVIEW_METRICS["grad_norm"]["keys"], "decreasing"),
+    ]
+    lr_candidates = DEFAULT_OVERVIEW_METRICS["lr"]["keys"]
+
+    history_keys = [step_key]
+    for _, candidates, _ in core_panels:
+        history_keys.extend(candidates)
+    history_keys.extend(lr_candidates)
+
+    df = _load_history_frame(run, keys=list(dict.fromkeys(history_keys)), step_key=step_key)
+    cols = set(df.columns)
+
+    curve_rows: list[dict[str, Any]] = []
+    for label, candidates, direction in core_panels:
+        resolved = _resolve_metric(cols, candidates)
+        if resolved is None:
+            continue
+        series = df[[step_key, resolved]].dropna()
+        if len(series) < 5:
+            continue
+        values = series[resolved].to_numpy()
+        steps = series[step_key].to_numpy()
+        if label == "grad_norm":
+            feats = grad_norm_features(values, steps)
+        else:
+            feats = curve_features(values, steps, direction=direction)
+        curve_rows.append(
+            {
+                "panel": label,
+                "metric_key": resolved,
+                "n_points": feats.get("n_points"),
+                "final_10pct_mean": feats.get("final_10pct_mean"),
+                "final_10pct_std": feats.get("final_10pct_std"),
+                "smoothness": feats.get("smoothness"),
+                "monotonicity_pct": feats.get("monotonicity_pct"),
+                "spike_count": feats.get("spike_count"),
+                "argmin_step": feats.get("argmin_step"),
+                "divergence_detected": feats.get("divergence", {}).get("detected"),
+                "kurtosis": feats.get("kurtosis"),
+                "dead_flag": feats.get("dead_flag"),
+            }
+        )
+
+    lr_rows: list[dict[str, Any]] = []
+    lr_key = _resolve_metric(cols, lr_candidates)
+    if lr_key is not None:
+        series = df[[step_key, lr_key]].dropna()
+        if len(series) >= 5:
+            feats = lr_schedule_features(
+                series[lr_key].to_numpy(),
+                series[step_key].to_numpy(),
+            )
+            lr_rows.append(
+                {
+                    "metric_key": lr_key,
+                    "peak_lr": feats.get("peak_lr"),
+                    "peak_step": feats.get("peak_step"),
+                    "warmup_steps": feats.get("warmup_steps"),
+                    "final_lr": feats.get("final_lr"),
+                    "decay_shape": feats.get("decay_shape"),
+                    "restart_steps": feats.get("restart_steps"),
+                }
+            )
+
+    return pd.DataFrame(curve_rows), pd.DataFrame(lr_rows)
+
+
+def _print_frame(title: str, df: pd.DataFrame) -> None:
+    print(f"\n## {title}")
+    if df.empty:
+        print("(no matching data found)")
+        return
+    print(df.to_string(index=False))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--entity", required=True, help="W&B entity")
+    parser.add_argument("--project", required=True, help="W&B project")
+    parser.add_argument("--run", dest="runs", action="append", required=True, help="Run id (repeatable)")
+    parser.add_argument("--metric", help="Metric to compare across runs when passing multiple --run values")
+    parser.add_argument("--step-key", help="Confirmed step-axis key. Required if the script reports ambiguity.")
+    parser.add_argument(
+        "--direction",
+        choices=["auto", "decreasing", "increasing"],
+        default="auto",
+        help="Curve direction for multi-run comparisons.",
+    )
+    args = parser.parse_args()
+
+    try:
+        _import_runtime_deps()
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    api = wandb.Api()
+    path = f"{args.entity}/{args.project}"
+    runs = [api.run(f"{path}/{run_id}") for run_id in args.runs]
+
+    try:
+        step_key, common_candidates, workspace_guess = _choose_step_key(
+            runs,
+            entity=args.entity,
+            project=args.project,
+            explicit_step_key=args.step_key,
+        )
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    print(f"Chosen step_key: {step_key}")
+    if common_candidates:
+        print(f"Common candidates: {common_candidates}")
+    if workspace_guess:
+        print(f"Workspace guess: {workspace_guess}")
+
+    if len(runs) == 1:
+        run = runs[0]
+        curve_df, lr_df = _single_run_tables(run, step_key=step_key)
+        overview_png = plot_single_run_overview(run, step_key=step_key)
+
+        print(f"Run: {run.name} [{run.id}]")
+        _print_frame("Curve Features", curve_df)
+        _print_frame("LR Schedule Features", lr_df)
+        print(f"\nOverview PNG: {overview_png}")
+        return 0
+
+    if not args.metric:
+        print("`--metric` is required when comparing multiple runs.", file=sys.stderr)
+        return 2
+
+    compare_df = compare_runs_curves(
+        runs,
+        metric=args.metric,
+        step_key=step_key,
+        direction=args.direction,
+    )
+    sort_ascending = args.direction != "increasing"
+    compare_df = compare_df.sort_values("final_10pct_mean", ascending=sort_ascending)
+
+    plot_runs = runs
+    if len(runs) > 6:
+        top_ids = compare_df["run_id"].tolist()[:6]
+        by_id = {run.id: run for run in runs}
+        plot_runs = [by_id[run_id] for run_id in top_ids]
+        print("More than 6 runs supplied; plotting the top 6 by final_10pct_mean.")
+
+    comparison_png = plot_run_comparison(plot_runs, metric=args.metric, step_key=step_key)
+
+    _print_frame(f"Run Comparison ({args.metric})", compare_df.reset_index())
+    if compare_df.attrs.get("warning"):
+        print(f"\nWarning: {compare_df.attrs['warning']}")
+    print(f"\nComparison PNG: {comparison_png}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,10 @@ results.tsv
 experiment_log/
 advisor_logs/
 student_logs/
+
+# Local scratch directories (not committed)
+.claude/worktrees/
+conversation_logs/
+analysis/operational_metrics/
+analysis/scratch/
+tm/

--- a/analysis/wandb_primary_training_diagnostics_adoption_audit_2026-04-23.md
+++ b/analysis/wandb_primary_training_diagnostics_adoption_audit_2026-04-23.md
@@ -1,0 +1,295 @@
+# W&B Primary Training Diagnostics Adoption Audit
+
+Date: 2026-04-23
+
+## Scope
+
+This audit covers the available `conversation_logs` window around the request date:
+
+- Present date folders: `2026-04-21`, `2026-04-22`
+- Missing date folders in the requested window: `2026-04-20`, `2026-04-23`
+- Archives scanned: `137` `.claude.tgz`
+- Embedded transcript files scanned: `1,388` `.jsonl`
+
+Method:
+
+1. Enumerate transcript-bearing archives across both dates.
+2. Search assistant, user, tool-result, and subagent records separately.
+3. Exclude the injected `wandb-primary` skill body itself when asking whether agents *used* the diagnostics helpers.
+4. Treat quoted PR text, GitHub comments, or other copied external text as weaker evidence than assistant-authored reasoning or commands.
+
+## Headline Findings
+
+### 1. The skill is being launched, but the packaged diagnostics helpers are not visibly being executed.
+
+High-confidence findings:
+
+- `41` assistant-side `wandb-primary` skill launches were found in the audited window.
+- `0` assistant-side invocations/imports were found for the concrete helper surface:
+  - `plot_single_run_overview`
+  - `compare_runs_curves`
+  - `plot_run_comparison`
+  - `curve_features`
+  - `lr_schedule_features`
+  - `grad_norm_features`
+  - `grad_histogram_features`
+  - `list_candidate_step_keys`
+  - `guess_step_key_from_workspace`
+
+Interpretation:
+
+- The skill is successfully triggered.
+- The current skill/reference shape is not reliably converting that trigger into actual helper usage.
+
+### 1b. There is also a concrete environment mismatch that can block helper adoption.
+
+Audit-time verification in the detected `uv` environment showed:
+
+- `wandb`: available
+- `weave`: available
+- `numpy`: available
+- `matplotlib`: available
+- `pandas`: missing
+
+Why this matters:
+
+- `training_diagnostics.py` and `curve_plots.py` import `pandas` at module import time.
+- A missing `pandas` means the diagnostics helper stack fails before any actual analysis begins.
+
+Interpretation:
+
+- Some of the observed non-adoption may be behavioral.
+- Some may be plain runtime friction: the helpers are not fully available in the detected project environment.
+
+### 2. The heuristics from `TRAINING_DIAGNOSTICS.md` *are* being used conceptually, often with high fidelity.
+
+Strong or medium evidence showed repeated manual use of:
+
+- step-axis correction and per-step scheduler reasoning
+- LR-peak spike analysis
+- plateau vs convergence distinctions
+- overfit after best-checkpoint reasoning
+- stability-aware run ranking
+- distinguishing normal restart blips from real instability
+- late-training grad-norm spike / "gradient storm" reasoning
+
+Interpretation:
+
+- Conceptual adoption is high.
+- Tool-level adoption is low.
+
+## Representative Evidence
+
+### Direct skill-launch evidence
+
+Representative archives with repeated `wandb-primary` launches:
+
+- `.agents/skills/wandb-primary` launched from advisor review subagents inside:
+  - `conversation_logs/2026-04-21/pai-2/advisor_restart_1822/advisor.claude.tgz`
+  - `conversation_logs/2026-04-21/pai-2/advisor_restart_2233/senpai-advisor-668b68b9f5-7bshd_root_.claude.tgz`
+  - `conversation_logs/2026-04-21/pai-2/advisor_restart_2356/senpai-advisor-9887f4d66-sbg2l_root_.claude.tgz`
+  - `conversation_logs/2026-04-22/k8s_pod_archive_185147/shouko/root_.claude.tgz`
+
+What did **not** show up after excluding injected skill text:
+
+- no assistant-authored `plot_single_run_overview(...)`
+- no assistant-authored `compare_runs_curves(...)`
+- no assistant-authored `plot_run_comparison(...)`
+- no assistant-authored `from training_diagnostics import ...`
+- no assistant-authored `from curve_plots import ...`
+
+### Heuristic adoption evidence
+
+#### Step-axis / x-axis semantics
+
+- `conversation_logs/2026-04-21/pai-2/luffy__senpai-luffy-787df5ff8c-lmxsw__claude.tgz`
+  - `.claude/projects/-workspace-senpai/bec791d0-8f08-4d65-8375-4a9f6cbb1a64.jsonl`
+  - `2026-04-21T05:04:24.299Z`
+  - The agent explicitly corrects the interpretation to scheduler steps per training step rather than per epoch and recalculates effective cosine-cycle frequency.
+
+- `conversation_logs/2026-04-22/k8s_pod_archive_185147/edward/root_.claude.tgz`
+  - `.claude/projects/-workspace-senpai/d7b38b16-3d3d-48b6-bc73-3ea736251bc5.jsonl`
+  - `2026-04-21T12:40:37.803Z`
+  - The agent revises trough analysis because the schedule operates per-step rather than per-epoch.
+
+#### Instability / spike reasoning
+
+- `conversation_logs/2026-04-22/k8s_pod_archive_185147/shouko/root_.claude.tgz`
+  - `.claude/projects/-workspace-senpai/eedbb179-9614-463e-b810-c2abc2555c32.jsonl`
+  - `2026-04-21T13:05:30.468Z`
+  - The agent ties a large loss spike and grad-norm spike directly to an LR peak.
+
+- `conversation_logs/2026-04-22/k8s_pod_archive_185147/chrome/root_.claude.tgz`
+  - `.claude/projects/-workspace-senpai/f88f2795-8aa8-4568-9ca7-0e1e482b9a10.jsonl`
+  - `2026-04-22T00:35:58.701Z`
+  - The agent diagnoses a late "gradient storm" and ranks runs by continued convergence vs disruption.
+
+- `conversation_logs/2026-04-22/k8s_pod_archive_185147/chrome/root_.claude.tgz`
+  - `.claude/projects/-workspace-senpai/f88f2795-8aa8-4568-9ca7-0e1e482b9a10.jsonl`
+  - `2026-04-22T03:05:32.980Z`
+  - The agent separates normal restart spikes from true instability by checking immediate recovery vs sustained damage.
+
+#### Plateau / convergence / overfit reasoning
+
+- `conversation_logs/2026-04-21/pai-2/advisor__senpai-advisor-7649cf9685-b6zjc__claude.tgz`
+  - `.claude/projects/-workspace-senpai/0d93f336-86f5-4b78-818d-220df0606f82.jsonl`
+  - `2026-04-21T10:05:46.573Z`
+  - The advisor segments the run into rapid descent, oscillating descent, and near-convergence, while noting slight overfit after the best epoch.
+
+- `conversation_logs/2026-04-21/pai-2/kill_immediate_1816/emma.claude.tgz`
+  - `.claude/projects/-workspace-senpai/f78343e3-0d09-4f4a-af66-1e8391b5d88e.jsonl`
+  - Multiple assistant-authored records describe the trough envelope as plateauing around `0.011-0.014` and explicitly compare basin quality across runs.
+
+- `conversation_logs/2026-04-22/k8s_pod_archive_185147/nezuko/root_.claude.tgz`
+  - `.claude/projects/-workspace-senpai/f793db55-c95b-4fab-ac18-dd470ad14ffa.jsonl`
+  - `2026-04-22T03:49:51.635Z`
+  - The agent compares successive troughs and labels a slight overfitting trend.
+
+#### Structured assistant-authored curve writeups
+
+- `conversation_logs/2026-04-21/pai-2/fern__senpai-fern-5c9766557c-7f8xv__claude.tgz`
+  - `.claude/projects/-workspace-senpai/ca0d1e4a-1a54-4aa7-965f-52bfa9fdde3d.jsonl`
+  - `2026-04-21T07:39:08.774Z`
+  - Assistant-authored PR comment uses a verdict, trough-envelope progression, grad-clip stats, and a plateau diagnosis.
+
+- `conversation_logs/2026-04-21/pai-2/fern__senpai-fern-5c9766557c-7f8xv__claude.tgz`
+  - `.claude/projects/-workspace-senpai/8adc937e-3a08-4a36-b1ee-2e649f9c92b9.jsonl`
+  - `2026-04-21T08:32:15.572Z`
+  - Assistant-authored comment includes a cosine-trough table, grad-norm trajectory table, and "no divergence / slower convergence" diagnosis.
+
+- `conversation_logs/2026-04-21/pai-2/senpai-tanjiro-75b9747f59-wspwz.claude.tgz`
+  - `.claude/projects/-workspace-senpai/e9a7e93f-576d-4c45-b9f2-f35c6afa8b05.jsonl`
+  - `2026-04-21T03:05:33.024Z`
+  - Assistant-authored results comment breaks the run into warmup vs post-warmup phases and ties best points to LR troughs.
+
+- `conversation_logs/2026-04-21/pai-2/senpai-shoya-7bcc8d6d47-sb677.claude.tgz`
+  - `.claude/projects/-workspace-senpai/8135e86a-f825-4f6f-9146-66bbc8fa7a29.jsonl`
+  - `2026-04-21T07:15:47.659Z`
+  - Assistant-authored comment includes a grad-norm stabilization table and a still-descending trough envelope diagnosis.
+
+- `conversation_logs/2026-04-22/k8s_pod_archive_185147/megumi/root_.claude.tgz`
+  - `.claude/projects/-workspace-senpai/9e00b322-16cd-4680-88ac-897a72c8189e/subagents/agent-a1643199da48054f5.jsonl`
+  - `2026-04-22T07:28:52.373Z`
+  - Assistant gives a healthy three-phase diagnosis, identifies a noisy plateau, and prefers the best checkpoint over the final one.
+
+## Diagnosis: Why adoption is uneven
+
+### Gap 1. The skill is easy to launch but too easy to use passively.
+
+Evidence:
+
+- `41` launches, `0` visible helper calls.
+- Agents often stop after querying W&B and then manually narrate the curves.
+
+Theory:
+
+- The current skill explains the workflow well, but it does not create enough pressure to *execute* it.
+- In practice, "I know what good and bad curves look like" beats "I should run the helper suite first."
+
+### Gap 2. The step-axis trap is real, but the current workflow does not feel mandatory enough.
+
+Evidence:
+
+- Luffy and Edward both had to correct their own analysis once they reasoned through per-step schedule semantics manually.
+
+Theory:
+
+- Agents are learning the lesson conceptually, but not associating it strongly enough with the `step_axis.py` helpers.
+- When the skill says "confirm `step_key`" without a hard failure mode, some agents still reason from epoch timing first.
+
+### Gap 3. Agents use natural phrases that are not directly mapped to helper calls.
+
+Evidence:
+
+- Common log phrases included "trough envelope plateaued," "gradient storm," "restart disruption," "still descending at cutoff," and "best checkpoint not final."
+
+Theory:
+
+- Those are exactly the right intuitions, but the skill mostly names the helper API surface, not the phrase-to-tool mapping.
+- If the agent cannot translate "gradient storm" into `grad_norm_features + lr_schedule_features + overview plot`, they keep analyzing manually.
+
+### Gap 4. There is no strong completion gate.
+
+Evidence:
+
+- Many assistant-authored analyses are thoughtful and detailed, but omit one or more of:
+  - explicit `step_key`
+  - helper-derived feature table
+  - generated PNG
+  - verdict tied to concrete step ranges
+
+Theory:
+
+- Without a completion gate, agents can stop once the narrative feels good enough.
+
+## Changes in This PR
+
+### 1. Add a one-shot diagnostics CLI
+
+File:
+
+- `.agents/skills/wandb-primary/scripts/curve_diagnostics_cli.py`
+
+Why:
+
+- The logs suggest that the current helper surface is too high-friction for routine use.
+- A single command that validates `step_key`, prints helper tables, and renders PNGs lowers the activation energy from "I know the workflow" to "I actually ran it."
+
+### 2. Make the workflow more mandatory
+
+Changes to:
+
+- `.agents/skills/wandb-primary/SKILL.md`
+
+Why:
+
+- The new wording makes curve analysis a default workflow rather than a polite suggestion.
+- The new completion gate is intended to prevent "query W&B, then narrate by hand" from counting as done.
+
+### 3. Add stop signs and phrase-to-helper mapping
+
+Changes to:
+
+- `.agents/skills/wandb-primary/SKILL.md`
+- `.agents/skills/wandb-primary/references/TRAINING_DIAGNOSTICS.md`
+
+Why:
+
+- This meets agents where the logs show they already are.
+- The skill now explicitly maps natural research phrases like "gradient storm" and "trough envelope plateaued" onto the helper calls that should back those claims.
+
+### 4. Strengthen step-axis and restart guidance
+
+Changes to:
+
+- `.agents/skills/wandb-primary/references/TRAINING_DIAGNOSTICS.md`
+
+Why:
+
+- Step-axis mistakes and restart interpretation showed up multiple times in the logs.
+- The updated reference now says those are mandatory checks, not just background nuance.
+
+### 5. Add explicit dependency preflight guidance
+
+Changes to:
+
+- `.agents/skills/wandb-primary/SKILL.md`
+- `.agents/skills/wandb-primary/scripts/curve_diagnostics_cli.py`
+
+Why:
+
+- The audit found that the detected `uv` environment currently lacks `pandas`, even though the diagnostics stack depends on it.
+- The skill now tells agents to verify imports before using the helpers, and the CLI now fails with a clear install message instead of a raw traceback.
+
+## Expected Impact
+
+If the changes work as intended, we should see:
+
+1. More assistant-side helper execution and fewer manual-only curve diagnoses.
+2. More analyses that explicitly name `step_key`.
+3. More outputs with helper-derived tables plus PNGs, rather than only prose.
+4. Fewer epoch-based misreads of step-based schedulers.
+
+## Caveat
+
+This is a log-based audit. It measures what was visible in conversation and tool transcripts. If an agent ever executed diagnostics logic in a way that never surfaced in the logs, this audit would not see it. Even with that caveat, the signal here is strong: conceptual adoption is already happening, while packaged-helper adoption is not yet happening reliably.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "weave",
     "tqdm",
     "matplotlib",
+    "pandas",
 ]
 
 [tool.setuptools.packages.find]

--- a/system_instructions/CLAUDE-STUDENT.md
+++ b/system_instructions/CLAUDE-STUDENT.md
@@ -99,6 +99,7 @@ swap_gh_pr_label <pr#> "status:wip" "status:review"
    - Exact train.py command used to run the experiment
    - Peak memory usage
    - W&B run ID
+   - Metric curves analysis: Detailed description of the relevant metrics curves (e.g. loss, reward, etc.). The goal is to provide a concise and clear description of the trends observed - different phases, spikes, plateaus, slopes, etc, as well as any diganostics for those observations. Use the wandb skill to help you with this. This information will be very helpful for future researchers trying to understand the quality of the training run.
    - **What happened** — honest analysis: did it work? why or why not?
    - **Suggested follow-ups** — what would you try next based on what you learned?
 

--- a/target/icml2026/airfrans/program.md
+++ b/target/icml2026/airfrans/program.md
@@ -34,6 +34,7 @@ Use the **official AirfRANS benchmark metric family**. For literature comparison
     - `loss_vol = loss_vol_var.mean()`
   - Finally average those case-level scalars over the evaluation split.
   - In the original AirfRANS training / scoring code, these MSEs are computed on the **normalized target tensors** produced by the official `Dataset(...)` loader using the training-set normalization coefficients, not on denormalized physical-unit fields.
+  - If training uses any extra target transform beyond that official z-score normalization, the paper-facing scorer must first map predictions back to raw target space and then recompute metrics with the official AirfRANS normalization only.
   - In the shared trainer, validation metrics are logged on `*_val` splits for model selection, while paper-facing comparison numbers come from the matching `*_test` split. The harness aliases these as `val_primary/surface_mse` and `test_primary/surface_mse`.
 
 - **Official target-field contract**
@@ -56,6 +57,7 @@ Use the **official AirfRANS benchmark metric family**. For literature comparison
     - the task name: `full`, `scarce`, `reynolds`, or `aoa`
     - `Surf MSE`
     - `Vol MSE`
+  - Always report both `Surf MSE` and `Vol MSE` together for paper-facing AirfRANS claims.
   - Do not relabel these as MAE or relative L2.
   - If a run is selected on validation, the final paper number must still be recomputed on the official task test split before citing it.
 

--- a/target/icml2026/drivaerml/program.md
+++ b/target/icml2026/drivaerml/program.md
@@ -79,14 +79,14 @@ Use the **DrivAerML relative-L2 contract** used by AB-UPT and continued in later
     `surface_cp` sprint target and shared-trainer implementation used in this repo.
   - The closest published surface-pressure references use the same nominal
     public DrivAerML train/val/test counts:
-    - `Transolver-3` (Table 4, `400 train / 34 effective val / 50 test`):
-      - `p_s = 3.71`
-    - `AB-UPT` (same table):
+    - `AB-UPT` (Table 4, `400 train / 34 effective val / 50 test`):
       - `p_s = 3.82`
-    - `Transolver++` (same table):
-      - `p_s = 4.12`
-    - `Transolver` (same table):
+    - `Transolver` baseline reported by `AB-UPT` on the same DrivAerML contract:
       - `p_s = 4.81`
+    - `Transolver-3` (Table 4, same public split family):
+      - `p_s = 3.71`
+    - `Transolver++` (later baseline row inside `Transolver-3` Table 4):
+      - `p_s = 4.12`
   - A separate `NeuralCFD` benchmark table reports `Transolver` at raw
     `L2 = 0.0388` on its own random `80/10/10` DrivAerML split with 40k sampled
     surface points. Interpreted on the percent scale used by
@@ -105,9 +105,10 @@ Use the **DrivAerML relative-L2 contract** used by AB-UPT and continued in later
 ## Sources
 
 - AB-UPT paper: <https://openreview.net/pdf?id=nwQ8nitlTZ>
+- AB-UPT arXiv mirror: <https://arxiv.org/abs/2502.09692>
 - `milieu_cfd` common evaluator: `scripts/eval_drivaerml.py` and `nn_cfd/noether/callbacks.py`
 - Transolver-3 paper: <https://arxiv.org/abs/2602.04940>
-- NeuralCFD paper: <https://arxiv.org/abs/2502.09692>
+- DrivAerML dataset paper: <https://arxiv.org/abs/2408.11969>
 
 ## Training schedules in related work
 

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -168,6 +168,19 @@ class TargetTransform:
         return out
 
 
+def airfrans_official_metric_tensors(
+    preds: torch.Tensor,
+    target: torch.Tensor,
+    *,
+    train_transform: TargetTransform,
+    metric_transform: TargetTransform | None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if metric_transform is None:
+        return preds, train_transform.apply(target)
+    pred_raw = train_transform.invert(preds)
+    return metric_transform.apply(pred_raw), metric_transform.apply(target)
+
+
 class TandemTargetTransform:
     def __init__(
         self,
@@ -735,6 +748,7 @@ def evaluate_grouped(
     anp_head: ANPSurfaceDecoder | None,
     loader: DataLoader,
     transform: TargetTransform | TandemTargetTransform,
+    metric_transform: TargetTransform | None,
     device: torch.device,
     *,
     amp_mode: str = "none",
@@ -812,9 +826,16 @@ def evaluate_grouped(
             )
         outputs = float_outputs(outputs)
         if dataset_name == "airfrans":
+            if not isinstance(transform, TargetTransform):
+                raise TypeError("AirfRANS evaluation requires TargetTransform")
             if batch.surface_y is not None and outputs["surface_preds"] is not None:
-                target = transform.apply(batch.surface_y)
-                case_values = (outputs["surface_preds"] - target).square()
+                surface_pred, surface_target = airfrans_official_metric_tensors(
+                    outputs["surface_preds"],
+                    batch.surface_y,
+                    train_transform=transform,
+                    metric_transform=metric_transform,
+                )
+                case_values = (surface_pred - surface_target).square()
                 for case_idx in range(case_values.shape[0]):
                     channel_mean = _case_masked_channel_means(case_values[case_idx], batch.surface_mask[case_idx])
                     if channel_mean is not None:
@@ -824,8 +845,13 @@ def evaluate_grouped(
                             surf_channel_sum = torch.zeros(channel_mean.shape[0], device=device)
                         surf_channel_sum += channel_mean.to(device)
             if batch.volume_y is not None and outputs["volume_preds"] is not None and batch.volume_mask is not None:
-                target = transform.apply(batch.volume_y)
-                case_values = (outputs["volume_preds"] - target).square()
+                volume_pred, volume_target = airfrans_official_metric_tensors(
+                    outputs["volume_preds"],
+                    batch.volume_y,
+                    train_transform=transform,
+                    metric_transform=metric_transform,
+                )
+                case_values = (volume_pred - volume_target).square()
                 for case_idx in range(case_values.shape[0]):
                     channel_mean = _case_masked_channel_means(case_values[case_idx], batch.volume_mask[case_idx])
                     if channel_mean is not None:
@@ -981,6 +1007,7 @@ def evaluate_abupt(
     model: torch.nn.Module,
     loader: DataLoader,
     transform: TargetTransform,
+    metric_transform: TargetTransform | None,
     device: torch.device,
     *,
     amp_mode: str = "none",
@@ -1013,16 +1040,26 @@ def evaluate_abupt(
         outputs = float_outputs(outputs)
         if dataset_name == "airfrans":
             if batch.surface_anchor_target is not None and outputs["surface_preds"] is not None:
-                target = transform.apply(batch.surface_anchor_target)
-                channel_mean = (outputs["surface_preds"] - target).square().mean(dim=(0, 1))
+                surface_pred, surface_target = airfrans_official_metric_tensors(
+                    outputs["surface_preds"],
+                    batch.surface_anchor_target,
+                    train_transform=transform,
+                    metric_transform=metric_transform,
+                )
+                channel_mean = (surface_pred - surface_target).square().mean(dim=(0, 1))
                 total_surface += float(channel_mean.mean().detach().cpu().item())
                 count_surface += 1
                 if surf_channel_sum is None:
                     surf_channel_sum = torch.zeros(channel_mean.shape[0], device=device)
                 surf_channel_sum += channel_mean.to(device)
             if batch.volume_anchor_target is not None and outputs["volume_preds"] is not None:
-                target = transform.apply(batch.volume_anchor_target)
-                channel_mean = (outputs["volume_preds"] - target).square().mean(dim=(0, 1))
+                volume_pred, volume_target = airfrans_official_metric_tensors(
+                    outputs["volume_preds"],
+                    batch.volume_anchor_target,
+                    train_transform=transform,
+                    metric_transform=metric_transform,
+                )
+                channel_mean = (volume_pred - volume_target).square().mean(dim=(0, 1))
                 total_volume += float(channel_mean.mean().detach().cpu().item())
                 count_volume += 1
                 if vol_channel_sum is None:
@@ -1276,6 +1313,7 @@ def evaluate_phase_metrics(
     anp_head: ANPSurfaceDecoder | None,
     loaders: dict[str, DataLoader],
     transform: TargetTransform | TandemTargetTransform,
+    metric_transform: TargetTransform | None,
     device: torch.device,
     phase: str,
 ) -> dict[str, float]:
@@ -1286,6 +1324,7 @@ def evaluate_phase_metrics(
                 forward_model,
                 loader,
                 transform,
+                metric_transform,
                 device,
                 amp_mode=config.amp_mode,
                 max_batches=config.max_eval_batches,
@@ -1296,6 +1335,7 @@ def evaluate_phase_metrics(
                 anp_head,
                 loader,
                 transform,
+                metric_transform,
                 device,
                 amp_mode=config.amp_mode,
                 max_batches=config.max_eval_batches,
@@ -1375,6 +1415,7 @@ def main() -> None:
             phys_stats=phys_stats,
             config=config,
         )
+        metric_transform = None
     else:
         transform = TargetTransform(
             pressure_index=bundle.spec.pressure_output_index,
@@ -1383,6 +1424,15 @@ def main() -> None:
             asinh_pressure=config.asinh_pressure,
             asinh_scale=config.asinh_scale,
         )
+        metric_transform = None
+        if bundle.spec.name == "airfrans":
+            metric_transform = TargetTransform(
+                pressure_index=bundle.spec.pressure_output_index,
+                stats_mean=bundle.target_stats.y_mean,
+                stats_std=bundle.target_stats.y_std,
+                asinh_pressure=False,
+                asinh_scale=config.asinh_scale,
+            )
 
     train_loader, val_loaders, test_loaders = build_loaders(config, bundle, num_workers=resolved_num_workers)
     model = build_model(config, bundle).to(device)
@@ -1459,6 +1509,7 @@ def main() -> None:
             anp_head=anp_head,
             loaders=val_loaders,
             transform=transform,
+            metric_transform=metric_transform,
             device=device,
             phase="val",
         )
@@ -1518,6 +1569,7 @@ def main() -> None:
             anp_head=anp_head,
             loaders=test_loaders,
             transform=transform,
+            metric_transform=metric_transform,
             device=device,
             phase="test",
         )
@@ -1543,6 +1595,7 @@ def main() -> None:
                 anp_head=anp_head,
                 loaders=test_loaders,
                 transform=transform,
+                metric_transform=metric_transform,
                 device=device,
                 phase="test",
             )

--- a/uv.lock
+++ b/uv.lock
@@ -2,11 +2,21 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
-    "python_full_version == '3.11.*'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version < '3.11'",
 ]
+
+[options]
+exclude-newer = "2026-04-16T12:59:01.569642Z"
+exclude-newer-span = "P7D"
 
 [[package]]
 name = "abnf"
@@ -688,9 +698,15 @@ name = "contourpy"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
-    "python_full_version == '3.11.*'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -835,7 +851,7 @@ name = "cuda-bindings"
 version = "12.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/d8/b546104b8da3f562c1ff8ab36d130c8fe1dd6a045ced80b4f6ad74f7d4e1/cuda_bindings-12.9.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d3c842c2a4303b2a580fe955018e31aea30278be19795ae05226235268032e5", size = 12148218, upload-time = "2025-10-21T14:51:28.855Z" },
@@ -1410,7 +1426,9 @@ name = "ipython"
 version = "9.10.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.11.*'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "colorama", marker = "python_full_version == '3.11.*' and sys_platform == 'win32'" },
@@ -1435,8 +1453,12 @@ name = "ipython"
 version = "9.11.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
@@ -2356,9 +2378,15 @@ name = "networkx"
 version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
-    "python_full_version == '3.11.*'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
 wheels = [
@@ -2463,9 +2491,15 @@ name = "numpy"
 version = "2.4.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
-    "python_full_version == '3.11.*'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/10/8b/c265f4823726ab832de836cdd184d0986dcf94480f81e8739692a7ac7af2/numpy-2.4.3.tar.gz", hash = "sha256:483a201202b73495f00dbc83796c6ae63137a9bdade074f7648b3e32613412dd", size = 20727743, upload-time = "2026-03-09T07:58:53.426Z" }
 wheels = [
@@ -2579,7 +2613,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -2590,7 +2624,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -2617,9 +2651,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cusparse-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -2630,7 +2664,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -2695,6 +2729,141 @@ wheels = [
 ]
 
 [[package]]
+name = "pandas"
+version = "2.3.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "pytz", marker = "python_full_version < '3.11'" },
+    { name = "tzdata", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/f7/f425a00df4fcc22b292c6895c6831c0c8ae1d9fac1e024d16f98a9ce8749/pandas-2.3.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:376c6446ae31770764215a6c937f72d917f214b43560603cd60da6408f183b6c", size = 11555763, upload-time = "2025-09-29T23:16:53.287Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4f/66d99628ff8ce7857aca52fed8f0066ce209f96be2fede6cef9f84e8d04f/pandas-2.3.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e19d192383eab2f4ceb30b412b22ea30690c9e618f78870357ae1d682912015a", size = 10801217, upload-time = "2025-09-29T23:17:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/03/3fc4a529a7710f890a239cc496fc6d50ad4a0995657dccc1d64695adb9f4/pandas-2.3.3-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5caf26f64126b6c7aec964f74266f435afef1c1b13da3b0636c7518a1fa3e2b1", size = 12148791, upload-time = "2025-09-29T23:17:18.444Z" },
+    { url = "https://files.pythonhosted.org/packages/40/a8/4dac1f8f8235e5d25b9955d02ff6f29396191d4e665d71122c3722ca83c5/pandas-2.3.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd7478f1463441ae4ca7308a70e90b33470fa593429f9d4c578dd00d1fa78838", size = 12769373, upload-time = "2025-09-29T23:17:35.846Z" },
+    { url = "https://files.pythonhosted.org/packages/df/91/82cc5169b6b25440a7fc0ef3a694582418d875c8e3ebf796a6d6470aa578/pandas-2.3.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4793891684806ae50d1288c9bae9330293ab4e083ccd1c5e383c34549c6e4250", size = 13200444, upload-time = "2025-09-29T23:17:49.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/ae/89b3283800ab58f7af2952704078555fa60c807fff764395bb57ea0b0dbd/pandas-2.3.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:28083c648d9a99a5dd035ec125d42439c6c1c525098c58af0fc38dd1a7a1b3d4", size = 13858459, upload-time = "2025-09-29T23:18:03.722Z" },
+    { url = "https://files.pythonhosted.org/packages/85/72/530900610650f54a35a19476eca5104f38555afccda1aa11a92ee14cb21d/pandas-2.3.3-cp310-cp310-win_amd64.whl", hash = "sha256:503cf027cf9940d2ceaa1a93cfb5f8c8c7e6e90720a2850378f0b3f3b1e06826", size = 11346086, upload-time = "2025-09-29T23:18:18.505Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fa/7ac648108144a095b4fb6aa3de1954689f7af60a14cf25583f4960ecb878/pandas-2.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:602b8615ebcc4a0c1751e71840428ddebeb142ec02c786e8ad6b1ce3c8dec523", size = 11578790, upload-time = "2025-09-29T23:18:30.065Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/35/74442388c6cf008882d4d4bdfc4109be87e9b8b7ccd097ad1e7f006e2e95/pandas-2.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8fe25fc7b623b0ef6b5009149627e34d2a4657e880948ec3c840e9402e5c1b45", size = 10833831, upload-time = "2025-09-29T23:38:56.071Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e4/de154cbfeee13383ad58d23017da99390b91d73f8c11856f2095e813201b/pandas-2.3.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b468d3dad6ff947df92dcb32ede5b7bd41a9b3cceef0a30ed925f6d01fb8fa66", size = 12199267, upload-time = "2025-09-29T23:18:41.627Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c9/63f8d545568d9ab91476b1818b4741f521646cbdd151c6efebf40d6de6f7/pandas-2.3.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b98560e98cb334799c0b07ca7967ac361a47326e9b4e5a7dfb5ab2b1c9d35a1b", size = 12789281, upload-time = "2025-09-29T23:18:56.834Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/00/a5ac8c7a0e67fd1a6059e40aa08fa1c52cc00709077d2300e210c3ce0322/pandas-2.3.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37b5848ba49824e5c30bedb9c830ab9b7751fd049bc7914533e01c65f79791", size = 13240453, upload-time = "2025-09-29T23:19:09.247Z" },
+    { url = "https://files.pythonhosted.org/packages/27/4d/5c23a5bc7bd209231618dd9e606ce076272c9bc4f12023a70e03a86b4067/pandas-2.3.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:db4301b2d1f926ae677a751eb2bd0e8c5f5319c9cb3f88b0becbbb0b07b34151", size = 13890361, upload-time = "2025-09-29T23:19:25.342Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/59/712db1d7040520de7a4965df15b774348980e6df45c129b8c64d0dbe74ef/pandas-2.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:f086f6fe114e19d92014a1966f43a3e62285109afe874f067f5abbdcbb10e59c", size = 11348702, upload-time = "2025-09-29T23:19:38.296Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/fb/231d89e8637c808b997d172b18e9d4a4bc7bf31296196c260526055d1ea0/pandas-2.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d21f6d74eb1725c2efaa71a2bfc661a0689579b58e9c0ca58a739ff0b002b53", size = 11597846, upload-time = "2025-09-29T23:19:48.856Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/bd/bf8064d9cfa214294356c2d6702b716d3cf3bb24be59287a6a21e24cae6b/pandas-2.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3fd2f887589c7aa868e02632612ba39acb0b8948faf5cc58f0850e165bd46f35", size = 10729618, upload-time = "2025-09-29T23:39:08.659Z" },
+    { url = "https://files.pythonhosted.org/packages/57/56/cf2dbe1a3f5271370669475ead12ce77c61726ffd19a35546e31aa8edf4e/pandas-2.3.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecaf1e12bdc03c86ad4a7ea848d66c685cb6851d807a26aa245ca3d2017a1908", size = 11737212, upload-time = "2025-09-29T23:19:59.765Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/63/cd7d615331b328e287d8233ba9fdf191a9c2d11b6af0c7a59cfcec23de68/pandas-2.3.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b3d11d2fda7eb164ef27ffc14b4fcab16a80e1ce67e9f57e19ec0afaf715ba89", size = 12362693, upload-time = "2025-09-29T23:20:14.098Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/de/8b1895b107277d52f2b42d3a6806e69cfef0d5cf1d0ba343470b9d8e0a04/pandas-2.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a68e15f780eddf2b07d242e17a04aa187a7ee12b40b930bfdd78070556550e98", size = 12771002, upload-time = "2025-09-29T23:20:26.76Z" },
+    { url = "https://files.pythonhosted.org/packages/87/21/84072af3187a677c5893b170ba2c8fbe450a6ff911234916da889b698220/pandas-2.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:371a4ab48e950033bcf52b6527eccb564f52dc826c02afd9a1bc0ab731bba084", size = 13450971, upload-time = "2025-09-29T23:20:41.344Z" },
+    { url = "https://files.pythonhosted.org/packages/86/41/585a168330ff063014880a80d744219dbf1dd7a1c706e75ab3425a987384/pandas-2.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:a16dcec078a01eeef8ee61bf64074b4e524a2a3f4b3be9326420cabe59c4778b", size = 10992722, upload-time = "2025-09-29T23:20:54.139Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/4b/18b035ee18f97c1040d94debd8f2e737000ad70ccc8f5513f4eefad75f4b/pandas-2.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:56851a737e3470de7fa88e6131f41281ed440d29a9268dcbf0002da5ac366713", size = 11544671, upload-time = "2025-09-29T23:21:05.024Z" },
+    { url = "https://files.pythonhosted.org/packages/31/94/72fac03573102779920099bcac1c3b05975c2cb5f01eac609faf34bed1ca/pandas-2.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bdcd9d1167f4885211e401b3036c0c8d9e274eee67ea8d0758a256d60704cfe8", size = 10680807, upload-time = "2025-09-29T23:21:15.979Z" },
+    { url = "https://files.pythonhosted.org/packages/16/87/9472cf4a487d848476865321de18cc8c920b8cab98453ab79dbbc98db63a/pandas-2.3.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e32e7cc9af0f1cc15548288a51a3b681cc2a219faa838e995f7dc53dbab1062d", size = 11709872, upload-time = "2025-09-29T23:21:27.165Z" },
+    { url = "https://files.pythonhosted.org/packages/15/07/284f757f63f8a8d69ed4472bfd85122bd086e637bf4ed09de572d575a693/pandas-2.3.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:318d77e0e42a628c04dc56bcef4b40de67918f7041c2b061af1da41dcff670ac", size = 12306371, upload-time = "2025-09-29T23:21:40.532Z" },
+    { url = "https://files.pythonhosted.org/packages/33/81/a3afc88fca4aa925804a27d2676d22dcd2031c2ebe08aabd0ae55b9ff282/pandas-2.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4e0a175408804d566144e170d0476b15d78458795bb18f1304fb94160cabf40c", size = 12765333, upload-time = "2025-09-29T23:21:55.77Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/0f/b4d4ae743a83742f1153464cf1a8ecfafc3ac59722a0b5c8602310cb7158/pandas-2.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:93c2d9ab0fc11822b5eece72ec9587e172f63cff87c00b062f6e37448ced4493", size = 13418120, upload-time = "2025-09-29T23:22:10.109Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c7/e54682c96a895d0c808453269e0b5928a07a127a15704fedb643e9b0a4c8/pandas-2.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:f8bfc0e12dc78f777f323f55c58649591b2cd0c43534e8355c51d3fede5f4dee", size = 10993991, upload-time = "2025-09-29T23:25:04.889Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ca/3f8d4f49740799189e1395812f3bf23b5e8fc7c190827d55a610da72ce55/pandas-2.3.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:75ea25f9529fdec2d2e93a42c523962261e567d250b0013b16210e1d40d7c2e5", size = 12048227, upload-time = "2025-09-29T23:22:24.343Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/5a/f43efec3e8c0cc92c4663ccad372dbdff72b60bdb56b2749f04aa1d07d7e/pandas-2.3.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:74ecdf1d301e812db96a465a525952f4dde225fdb6d8e5a521d47e1f42041e21", size = 11411056, upload-time = "2025-09-29T23:22:37.762Z" },
+    { url = "https://files.pythonhosted.org/packages/46/b1/85331edfc591208c9d1a63a06baa67b21d332e63b7a591a5ba42a10bb507/pandas-2.3.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6435cb949cb34ec11cc9860246ccb2fdc9ecd742c12d3304989017d53f039a78", size = 11645189, upload-time = "2025-09-29T23:22:51.688Z" },
+    { url = "https://files.pythonhosted.org/packages/44/23/78d645adc35d94d1ac4f2a3c4112ab6f5b8999f4898b8cdf01252f8df4a9/pandas-2.3.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:900f47d8f20860de523a1ac881c4c36d65efcb2eb850e6948140fa781736e110", size = 12121912, upload-time = "2025-09-29T23:23:05.042Z" },
+    { url = "https://files.pythonhosted.org/packages/53/da/d10013df5e6aaef6b425aa0c32e1fc1f3e431e4bcabd420517dceadce354/pandas-2.3.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a45c765238e2ed7d7c608fc5bc4a6f88b642f2f01e70c0c23d2224dd21829d86", size = 12712160, upload-time = "2025-09-29T23:23:28.57Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/17/e756653095a083d8a37cbd816cb87148debcfcd920129b25f99dd8d04271/pandas-2.3.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c4fc4c21971a1a9f4bdb4c73978c7f7256caa3e62b323f70d6cb80db583350bc", size = 13199233, upload-time = "2025-09-29T23:24:24.876Z" },
+    { url = "https://files.pythonhosted.org/packages/04/fd/74903979833db8390b73b3a8a7d30d146d710bd32703724dd9083950386f/pandas-2.3.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:ee15f284898e7b246df8087fc82b87b01686f98ee67d85a17b7ab44143a3a9a0", size = 11540635, upload-time = "2025-09-29T23:25:52.486Z" },
+    { url = "https://files.pythonhosted.org/packages/21/00/266d6b357ad5e6d3ad55093a7e8efc7dd245f5a842b584db9f30b0f0a287/pandas-2.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1611aedd912e1ff81ff41c745822980c49ce4a7907537be8692c8dbc31924593", size = 10759079, upload-time = "2025-09-29T23:26:33.204Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/05/d01ef80a7a3a12b2f8bbf16daba1e17c98a2f039cbc8e2f77a2c5a63d382/pandas-2.3.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d2cefc361461662ac48810cb14365a365ce864afe85ef1f447ff5a1e99ea81c", size = 11814049, upload-time = "2025-09-29T23:27:15.384Z" },
+    { url = "https://files.pythonhosted.org/packages/15/b2/0e62f78c0c5ba7e3d2c5945a82456f4fac76c480940f805e0b97fcbc2f65/pandas-2.3.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ee67acbbf05014ea6c763beb097e03cd629961c8a632075eeb34247120abcb4b", size = 12332638, upload-time = "2025-09-29T23:27:51.625Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/33/dd70400631b62b9b29c3c93d2feee1d0964dc2bae2e5ad7a6c73a7f25325/pandas-2.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c46467899aaa4da076d5abc11084634e2d197e9460643dd455ac3db5856b24d6", size = 12886834, upload-time = "2025-09-29T23:28:21.289Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/18/b5d48f55821228d0d2692b34fd5034bb185e854bdb592e9c640f6290e012/pandas-2.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6253c72c6a1d990a410bc7de641d34053364ef8bcd3126f7e7450125887dffe3", size = 13409925, upload-time = "2025-09-29T23:28:58.261Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/3d/124ac75fcd0ecc09b8fdccb0246ef65e35b012030defb0e0eba2cbbbe948/pandas-2.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:1b07204a219b3b7350abaae088f451860223a52cfb8a6c53358e7948735158e5", size = 11109071, upload-time = "2025-09-29T23:32:27.484Z" },
+    { url = "https://files.pythonhosted.org/packages/89/9c/0e21c895c38a157e0faa1fb64587a9226d6dd46452cac4532d80c3c4a244/pandas-2.3.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2462b1a365b6109d275250baaae7b760fd25c726aaca0054649286bcfbb3e8ec", size = 12048504, upload-time = "2025-09-29T23:29:31.47Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/82/b69a1c95df796858777b68fbe6a81d37443a33319761d7c652ce77797475/pandas-2.3.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0242fe9a49aa8b4d78a4fa03acb397a58833ef6199e9aa40a95f027bb3a1b6e7", size = 11410702, upload-time = "2025-09-29T23:29:54.591Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/88/702bde3ba0a94b8c73a0181e05144b10f13f29ebfc2150c3a79062a8195d/pandas-2.3.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a21d830e78df0a515db2b3d2f5570610f5e6bd2e27749770e8bb7b524b89b450", size = 11634535, upload-time = "2025-09-29T23:30:21.003Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/1e/1bac1a839d12e6a82ec6cb40cda2edde64a2013a66963293696bbf31fbbb/pandas-2.3.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2e3ebdb170b5ef78f19bfb71b0dc5dc58775032361fa188e814959b74d726dd5", size = 12121582, upload-time = "2025-09-29T23:30:43.391Z" },
+    { url = "https://files.pythonhosted.org/packages/44/91/483de934193e12a3b1d6ae7c8645d083ff88dec75f46e827562f1e4b4da6/pandas-2.3.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d051c0e065b94b7a3cea50eb1ec32e912cd96dba41647eb24104b6c6c14c5788", size = 12699963, upload-time = "2025-09-29T23:31:10.009Z" },
+    { url = "https://files.pythonhosted.org/packages/70/44/5191d2e4026f86a2a109053e194d3ba7a31a2d10a9c2348368c63ed4e85a/pandas-2.3.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3869faf4bd07b3b66a9f462417d0ca3a9df29a9f6abd5d0d0dbab15dac7abe87", size = 13202175, upload-time = "2025-09-29T23:31:59.173Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/99/b342345300f13440fe9fe385c3c481e2d9a595ee3bab4d3219247ac94e9a/pandas-3.0.2.tar.gz", hash = "sha256:f4753e73e34c8d83221ba58f232433fca2748be8b18dbca02d242ed153945043", size = 4645855, upload-time = "2026-03-31T06:48:30.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/35/6411db530c618e0e0005187e35aa02ce60ae4c4c4d206964a2f978217c27/pandas-3.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a727a73cbdba2f7458dc82449e2315899d5140b449015d822f515749a46cbbe0", size = 10326926, upload-time = "2026-03-31T06:46:08.29Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/d3/b7da1d5d7dbdc5ef52ed7debd2b484313b832982266905315dad5a0bf0b1/pandas-3.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dbbd4aa20ca51e63b53bbde6a0fa4254b1aaabb74d2f542df7a7959feb1d760c", size = 9926987, upload-time = "2026-03-31T06:46:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/52/77/9b1c2d6070b5dbe239a7bc889e21bfa58720793fb902d1e070695d87c6d0/pandas-3.0.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:339dda302bd8369dedeae979cb750e484d549b563c3f54f3922cb8ff4978c5eb", size = 10757067, upload-time = "2026-03-31T06:46:14.903Z" },
+    { url = "https://files.pythonhosted.org/packages/20/17/ec40d981705654853726e7ac9aea9ddbb4a5d9cf54d8472222f4f3de06c2/pandas-3.0.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:61c2fd96d72b983a9891b2598f286befd4ad262161a609c92dc1652544b46b76", size = 11258787, upload-time = "2026-03-31T06:46:17.683Z" },
+    { url = "https://files.pythonhosted.org/packages/90/e3/3f1126d43d3702ca8773871a81c9f15122a1f412342cc56284ffda5b1f70/pandas-3.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c934008c733b8bbea273ea308b73b3156f0181e5b72960790b09c18a2794fe1e", size = 11771616, upload-time = "2026-03-31T06:46:20.532Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/cf/0f4e268e1f5062e44a6bda9f925806721cd4c95c2b808a4c82ebe914f96b/pandas-3.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:60a80bb4feacbef5e1447a3f82c33209c8b7e07f28d805cfd1fb951e5cb443aa", size = 12337623, upload-time = "2026-03-31T06:46:23.754Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/97a6339859d4acb2536efb24feb6708e82f7d33b2ed7e036f2983fcced82/pandas-3.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:ed72cb3f45190874eb579c64fa92d9df74e98fd63e2be7f62bce5ace0ade61df", size = 9897372, upload-time = "2026-03-31T06:46:26.703Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/eb/781516b808a99ddf288143cec46b342b3016c3414d137da1fdc3290d8860/pandas-3.0.2-cp311-cp311-win_arm64.whl", hash = "sha256:f12b1a9e332c01e09510586f8ca9b108fd631fd656af82e452d7315ef6df5f9f", size = 9154922, upload-time = "2026-03-31T06:46:30.284Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/b0/c20bd4d6d3f736e6bd6b55794e9cd0a617b858eaad27c8f410ea05d953b7/pandas-3.0.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:232a70ebb568c0c4d2db4584f338c1577d81e3af63292208d615907b698a0f18", size = 10347921, upload-time = "2026-03-31T06:46:33.36Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d0/4831af68ce30cc2d03c697bea8450e3225a835ef497d0d70f31b8cdde965/pandas-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:970762605cff1ca0d3f71ed4f3a769ea8f85fc8e6348f6e110b8fea7e6eb5a14", size = 9888127, upload-time = "2026-03-31T06:46:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a9/16ea9346e1fc4a96e2896242d9bc674764fb9049b0044c0132502f7a771e/pandas-3.0.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aff4e6f4d722e0652707d7bcb190c445fe58428500c6d16005b02401764b1b3d", size = 10399577, upload-time = "2026-03-31T06:46:39.224Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a8/3a61a721472959ab0ce865ef05d10b0d6bfe27ce8801c99f33d4fa996e65/pandas-3.0.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ef8b27695c3d3dc78403c9a7d5e59a62d5464a7e1123b4e0042763f7104dc74f", size = 10880030, upload-time = "2026-03-31T06:46:42.412Z" },
+    { url = "https://files.pythonhosted.org/packages/da/65/7225c0ea4d6ce9cb2160a7fb7f39804871049f016e74782e5dade4d14109/pandas-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f8d68083e49e16b84734eb1a4dcae4259a75c90fb6e2251ab9a00b61120c06ab", size = 11409468, upload-time = "2026-03-31T06:46:45.2Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5b/46e7c76032639f2132359b5cf4c785dd8cf9aea5ea64699eac752f02b9db/pandas-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:32cc41f310ebd4a296d93515fcac312216adfedb1894e879303987b8f1e2b97d", size = 11936381, upload-time = "2026-03-31T06:46:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/8b/721a9cff6fa6a91b162eb51019c6243b82b3226c71bb6c8ef4a9bd65cbc6/pandas-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:a4785e1d6547d8427c5208b748ae2efb64659a21bd82bf440d4262d02bfa02a4", size = 9744993, upload-time = "2026-03-31T06:46:51.488Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/18/7f0bd34ae27b28159aa80f2a6799f47fda34f7fb938a76e20c7b7fe3b200/pandas-3.0.2-cp312-cp312-win_arm64.whl", hash = "sha256:08504503f7101300107ecdc8df73658e4347586db5cfdadabc1592e9d7e7a0fd", size = 9056118, upload-time = "2026-03-31T06:46:54.548Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ca/3e639a1ea6fcd0617ca4e8ca45f62a74de33a56ae6cd552735470b22c8d3/pandas-3.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b5918ba197c951dec132b0c5929a00c0bf05d5942f590d3c10a807f6e15a57d3", size = 10321105, upload-time = "2026-03-31T06:46:57.327Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/77/dbc82ff2fb0e63c6564356682bf201edff0ba16c98630d21a1fb312a8182/pandas-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d606a041c89c0a474a4702d532ab7e73a14fe35c8d427b972a625c8e46373668", size = 9864088, upload-time = "2026-03-31T06:46:59.935Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/2b/341f1b04bbca2e17e13cd3f08c215b70ef2c60c5356ef1e8c6857449edc7/pandas-3.0.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:710246ba0616e86891b58ab95f2495143bb2bc83ab6b06747c74216f583a6ac9", size = 10369066, upload-time = "2026-03-31T06:47:02.792Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c5/cbb1ffefb20a93d3f0e1fdcda699fb84976210d411b008f97f48bf6ce27e/pandas-3.0.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5d3cfe227c725b1f3dff4278b43d8c784656a42a9325b63af6b1492a8232209e", size = 10876780, upload-time = "2026-03-31T06:47:06.205Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fe/2249ae5e0a69bd0ddf17353d0a5d26611d70970111f5b3600cdc8be883e7/pandas-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c3b723df9087a9a9a840e263ebd9f88b64a12075d1bf2ea401a5a42f254f084d", size = 11375181, upload-time = "2026-03-31T06:47:09.383Z" },
+    { url = "https://files.pythonhosted.org/packages/de/64/77a38b09e70b6464883b8d7584ab543e748e42c1b5d337a2ee088e0df741/pandas-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a3096110bf9eac0070b7208465f2740e2d8a670d5cb6530b5bb884eca495fd39", size = 11928899, upload-time = "2026-03-31T06:47:12.686Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/52/42855bf626868413f761addd574acc6195880ae247a5346477a4361c3acb/pandas-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:07a10f5c36512eead51bc578eb3354ad17578b22c013d89a796ab5eee90cd991", size = 9746574, upload-time = "2026-03-31T06:47:15.64Z" },
+    { url = "https://files.pythonhosted.org/packages/88/39/21304ae06a25e8bf9fc820d69b29b2c495b2ae580d1e143146c309941760/pandas-3.0.2-cp313-cp313-win_arm64.whl", hash = "sha256:5fdbfa05931071aba28b408e59226186b01eb5e92bea2ab78b65863ca3228d84", size = 9047156, upload-time = "2026-03-31T06:47:18.595Z" },
+    { url = "https://files.pythonhosted.org/packages/72/20/7defa8b27d4f330a903bb68eea33be07d839c5ea6bdda54174efcec0e1d2/pandas-3.0.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:dbc20dea3b9e27d0e66d74c42b2d0c1bed9c2ffe92adea33633e3bedeb5ac235", size = 10756238, upload-time = "2026-03-31T06:47:22.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/95/49433c14862c636afc0e9b2db83ff16b3ad92959364e52b2955e44c8e94c/pandas-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b75c347eff42497452116ce05ef461822d97ce5b9ff8df6edacb8076092c855d", size = 10408520, upload-time = "2026-03-31T06:47:25.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/f8/462ad2b5881d6b8ec8e5f7ed2ea1893faa02290d13870a1600fe72ad8efc/pandas-3.0.2-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d1478075142e83a5571782ad007fb201ed074bdeac7ebcc8890c71442e96adf7", size = 10324154, upload-time = "2026-03-31T06:47:28.097Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/65/d1e69b649cbcddda23ad6e4c40ef935340f6f652a006e5cbc3555ac8adb3/pandas-3.0.2-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5880314e69e763d4c8b27937090de570f1fb8d027059a7ada3f7f8e98bdcb677", size = 10714449, upload-time = "2026-03-31T06:47:30.85Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a4/85b59bc65b8190ea3689882db6cdf32a5003c0ccd5a586c30fdcc3ffc4fc/pandas-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b5329e26898896f06035241a626d7c335daa479b9bbc82be7c2742d048e41172", size = 11338475, upload-time = "2026-03-31T06:47:34.026Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c4/bc6966c6e38e5d9478b935272d124d80a589511ed1612a5d21d36f664c68/pandas-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:81526c4afd31971f8b62671442a4b2b51e0aa9acc3819c9f0f12a28b6fcf85f1", size = 11786568, upload-time = "2026-03-31T06:47:36.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/74/09298ca9740beed1d3504e073d67e128aa07e5ca5ca2824b0c674c0b8676/pandas-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:7cadd7e9a44ec13b621aec60f9150e744cfc7a3dd32924a7e2f45edff31823b0", size = 10488652, upload-time = "2026-03-31T06:47:40.612Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/40/c6ea527147c73b24fc15c891c3fcffe9c019793119c5742b8784a062c7db/pandas-3.0.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:db0dbfd2a6cdf3770aa60464d50333d8f3d9165b2f2671bcc299b72de5a6677b", size = 10326084, upload-time = "2026-03-31T06:47:43.834Z" },
+    { url = "https://files.pythonhosted.org/packages/95/25/bdb9326c3b5455f8d4d3549fce7abcf967259de146fe2cf7a82368141948/pandas-3.0.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0555c5882688a39317179ab4a0ed41d3ebc8812ab14c69364bbee8fb7a3f6288", size = 9914146, upload-time = "2026-03-31T06:47:46.67Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/77/3a227ff3337aa376c60d288e1d61c5d097131d0ac71f954d90a8f369e422/pandas-3.0.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:01f31a546acd5574ef77fe199bc90b55527c225c20ccda6601cf6b0fd5ed597c", size = 10444081, upload-time = "2026-03-31T06:47:49.681Z" },
+    { url = "https://files.pythonhosted.org/packages/15/88/3cdd54fa279341afa10acf8d2b503556b1375245dccc9315659f795dd2e9/pandas-3.0.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:deeca1b5a931fdf0c2212c8a659ade6d3b1edc21f0914ce71ef24456ca7a6535", size = 10897535, upload-time = "2026-03-31T06:47:53.033Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9d/98cc7a7624f7932e40f434299260e2917b090a579d75937cb8a57b9d2de3/pandas-3.0.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0f48afd9bb13300ffb5a3316973324c787054ba6665cda0da3fbd67f451995db", size = 11446992, upload-time = "2026-03-31T06:47:56.193Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/cd/19ff605cc3760e80602e6826ddef2824d8e7050ed80f2e11c4b079741dc3/pandas-3.0.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6c4d8458b97a35717b62469a4ea0e85abd5ed8687277f5ccfc67f8a5126f8c53", size = 11968257, upload-time = "2026-03-31T06:47:59.137Z" },
+    { url = "https://files.pythonhosted.org/packages/db/60/aba6a38de456e7341285102bede27514795c1eaa353bc0e7638b6b785356/pandas-3.0.2-cp314-cp314-win_amd64.whl", hash = "sha256:b35d14bb5d8285d9494fe93815a9e9307c0876e10f1e8e89ac5b88f728ec8dcf", size = 9865893, upload-time = "2026-03-31T06:48:02.038Z" },
+    { url = "https://files.pythonhosted.org/packages/08/71/e5ec979dd2e8a093dacb8864598c0ff59a0cee0bbcdc0bfec16a51684d4f/pandas-3.0.2-cp314-cp314-win_arm64.whl", hash = "sha256:63d141b56ef686f7f0d714cfb8de4e320475b86bf4b620aa0b7da89af8cbdbbb", size = 9188644, upload-time = "2026-03-31T06:48:05.045Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/6c/7b45d85db19cae1eb524f2418ceaa9d85965dcf7b764ed151386b7c540f0/pandas-3.0.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:140f0cffb1fa2524e874dde5b477d9defe10780d8e9e220d259b2c0874c89d9d", size = 10776246, upload-time = "2026-03-31T06:48:07.789Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/3e/7b00648b086c106e81766f25322b48aa8dfa95b55e621dbdf2fdd413a117/pandas-3.0.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae37e833ff4fed0ba352f6bdd8b73ba3ab3256a85e54edfd1ab51ae40cca0af8", size = 10424801, upload-time = "2026-03-31T06:48:10.897Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/558dd09a71b53b4008e7fc8a98ec6d447e9bfb63cdaeea10e5eb9b2dabe8/pandas-3.0.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4d888a5c678a419a5bb41a2a93818e8ed9fd3172246555c0b37b7cc27027effd", size = 10345643, upload-time = "2026-03-31T06:48:13.7Z" },
+    { url = "https://files.pythonhosted.org/packages/be/e3/921c93b4d9a280409451dc8d07b062b503bbec0531d2627e73a756e99a82/pandas-3.0.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b444dc64c079e84df91baa8bf613d58405645461cabca929d9178f2cd392398d", size = 10743641, upload-time = "2026-03-31T06:48:16.659Z" },
+    { url = "https://files.pythonhosted.org/packages/56/ca/fd17286f24fa3b4d067965d8d5d7e14fe557dd4f979a0b068ac0deaf8228/pandas-3.0.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4544c7a54920de8eeacaa1466a6b7268ecfbc9bc64ab4dbb89c6bbe94d5e0660", size = 11361993, upload-time = "2026-03-31T06:48:19.475Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/a5/2f6ed612056819de445a433ca1f2821ac3dab7f150d569a59e9cc105de1d/pandas-3.0.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:734be7551687c00fbd760dc0522ed974f82ad230d4a10f54bf51b80d44a08702", size = 11815274, upload-time = "2026-03-31T06:48:22.695Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2f/b622683e99ec3ce00b0854bac9e80868592c5b051733f2cf3a868e5fea26/pandas-3.0.2-cp314-cp314t-win_amd64.whl", hash = "sha256:57a07209bebcbcf768d2d13c9b78b852f9a15978dac41b9e6421a81ad4cdd276", size = 10888530, upload-time = "2026-03-31T06:48:25.806Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/2b/f8434233fab2bd66a02ec014febe4e5adced20e2693e0e90a07d118ed30e/pandas-3.0.2-cp314-cp314t-win_arm64.whl", hash = "sha256:5371b72c2d4d415d08765f32d689217a43227484e81b2305b52076e328f6f482", size = 9455341, upload-time = "2026-03-31T06:48:28.418Z" },
+]
+
+[[package]]
 name = "pandocfilters"
 version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2730,7 +2899,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -3266,6 +3435,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pytz"
+version = "2026.1.post1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
+]
+
+[[package]]
 name = "pywinpty"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3665,6 +3843,8 @@ dependencies = [
     { name = "matplotlib" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "rich" },
@@ -3692,6 +3872,7 @@ requires-dist = [
     { name = "jupyter", marker = "extra == 'dev'" },
     { name = "matplotlib" },
     { name = "numpy" },
+    { name = "pandas" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "rich" },


### PR DESCRIPTION
## Summary
- audit recent conversation logs for `wandb-primary` training-diagnostics adoption
- document the findings in `analysis/wandb_primary_training_diagnostics_adoption_audit_2026-04-23.md`
- tighten the skill/reference guidance around `step_key`, completion criteria, and phrase-to-helper mapping
- add a one-shot `curve_diagnostics_cli.py` wrapper to lower the activation energy for actually running the helper workflow

## Findings
- scanned the available `2026-04-21` and `2026-04-22` logs (`137` archives / `1,388` embedded `.jsonl` transcripts)
- found `41` assistant-side `wandb-primary` skill launches
- found `0` assistant-side invocations of the concrete diagnostics helper surface (`plot_single_run_overview`, `compare_runs_curves`, `plot_run_comparison`, `curve_features`, `lr_schedule_features`, `grad_norm_features`, `grad_histogram_features`, `list_candidate_step_keys`, `guess_step_key_from_workspace`) after excluding injected skill text
- found strong heuristic-level adoption instead: step-axis corrections, LR-peak spike analysis, plateau vs convergence distinctions, overfit reasoning, and stability-aware run ranking
- found a new runtime blocker: the detected `uv` environment currently lacks `pandas`, even though the diagnostics helper stack imports it at module import time

## Why This May Help
- lower activation energy: the new CLI turns the default workflow into one command
- stronger completion gate: the skill now pushes toward `step_key` + helper-derived table + PNG + verdict instead of manual narration alone
- better mapping from natural research phrases like `gradient storm` and `trough envelope plateaued` to the helper surface that should back those claims
- stronger step-axis and restart guidance, based on concrete failure modes seen in the logs

## Validation
- `uv run python -m py_compile .agents/skills/wandb-primary/scripts/curve_diagnostics_cli.py`
- `uv run python .agents/skills/wandb-primary/scripts/curve_diagnostics_cli.py --help`
- `uv run python .agents/skills/wandb-primary/scripts/curve_diagnostics_cli.py --entity foo --project bar --run baz` (expected helpful missing-dependency message for `pandas` in the current `uv` environment)
