### PR TITLE
DrivAerML: attention distance bias — spatial locality prior

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -21,6 +21,7 @@ import wandb
 from torch.utils.data import DataLoader, WeightedRandomSampler
 
 from core.architectures import ABUPTReference, ANPSurfaceDecoder, ReferenceTransolver, SenpaiTransolver
+from core.architectures.transolver_reference import TransolverAttention
 from core.contracts import ABUPTBatch, DatasetBundle, GroupedBatch, TargetTransformStats
 from core.datasets import ABUPTCollate, build_dataset_bundle, collate_grouped
 from core.features import (
@@ -169,6 +170,7 @@ class TrainConfig:
     volume_loss_weight: float = 1.0
     save_checkpoint: bool = False
     seed: int = 0
+    distance_bias: str = "none"
 
 
 @dataclass
@@ -499,6 +501,81 @@ def cp_panel_prior_index(config: TrainConfig, bundle: DatasetBundle) -> int | No
     return None
 
 
+class DistanceBiasTransolverAttention(TransolverAttention):
+    """TransolverAttention with ALiBi-style spatial distance bias on slice centroids."""
+
+    def __init__(self, hidden_dim: int, num_heads: int, num_slices: int, dropout: float = 0.0, *, use_log_distance: bool = False):
+        super().__init__(hidden_dim, num_heads, num_slices, dropout)
+        self.use_log_distance = use_log_distance
+        log_alpha_init = torch.zeros(num_heads)
+        for h in range(num_heads):
+            target = 2.0 ** (-8.0 * (h + 1) / num_heads)
+            log_alpha_init[h] = math.log(math.exp(target) - 1.0)
+        self.log_alpha = torch.nn.Parameter(log_alpha_init)
+        self._cached_pos: torch.Tensor | None = None
+
+    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+        slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask)
+        qkv = self.qkv(slice_tokens)
+        q, k, v = qkv.chunk(3, dim=-1)
+
+        distance_bias = None
+        pos = self._cached_pos
+        if pos is not None:
+            slice_norm = slice_weights.sum(dim=2)
+            slice_pos = torch.einsum("bhns,bnd->bhsd", slice_weights, pos.float()) / (slice_norm.unsqueeze(-1) + 1e-5)
+            d = torch.cdist(slice_pos, slice_pos)
+            alpha = F.softplus(self.log_alpha)
+            if self.use_log_distance:
+                distance_bias = -alpha[None, :, None, None] * torch.log1p(d)
+            else:
+                distance_bias = -alpha[None, :, None, None] * d
+
+        out_slice = F.scaled_dot_product_attention(
+            q, k, v,
+            attn_mask=distance_bias,
+            dropout_p=self.dropout if self.training else 0.0,
+        )
+        out_x = torch.einsum("bhsc,bhns->bhnc", out_slice, slice_weights)
+        out_x = out_x.permute(0, 2, 1, 3).contiguous().view(x.shape[0], x.shape[1], self.hidden_dim)
+        return self.proj_dropout(self.proj(out_x))
+
+
+class DistanceBiasSenpaiTransolver(SenpaiTransolver):
+    """SenpaiTransolver with distance-biased attention."""
+
+    def __init__(self, *, use_log_distance: bool = False, **kwargs):
+        super().__init__(**kwargs)
+        self._use_log_distance = use_log_distance
+        for block in self.backbone.blocks:
+            old = block.attention
+            new_attn = DistanceBiasTransolverAttention(
+                hidden_dim=old.hidden_dim,
+                num_heads=old.num_heads,
+                num_slices=old.num_slices,
+                dropout=old.dropout,
+                use_log_distance=use_log_distance,
+            )
+            new_attn.load_state_dict(old.state_dict(), strict=False)
+            block.attention = new_attn
+
+    def forward(self, *, surface_x: torch.Tensor, surface_mask: torch.Tensor, volume_x: torch.Tensor | None = None, volume_mask: torch.Tensor | None = None) -> dict[str, torch.Tensor | None]:
+        pos_parts = [surface_x[:, :, :self.space_dim]]
+        if volume_x is not None and volume_mask is not None and self.volume_output_dim > 0:
+            pos_parts.append(volume_x[:, :, :self.space_dim])
+        all_pos = torch.cat(pos_parts, dim=1)
+
+        for blk in self.backbone.blocks:
+            blk.attention._cached_pos = all_pos
+
+        result = super().forward(surface_x=surface_x, surface_mask=surface_mask, volume_x=volume_x, volume_mask=volume_mask)
+
+        for blk in self.backbone.blocks:
+            blk.attention._cached_pos = None
+
+        return result
+
+
 def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
     transolver_kwargs = {
         "n_layers": config.model_layers,
@@ -508,8 +585,9 @@ def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
         "mlp_ratio": config.model_mlp_ratio,
         "slice_num": config.model_slices,
     }
+    model: torch.nn.Module
     if config.model == "reference_transolver":
