### PR TITLE
DrivAerML: Fourier-encode surface normals (angular freq features)

### DIFF
--- a/target/icml2026/core/datasets.py
+++ b/target/icml2026/core/datasets.py
@@ -281,6 +281,8 @@ class DrivAerMLCaseDataset(Dataset):
         manifest_path: str | Path = DEFAULT_DRIVAERML_MANIFEST,
         root: str | Path | None = None,
         enable_fourier: bool = False,
+        fourier_encode_normals: bool = False,
+        fourier_normals_half_bands: bool = False,
         surface_only: bool = True,
         max_surface_points: int = 0,
         max_volume_points: int = 0,
@@ -297,6 +299,8 @@ class DrivAerMLCaseDataset(Dataset):
             enable_cp_panel=False,
             enable_wake_deficit=False,
             enable_wake_angle=False,
+            fourier_encode_normals=fourier_encode_normals,
+            fourier_normals_half_bands=fourier_normals_half_bands,
         )
         self.views = self._build_views()
 
@@ -789,6 +793,8 @@ def build_drivaerml_bundle(
     root: str | Path | None = None,
     surface_only: bool = True,
     enable_fourier: bool = False,
+    fourier_encode_normals: bool = False,
+    fourier_normals_half_bands: bool = False,
     train_surface_points: int = 0,
     eval_surface_points: int = 0,
     train_volume_points: int = 0,
@@ -798,11 +804,12 @@ def build_drivaerml_bundle(
     _validate_drivaerml_manifest(manifest, manifest_path)
     train_sampling_mode = "train_random" if train_surface_points > 0 or train_volume_points > 0 else "full"
     eval_sampling_mode = "eval_chunk" if eval_surface_points > 0 or eval_volume_points > 0 else "full"
+    fourier_kwargs = dict(enable_fourier=enable_fourier, fourier_encode_normals=fourier_encode_normals, fourier_normals_half_bands=fourier_normals_half_bands)
     train_dataset = DrivAerMLCaseDataset(
         list(manifest["surface_splits"]["train"]),
         manifest_path=manifest_path,
         root=root,
-        enable_fourier=enable_fourier,
+        **fourier_kwargs,
         surface_only=surface_only,
         max_surface_points=train_surface_points,
         max_volume_points=train_volume_points,
@@ -812,7 +819,7 @@ def build_drivaerml_bundle(
         list(manifest["surface_splits"]["val"]),
         manifest_path=manifest_path,
         root=root,
-        enable_fourier=enable_fourier,
+        **fourier_kwargs,
         surface_only=surface_only,
         max_surface_points=eval_surface_points,
         max_volume_points=eval_volume_points,
@@ -822,7 +829,7 @@ def build_drivaerml_bundle(
         list(manifest["surface_splits"]["test"]),
         manifest_path=manifest_path,
         root=root,
-        enable_fourier=enable_fourier,
+        **fourier_kwargs,
         surface_only=surface_only,
         max_surface_points=eval_surface_points,
         max_volume_points=eval_volume_points,
@@ -838,6 +845,9 @@ def build_drivaerml_bundle(
     base_surface_dim = prepare_drivaerml.SURFACE_X_DIM
     base_volume_dim = 0 if surface_only else prepare_drivaerml.VOLUME_X_DIM
     fourier_extra = 24 if enable_fourier else 0
+    if enable_fourier and fourier_encode_normals:
+        n_normal_freqs = 2 if fourier_normals_half_bands else 4
+        fourier_extra += 3 * n_normal_freqs * 2
     return DatasetBundle(
         train_dataset=train_dataset,
         val_datasets={"val_surface": val_dataset},
@@ -884,6 +894,8 @@ def build_dataset_bundle(
     drivaerml_train_volume_points: int = 0,
     drivaerml_eval_volume_points: int = 0,
     enable_fourier: bool = False,
+    fourier_encode_normals: bool = False,
+    fourier_normals_half_bands: bool = False,
     enable_te_coord_frame: bool = False,
     enable_cp_panel: bool = False,
     enable_wake_deficit: bool = False,
@@ -927,6 +939,8 @@ def build_dataset_bundle(
             root=drivaerml_root,
             surface_only=drivaerml_surface_only,
             enable_fourier=enable_fourier,
+            fourier_encode_normals=fourier_encode_normals,
+            fourier_normals_half_bands=fourier_normals_half_bands,
             train_surface_points=drivaerml_train_surface_points,
             eval_surface_points=drivaerml_eval_surface_points,
             train_volume_points=drivaerml_train_volume_points,

--- a/target/icml2026/core/features.py
+++ b/target/icml2026/core/features.py
@@ -266,6 +266,8 @@ def augment_case_sample(
     enable_cp_panel: bool = False,
     enable_wake_deficit: bool = False,
     enable_wake_angle: bool = False,
+    fourier_encode_normals: bool = False,
+    fourier_normals_half_bands: bool = False,
 ) -> CaseSample:
     if sample.dataset_name == "tandemfoilset":
         return sample
@@ -277,6 +279,12 @@ def augment_case_sample(
     appended_full: list[torch.Tensor] = []
     if enable_fourier:
         full_x = append_fourier_features(full_x, sample.space_dim, fourier_freqs)
+    if enable_fourier and fourier_encode_normals and full_x.shape[1] >= 2 * sample.space_dim:
+        normal_freqs = fourier_freqs[:len(fourier_freqs) // 2] if fourier_normals_half_bands else fourier_freqs
+        normals = full_x[:, sample.space_dim:2 * sample.space_dim]
+        for freq in normal_freqs:
+            appended_full.append(torch.sin(normals * freq))
+            appended_full.append(torch.cos(normals * freq))
     if enable_cp_panel and sample.dataset_name == "airfrans":
         appended_full.append(_compute_airfrans_cp_panel(full_x))
     if enable_wake_deficit and sample.dataset_name.startswith("tandemfoilset"):

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -141,6 +141,8 @@ class TrainConfig:
     tandemfoil_paper_manifest: str = ""
     tandemfoil_paper_stats: str = ""
     enable_fourier: bool = False
+    fourier_encode_normals: bool = False
+    fourier_normals_half_bands: bool = False
     enable_te_coord_frame: bool = False
     enable_cp_panel: bool = False
     enable_cp_panel_tandem_only: bool = False
@@ -466,6 +468,8 @@ def build_bundle(config: TrainConfig) -> DatasetBundle:
         "drivaerml_train_volume_points": config.drivaerml_train_volume_points,
         "drivaerml_eval_volume_points": config.drivaerml_eval_volume_points,
         "enable_fourier": config.enable_fourier,
+        "fourier_encode_normals": config.fourier_encode_normals,
+        "fourier_normals_half_bands": config.fourier_normals_half_bands,
         "enable_te_coord_frame": config.enable_te_coord_frame,
         "enable_cp_panel": config.enable_cp_panel,
         "enable_wake_deficit": config.enable_wake_deficit,
@@ -1643,9 +1647,9 @@ def main() -> None:
     best_anp_state: dict[str, torch.Tensor] | None = None
 
     if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
+        _checkpoint_metric_key = "val_primary/surface_pressure_mae"
     else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+        _checkpoint_metric_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1719,7 +1723,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(_checkpoint_metric_key)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

Surface normals (columns 3–5 of the DrivAerML input tensor, `SURFACE_X_DIM=7`) are currently passed to the model as raw floats, while xyz coordinates (columns 0–2) already receive Fourier positional encoding. Brook discovered this asymmetry in PR #3213.

Motivated by NeRF (Mildenhall et al., 2020): MLPs cannot learn high-frequency functions from raw inputs, but Fourier features lift them into a high-frequency-accessible space. Surface normals encode angular information about the car body — sharp creases, flat panels, curved surfaces — that is inherently high-frequency in angular space. We expect Fourier-encoding the normals to give the model a richer, more expressive representation of local surface geometry.

We run two trials to find the right frequency budget for unit-vector inputs:

- **Trial 1**: same number of frequency bands as xyz (normals are bounded in [-1, 1], so the same bands apply directly)
- **Trial 2**: half the frequency bands (normals are unit vectors; lower frequencies may suffice and reduce over-parameterisation)

Reference: Mildenhall et al. (2020), *NeRF: Representing Scenes as Neural Radiance Fields for View Synthesis* — https://arxiv.org/abs/2003.08934

## Instructions

**Step 0 — smoke test first.** Before running full training, run 2 epochs on DrivAerML to confirm no shape mismatches after extending the Fourier encoding:
```bash
cd target/icml2026
SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 \
  --enable-fourier --fourier-encode-normals \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 2 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 10 --max-eval-batches 5
```
If a new flag is needed, add it to the Fourier encoding section in `train.py` (or wherever Fourier features are assembled — check `prepare_drivaerml.py` or the model forward pass). The key change is: locate where Fourier positional encoding is applied to xyz (columns 0–2) and extend the same logic to surface normals (columns 3–5). The input MLP should handle the expanded `input_dim` automatically if it reads the dimension from data at build time.

**Trial 1 — same frequency bands as xyz:**
```bash
cd target/icml2026
SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 \
  --enable-fourier --fourier-encode-normals \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --wandb_group dm-fourier-normals \
  --wandb_run_name dm-fourier-normals-trial1-full-bands
```

**Trial 2 — half frequency bands for normals:**
```bash
cd target/icml2026
SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 \
  --enable-fourier --fourier-encode-normals --fourier-normals-half-bands \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --wandb_group dm-fourier-normals \
  --wandb_run_name dm-fourier-normals-trial2-half-bands
```

Run both trials and report `val_primary/surface_rel_l2_pct` for each. If either trial produces NaN losses or diverges, report that immediately — do not continue training.

## Baseline

Current best DrivAerML metrics (from PR #3072, eren — EMA=0.9995 + gc=0.5, 4L/512d/8H, AdamW lr=5e-4, T_max=30):

- **val_primary/surface_rel_l2_pct: 3.833%** at epoch 511
- test surface_rel_l2_pct: 4.685%
- W&B run: [ncl1dh88](https://wandb.ai/senpai/icml2026/runs/ncl1dh88)
- Reproduce:
  ```bash
  cd target/icml2026
  SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml \
    --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 \
    --enable-fourier \
    --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
    --epochs 999 --batch-size 1 \
    --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
    --max-train-batches 394 --max-eval-batches 200 \
    --ema-decay 0.9995
  ```

**Target: val_primary/surface_rel_l2_pct < 3.833%**