### PR TITLE
AirfRANS: Huber loss on volume channel for robust optimization

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -167,6 +167,7 @@ class TrainConfig:
     grad_clip: float = 0.0
     grad_accum_steps: int = 1
     volume_loss_weight: float = 1.0
+    vol_loss_delta: float = 0.0
     save_checkpoint: bool = False
     seed: int = 0
 
@@ -758,11 +759,18 @@ def _named_channel_metrics(prefix: str, values: torch.Tensor, names: tuple[str, 
     return metrics
 
 
+def _volume_loss(pred: torch.Tensor, target: torch.Tensor, delta: float) -> torch.Tensor:
+    if delta > 0.0:
+        return F.huber_loss(pred, target, delta=delta)
+    return F.mse_loss(pred, target)
+
+
 def loss_grouped(
     batch: GroupedBatch,
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
     volume_loss_weight: float = 1.0,
+    vol_loss_delta: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.surface_x.device)
     metrics: dict[str, float] = {}
@@ -773,7 +781,7 @@ def loss_grouped(
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
     if batch.volume_y is not None and outputs["volume_preds"] is not None and batch.volume_mask is not None:
         target = transform.apply(batch.volume_y)
-        vol_loss = F.mse_loss(outputs["volume_preds"][batch.volume_mask], target[batch.volume_mask])
+        vol_loss = _volume_loss(outputs["volume_preds"][batch.volume_mask], target[batch.volume_mask], vol_loss_delta)
         total = total + vol_loss * volume_loss_weight
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
@@ -784,6 +792,7 @@ def loss_grouped_tandem(
     prepared: TandemPreparedBatch,
     outputs: dict[str, torch.Tensor | None],
     volume_loss_weight: float = 1.0,
+    vol_loss_delta: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=prepared.surface_x.device)
     metrics: dict[str, float] = {}
@@ -792,7 +801,7 @@ def loss_grouped_tandem(
         total = total + surf_loss
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
     if prepared.volume_target is not None and outputs["volume_preds"] is not None and prepared.volume_mask is not None:
-        vol_loss = F.mse_loss(outputs["volume_preds"][prepared.volume_mask], prepared.volume_target[prepared.volume_mask])
+        vol_loss = _volume_loss(outputs["volume_preds"][prepared.volume_mask], prepared.volume_target[prepared.volume_mask], vol_loss_delta)
         total = total + vol_loss * volume_loss_weight
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
@@ -804,6 +813,7 @@ def loss_abupt(
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
     volume_loss_weight: float = 1.0,
+    vol_loss_delta: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.geometry_position.device)
     metrics: dict[str, float] = {}
@@ -814,7 +824,7 @@ def loss_abupt(
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
     if batch.volume_anchor_target is not None and outputs["volume_preds"] is not None:
         vol_target = transform.apply(batch.volume_anchor_target)
-        vol_loss = F.mse_loss(outputs["volume_preds"], vol_target)
+        vol_loss = _volume_loss(outputs["volume_preds"], vol_target, vol_loss_delta)
         total = total + vol_loss * volume_loss_weight
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
@@ -1271,6 +1281,7 @@ def train_one_epoch(
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
     volume_loss_weight: float = 1.0,
+    vol_loss_delta: float = 0.0,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1304,7 +1315,7 @@ def train_one_epoch(
                         surface_anchor_position=batch.surface_anchor_position,
                         volume_anchor_position=batch.volume_anchor_position,
                     )
-                    loss, _ = loss_abupt(batch, outputs, transform, volume_loss_weight=volume_loss_weight)
+                    loss, _ = loss_abupt(batch, outputs, transform, volume_loss_weight=volume_loss_weight, vol_loss_delta=vol_loss_delta)
             else:
                 batch = batch.to(device)
                 if isinstance(transform, TandemTargetTransform):
@@ -1317,7 +1328,7 @@ def train_one_epoch(
                             volume_mask=prepared.volume_mask,
                         )
                         outputs = maybe_apply_anp(outputs, prepared, anp_head)
-                        loss, _ = loss_grouped_tandem(prepared, outputs, volume_loss_weight=volume_loss_weight)
+                        loss, _ = loss_grouped_tandem(prepared, outputs, volume_loss_weight=volume_loss_weight, vol_loss_delta=vol_loss_delta)
                 else:
                     with autocast_context(device, amp_mode):
                         outputs = model(
@@ -1326,7 +1337,7 @@ def train_one_epoch(
                             volume_x=batch.volume_x,
                             volume_mask=batch.volume_mask,
                         )
-                        loss, _ = loss_grouped(batch, outputs, transform, volume_loss_weight=volume_loss_weight)
+                        loss, _ = loss_grouped(batch, outputs, transform, volume_loss_weight=volume_loss_weight, vol_loss_delta=vol_loss_delta)
 
             accum_loss += float(loss.detach().cpu().item())
             (loss / grad_accum_steps).backward()
@@ -1642,17 +1653,6 @@ def main() -> None:
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
 
-    if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
-    else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
-    best_val_metric = float("inf")
-    best_epoch = 0
-    best_model_state: dict[str, torch.Tensor] | None = None
-    best_anp_state: dict[str, torch.Tensor] | None = None
-    best_ema_shadow: dict[str, torch.Tensor] | None = None
-    best_anp_ema_shadow: dict[str, torch.Tensor] | None = None
-
     run = None
     if config.wandb_name:
         run_config = asdict(config)
@@ -1688,6 +1688,7 @@ def main() -> None:
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
             volume_loss_weight=config.volume_loss_weight,
+            vol_loss_delta=config.vol_loss_delta,
         )
 
         if ema is not None:
@@ -1719,32 +1720,20 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
-        if current_val is not None and current_val < best_val_metric:
-            best_val_metric = current_val
-            best_epoch = epoch
-            best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
-            if anp_head is not None:
-                best_anp_state = {k: v.cpu().clone() for k, v in anp_head.state_dict().items()}
-            if ema is not None:
-                best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
-            if anp_ema is not None:
-                best_anp_ema_shadow = {k: v.cpu().clone() for k, v in anp_ema.shadow.items()}
-
         if ema is not None:
             ema.restore(model)
         if anp_head is not None and anp_ema is not None:
             anp_ema.restore(anp_head)
 
         epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
-        epoch_metrics["best_val_metric"] = best_val_metric
-        epoch_metrics["best_epoch"] = float(best_epoch)
+        epoch_metrics["best_val_metric"] = best_val_primary_metric if best_val_primary_metric is not None else float("inf")
+        epoch_metrics["best_epoch"] = float(best_epoch) if best_epoch is not None else 0.0
         history.append(epoch_metrics)
         if run is not None:
             wandb.log(epoch_metrics, step=epoch)
             run.summary["epoch"] = epoch
             run.summary["best_epoch"] = best_epoch
-            run.summary["best_val_metric"] = best_val_metric
+            run.summary["best_val_metric"] = best_val_primary_metric
         print(json.dumps(epoch_metrics, sort_keys=True), flush=True)
 
     if best_epoch is not None:
@@ -1795,8 +1784,8 @@ def main() -> None:
             wandb.log(final_test_metrics, step=int(history[-1]["epoch"]) if history else 0)
             run.summary.update(final_test_metrics)
             run.summary["best_epoch"] = best_epoch
-            run.summary["best_val_metric"] = best_val_metric
-        print(json.dumps({"final_test_metrics": final_test_metrics, "best_epoch": best_epoch, "best_val_metric": best_val_metric}, sort_keys=True), flush=True)
+            run.summary["best_val_metric"] = best_val_primary_metric
+        print(json.dumps({"final_test_metrics": final_test_metrics, "best_epoch": best_epoch, "best_val_metric": best_val_primary_metric}, sort_keys=True), flush=True)
 
         if best_model_state is not None:
             restore_module_state(model, best_model_state)


### PR DESCRIPTION
## Hypothesis

The volume MSE loss is sensitive to outlier gradient magnitudes — a small fraction of cells with large prediction errors dominate the gradient signal and destabilize volume optimization. Replacing the volume channel's MSE loss with **Huber loss (SmoothL1)** should suppress these outlier gradients: for errors smaller than delta, Huber behaves like MSE (quadratic); for larger errors it falls back to L1 (linear). This reduces the variance of the gradient signal coming from volume errors without completely abandoning the strong quadratic pull near zero.

The champion config already achieves a programme-best vol_mse = 0.002039 with `--vol-loss-weight 10x`. We believe a tighter vol_mse (target: < 0.0017) is achievable by making the volume loss more robust, without sacrificing the current surface_mse champion of 0.000296.

Reference: Huber (1964), also implemented as `torch.nn.SmoothL1Loss(beta=delta)` or `torch.nn.HuberLoss(delta=delta)` in PyTorch.

## Instructions

**Hard constraint:** surface_mse must NOT regress below 0.000296. If any trial causes surface_mse > 0.000296, note it but do not treat it as a winner.

**Target:** vol_mse < 0.0017 (current champion: 0.002039).

Use `--wandb_group af-huber-volume` for all runs so related trials are grouped in W&B.

### Implementation

In `target/icml2026/train.py`, locate the volume loss computation. Replace the MSE volume loss with Huber loss:

```python
# Before (MSE):
vol_loss = F.mse_loss(vol_pred, vol_target)

# After (Huber / SmoothL1):
vol_loss = F.huber_loss(vol_pred, vol_target, delta=DELTA)
# OR equivalently:
# vol_loss = F.smooth_l1_loss(vol_pred, vol_target, beta=DELTA)
```

Keep the surface loss as MSE (unchanged). Only the volume channel loss changes.

Add a `--vol-loss-delta` argument (float, default=1.0) to `train.py` to control the Huber delta at runtime so no code changes are needed between trials.

### Smoke test (run first before full trials)

Run 3 epochs to confirm no crashes and that vol_loss is well-behaved:

```bash
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 \
  --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --ema-decay 0.999 --vol-loss-weight 10.0 \
  --vol-loss-delta 1.0 \
  --wandb_group af-huber-volume \
  --epochs 3
```

### Trial 1 — Huber delta=1.0 (full run)

Full run with the champion config and Huber delta=1.0:

```bash
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 \
  --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --ema-decay 0.999 --vol-loss-weight 10.0 \
  --vol-loss-delta 1.0 \
  --wandb_group af-huber-volume \
  --epochs 999
```

### Trial 2 — Huber delta=0.1 (full run)

A much tighter transition threshold — forces L1 behavior for a wider range of errors. This is more aggressive outlier suppression:

```bash
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 \
  --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --ema-decay 0.999 --vol-loss-weight 10.0 \
  --vol-loss-delta 0.1 \
  --wandb_group af-huber-volume \
  --epochs 999
```

### Trial 3 — Best delta + vol-weight=15x (conditional)

**Only run Trial 3 if both Trial 1 and Trial 2 improve vol_mse below 0.002039.**

Take whichever delta value performed better (1.0 or 0.1) and increase the volume loss weight to 15x:

```bash
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 \
  --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --ema-decay 0.999 --vol-loss-weight 15.0 \
  --vol-loss-delta <BEST_DELTA_FROM_T1_OR_T2> \
  --wandb_group af-huber-volume \
  --epochs 999
```

### Reporting

Report surface_mse and vol_mse from both the best-val-surface-MSE checkpoint and the best-val-vol-MSE checkpoint for each trial. Include W&B run IDs.

## Baseline

Current AirfRANS champion (PR #3135):

| Metric | Value | Epoch |
|--------|-------|-------|
| val_primary/surface_mse | **0.000296** | 704 |
| val_primary/vol_mse | **0.002039** | 743 |

- W&B baseline run: `sh2zyfwr` (nezuko/af-ema-vol-weight-10x)
- PR: #3135
- Config: 2L/256d/4H, AdamW lr=6e-4, T_max=50, gc=1.0, WD=1e-2, EMA=0.999, vol-weight=10x, Fourier

**Reproduce command:**
```bash
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 \
  --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 \
  --ema-decay 0.999 --vol-loss-weight 10.0
```