-        return ReferenceTransolver(
+        model = ReferenceTransolver(
             space_dim=bundle.spec.space_dim,
             surface_input_dim=bundle.spec.surface_input_dim,
             surface_output_dim=bundle.spec.surface_output_dim,
@@ -517,9 +595,9 @@ def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
             volume_output_dim=bundle.spec.volume_output_dim,
             **transolver_kwargs,
         )
-    if config.model == "senpai_transolver":
+    elif config.model == "senpai_transolver":
         prior_idx = cp_panel_prior_index(config, bundle)
-        return SenpaiTransolver(
+        senpai_kwargs = dict(
             space_dim=bundle.spec.space_dim,
             surface_input_dim=bundle.spec.surface_input_dim,
             surface_output_dim=bundle.spec.surface_output_dim,
@@ -533,13 +611,20 @@ def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
             volume_pressure_prior_idx=prior_idx,
             **transolver_kwargs,
         )
-    if config.model == "reference_abupt":
-        return ABUPTReference(
+        if config.distance_bias != "none":
+            model = DistanceBiasSenpaiTransolver(use_log_distance=config.distance_bias == "log", **senpai_kwargs)
+        else:
+            model = SenpaiTransolver(**senpai_kwargs)
+    elif config.model == "reference_abupt":
+        model = ABUPTReference(
             space_dim=bundle.spec.space_dim,
             surface_output_dim=bundle.spec.surface_output_dim,
             volume_output_dim=bundle.spec.volume_output_dim,
         )
-    raise ValueError(f"Unknown model: {config.model}")
+    else:
+        raise ValueError(f"Unknown model: {config.model}")
+
+    return model
 
 
 def build_optimizer(params, config: TrainConfig):
@@ -1635,17 +1720,8 @@ def main() -> None:
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
     history: list[dict[str, float]] = []
-    best_epoch: int | None = None
     best_val_primary_metric_name = primary_metric_key(bundle, phase="val")
     best_val_primary_metric: float | None = None
-    best_val_metrics: dict[str, float] = {}
-    best_model_state: dict[str, torch.Tensor] | None = None
-    best_anp_state: dict[str, torch.Tensor] | None = None
-
-    if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
-    else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1719,7 +1795,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(best_val_primary_metric_name)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch
@@ -1739,6 +1815,12 @@ def main() -> None:
         epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
         epoch_metrics["best_val_metric"] = best_val_metric
         epoch_metrics["best_epoch"] = float(best_epoch)
+        for blk_idx, blk in enumerate(getattr(getattr(model, "backbone", None), "blocks", [])):
+            attn = blk.attention
+            if isinstance(attn, DistanceBiasTransolverAttention):
+                alphas = F.softplus(attn.log_alpha).detach().cpu()
+                for head_idx in range(alphas.shape[0]):
+                    epoch_metrics[f"distance_bias/layer{blk_idx}_head{head_idx}_alpha"] = float(alphas[head_idx])
         history.append(epoch_metrics)
         if run is not None:
             wandb.log(epoch_metrics, step=epoch)


### PR DESCRIPTION
## Hypothesis

Attention in the current transformer processes all token pairs equally, regardless of geometric distance. But in CFD, local geometry dominates pressure fields — the aerodynamic influence of a surface patch decays strongly with distance. We hypothesize that injecting a spatial locality prior via ALiBi-style distance biases (Press et al., 2021) into the attention scores will improve the model's inductive bias for surface pressure prediction, reducing surface_rel_l2_pct on DrivAerML.

Reference: ALiBi (Train Short, Test Long): https://arxiv.org/abs/2108.12409

Adapted here for 3D surface meshes: after computing QK^T attention logits, we add a learned distance penalty:

```
attn_scores = QK^T / sqrt(d_k) + distance_bias
```

where `distance_bias = -alpha * f(distances)` and `alpha` is a learnable scalar (per-head or shared).

**IMPORTANT — OOM smoke test first**: Computing a full N×N pairwise distance matrix for N=50k surface points will OOM. You MUST restrict distance computation to within supernodes (or local neighborhoods), or use a sparse approximation. Run a quick forward pass with a small batch before launching full training to confirm no OOM.

## Instructions

Keep the champion DrivAerML config as the base for both trials:
- 4 layers, 512 hidden dim, 8 heads
- AdamW lr=5e-4, cosine T_max=30
- EMA decay=0.9995, grad-clip=0.5
- Fourier features enabled
- `SENPAI_MAX_EPOCHS=9999 --epochs 999`
- `--batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`

**Trial 1 — Linear distance bias:**

In the attention module, after computing `attn_scores = (Q @ K.T) / sqrt(d_k)`, compute pairwise distances between the node positions within each supernode, then add:

```python
# alpha is a learnable scalar per attention head, initialized to 1.0
distance_bias = -alpha * distances  # shape: [batch, heads, N, N]
attn_scores = attn_scores + distance_bias
```

Log `alpha` values per head to W&B each epoch so we can see if they converge.

Run command:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --grad-clip 0.5 --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --wandb_group dm-attention-distance-bias
```

**Trial 2 — Log-distance bias:**

Same as Trial 1, but use a softer log penalty that is less aggressive for nearby nodes and decays more slowly for distant nodes:

```python
distance_bias = -alpha * torch.log(1 + distances)
attn_scores = attn_scores + distance_bias
```

Run command (same flags as Trial 1, just with the log-distance formulation in the code):
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --grad-clip 0.5 --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --wandb_group dm-attention-distance-bias
```

**Logging requirement:** For both trials, log `alpha` (per-head learnable scalars) to W&B each epoch. This lets us diagnose whether the model is using or ignoring the distance prior.

## Baseline

Current best DrivAerML metrics (from PR #3072, student eren):
- `val_primary/surface_rel_l2_pct`: **3.833%** (epoch 511)
- Test: 4.685%
- External target: <3.71% (AB-UPT, ~500 epochs) — gap: 0.123 pp
- W&B run: `ncl1dh88`
- Reproduce:
  ```bash
  cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
    --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
    --grad-clip 0.5 --enable-fourier \
    --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
    --epochs 999 \
    --batch-size 1 \
    --drivaerml-train-surface-points 50000 \
    --drivaerml-eval-surface-points 50000 \
    --max-train-batches 394 --max-eval-batches 200 \
    --ema-decay 0.9995
  ```