### PR TITLE
DrivAerML: SAM optimizer for flat-basin LR-restart robustness

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -86,6 +86,58 @@ class EMAWithWarmup:
         self.backup = None
 
 
+class SAM:
+    """Sharpness-Aware Minimization wrapper (Foret et al. 2021)."""
+
+    def __init__(self, params, base_optimizer_cls, rho: float = 0.05, **kwargs):
+        self.base_optimizer = base_optimizer_cls(params, **kwargs)
+        self.rho = rho
+        self.param_groups = self.base_optimizer.param_groups
+        self._old_params: dict[int, torch.Tensor] = {}
+
+    @torch.no_grad()
+    def first_step(self):
+        grad_norm = self._grad_norm()
+        for group in self.param_groups:
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                self._old_params[id(p)] = p.data.clone()
+                e_w = self.rho * p.grad / (grad_norm + 1e-12)
+                p.add_(e_w)
+        self.base_optimizer.zero_grad(set_to_none=True)
+
+    @torch.no_grad()
+    def second_step(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                pid = id(p)
+                if pid in self._old_params:
+                    p.data.copy_(self._old_params[pid])
+        self._old_params.clear()
+        self.base_optimizer.step()
+        self.base_optimizer.zero_grad(set_to_none=True)
+
+    def zero_grad(self, set_to_none: bool = True):
+        self.base_optimizer.zero_grad(set_to_none=set_to_none)
+
+    def _grad_norm(self) -> torch.Tensor:
+        norms = []
+        for group in self.param_groups:
+            for p in group["params"]:
+                if p.grad is not None:
+                    norms.append(p.grad.detach().norm(p=2))
+        if not norms:
+            return torch.tensor(0.0)
+        return torch.norm(torch.stack(norms), p=2)
+
+    def state_dict(self):
+        return self.base_optimizer.state_dict()
+
+    def load_state_dict(self, state_dict):
+        self.base_optimizer.load_state_dict(state_dict)
+
+
 LEGACY_VAL_ALIAS = {
     "val_in_dist": "p_in",
     "val_ood_cond": "p_oodc",
@@ -166,6 +218,7 @@ class TrainConfig:
     volume_anchor_points: int = 8_000
     grad_clip: float = 0.0
     grad_accum_steps: int = 1
+    sam_rho: float = 0.05
     volume_loss_weight: float = 1.0
     save_checkpoint: bool = False
     seed: int = 0
@@ -547,6 +600,15 @@ def build_optimizer(params, config: TrainConfig):
         optimizer = Lion(params, lr=config.lr, weight_decay=config.weight_decay)
     elif config.optimizer == "adamw":
         optimizer = torch.optim.AdamW(params, lr=config.lr, weight_decay=config.weight_decay)
+    elif config.optimizer == "sam-adamw":
+        optimizer = SAM(
+            params,
+            torch.optim.AdamW,
+            rho=config.sam_rho,
+            lr=config.lr,
+            weight_decay=config.weight_decay,
+        )
+        return optimizer
     else:
         raise ValueError(f"Unknown optimizer: {config.optimizer}")
     if config.use_lookahead:
@@ -1281,11 +1343,47 @@ def train_one_epoch(
     batches = loader if max_batches <= 0 else itertools.islice(loader, max_batches)
     batch_iter = iter(batches)
     exhausted = False
+    is_sam = isinstance(optimizer, SAM)
+    clip_max = grad_clip if grad_clip > 0 else float("inf")
+
+    def _forward_loss(b):
+        if model_name == "reference_abupt":
+            with autocast_context(device, amp_mode):
+                outputs = model(
+                    geometry_position=b.geometry_position,
+                    geometry_supernode_idx=b.geometry_supernode_idx,
+                    geometry_batch_idx=b.geometry_batch_idx,
+                    surface_anchor_position=b.surface_anchor_position,
+                    volume_anchor_position=b.volume_anchor_position,
+                )
+                loss, _ = loss_abupt(b, outputs, transform, volume_loss_weight=volume_loss_weight)
+        elif isinstance(transform, TandemTargetTransform):
+            prepared = transform.prepare_batch(b)
+            with autocast_context(device, amp_mode):
+                outputs = model(
+                    surface_x=prepared.surface_x,
+                    surface_mask=prepared.surface_mask,
+                    volume_x=prepared.volume_x,
+                    volume_mask=prepared.volume_mask,
+                )
+                outputs = maybe_apply_anp(outputs, prepared, anp_head)
+                loss, _ = loss_grouped_tandem(prepared, outputs, volume_loss_weight=volume_loss_weight)
+        else:
+            with autocast_context(device, amp_mode):
+                outputs = model(
+                    surface_x=b.surface_x,
+                    surface_mask=b.surface_mask,
+                    volume_x=b.volume_x,
+                    volume_mask=b.volume_mask,
+                )
+                loss, _ = loss_grouped(b, outputs, transform, volume_loss_weight=volume_loss_weight)
+        return loss
 
     while not exhausted:
         optimizer.zero_grad(set_to_none=True)
         accum_loss = 0.0
         micro_count = 0
+        stored_batches: list = [] if is_sam else []
 
         for _ in range(grad_accum_steps):
             try:
@@ -1294,43 +1392,13 @@ def train_one_epoch(
                 exhausted = True
                 break
 
-            if model_name == "reference_abupt":
-                batch = batch.to(device)
-                with autocast_context(device, amp_mode):
-                    outputs = model(
-                        geometry_position=batch.geometry_position,
-                        geometry_supernode_idx=batch.geometry_supernode_idx,
-                        geometry_batch_idx=batch.geometry_batch_idx,
-                        surface_anchor_position=batch.surface_anchor_position,
-                        volume_anchor_position=batch.volume_anchor_position,
-                    )
-                    loss, _ = loss_abupt(batch, outputs, transform, volume_loss_weight=volume_loss_weight)
-            else:
-                batch = batch.to(device)
-                if isinstance(transform, TandemTargetTransform):
-                    prepared = transform.prepare_batch(batch)
-                    with autocast_context(device, amp_mode):
-                        outputs = model(
-                            surface_x=prepared.surface_x,
-                            surface_mask=prepared.surface_mask,
-                            volume_x=prepared.volume_x,
-                            volume_mask=prepared.volume_mask,
-                        )
-                        outputs = maybe_apply_anp(outputs, prepared, anp_head)
-                        loss, _ = loss_grouped_tandem(prepared, outputs, volume_loss_weight=volume_loss_weight)
-                else:
-                    with autocast_context(device, amp_mode):
-                        outputs = model(
-                            surface_x=batch.surface_x,
-                            surface_mask=batch.surface_mask,
-                            volume_x=batch.volume_x,
-                            volume_mask=batch.volume_mask,
-                        )
-                        loss, _ = loss_grouped(batch, outputs, transform, volume_loss_weight=volume_loss_weight)
-
+            batch = batch.to(device)
+            loss = _forward_loss(batch)
             accum_loss += float(loss.detach().cpu().item())
             (loss / grad_accum_steps).backward()
             micro_count += 1
+            if is_sam:
+                stored_batches.append(batch)
 
         if micro_count == 0:
             break
@@ -1338,13 +1406,27 @@ def train_one_epoch(
         all_params = list(model.parameters())
         if anp_head is not None:
             all_params += list(anp_head.parameters())
-        grad_norm = torch.nn.utils.clip_grad_norm_(all_params, max_norm=grad_clip if grad_clip > 0 else float("inf"))
+        grad_norm = torch.nn.utils.clip_grad_norm_(all_params, max_norm=clip_max)
         running.setdefault("grad_norm_mean", 0.0)
         running["grad_norm_mean"] += float(grad_norm)
         if grad_clip > 0 and float(grad_norm) > grad_clip:
             running.setdefault("grad_clip_events", 0.0)
             running["grad_clip_events"] += 1.0
-        optimizer.step()
+
+        if is_sam:
+            optimizer.first_step()
+            perturbed_loss = 0.0
+            for b in stored_batches:
+                loss = _forward_loss(b)
+                perturbed_loss += float(loss.detach().cpu().item())
+                (loss / grad_accum_steps).backward()
+            torch.nn.utils.clip_grad_norm_(all_params, max_norm=clip_max)
+            optimizer.second_step()
+            running.setdefault("train/sharpness", 0.0)
+            running["train/sharpness"] += (perturbed_loss / micro_count) - (accum_loss / micro_count)
+        else:
+            optimizer.step()
+
         if scheduler is not None:
             scheduler.step()
         if ema is not None:
@@ -1359,6 +1441,8 @@ def train_one_epoch(
     running["loss"] /= max(steps, 1)
     if "grad_norm_mean" in running:
         running["grad_norm_mean"] /= max(steps, 1)
+    if "train/sharpness" in running:
+        running["train/sharpness"] /= max(steps, 1)
     running["train_steps"] = float(steps)
     running["micro_batches"] = float(micro_batches_total)
     if scheduler is not None:
@@ -1629,7 +1713,12 @@ def main() -> None:
     optimizer = build_optimizer(params, config)
     scheduler = None
     if config.cosine_t_max > 0:
-        base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
+        if isinstance(optimizer, SAM):
+            base_optimizer = optimizer.base_optimizer
+        elif isinstance(optimizer, Lookahead):
+            base_optimizer = optimizer.optimizer
+        else:
+            base_optimizer = optimizer
         scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
 
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
@@ -1642,10 +1731,6 @@ def main() -> None:
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
 
-    if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
-    else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1719,7 +1804,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(best_val_primary_metric_name)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

Sharpness-Aware Minimization (SAM; Foret et al. 2021) steers training toward flatter loss basins by computing gradients at adversarially perturbed weight locations (radius `rho`). Our champion DrivAerML config uses cosine LR restarts (T_max=30), which periodically spike the learning rate and can kick weights out of sharp minima. The hypothesis is that SAM-trained weights, sitting in flatter basins, will survive these restart peaks better and converge to a lower surface_rel_l2_pct than AdamW alone.

References:
- Foret et al. 2021 — "Sharpness-Aware Minimization for Efficiently Improving Generalization": https://arxiv.org/abs/2010.01412
- PyPI `torch-sam` or manual two-step update pattern

## Instructions

Start from the champion DrivAerML config (PR #3072): 4L/512d/8H, AdamW lr=5e-4, T_max=30, EMA=0.9995, gc=0.5, Fourier, no WD.

**Implementation — wrapping AdamW with SAM:**

SAM is a wrapper around a base optimizer. The two-step update is:
1. Compute gradient at current weights w, perturb: w_hat = w + rho * grad / ||grad||
2. Compute gradient at w_hat, update base optimizer with that gradient, restore weights to w

You can implement this manually or use the `torch-sam` package (`pip install torch-sam`). If using torch-sam:

```python
from sam import SAM
base_optimizer = torch.optim.AdamW
optimizer = SAM(model.parameters(), base_optimizer, rho=0.05, lr=5e-4)

# Training step:
loss = criterion(outputs, targets)
loss.backward()
optimizer.first_step(zero_grad=True)   # perturb
loss2 = criterion(model(inputs), targets)
loss2.backward()
optimizer.second_step(zero_grad=True)  # update + restore
```

Grad-clip (gc=0.5) must be applied before each `first_step` and `second_step` call. EMA update should happen after `second_step`.

**Log a sharpness metric to W&B** each epoch:
```python
sharpness = (loss_at_perturbed - loss_at_current).item()
wandb.log({"train/sharpness": sharpness})
```

**Warning:** SAM doubles per-step compute (two forward-backward passes). Expect ~250 epochs in the 360-min timeout budget instead of ~500. This is acceptable — flat-basin benefits should appear within 150-200 epochs.

**Smoke test first:** Run 5 epochs with `--max-train-batches 10 --max-eval-batches 5` to confirm SAM integrates without errors before launching full runs.

---

### Trial 1 — SAM rho=0.05 (wider perturbation)

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer sam-adamw \
  --sam-rho 0.05 \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --wandb_group dm-sam-optimizer
```

If `--optimizer sam-adamw` and `--sam-rho` are not yet CLI flags, add them to `train.py` (add args + wrap the AdamW instantiation in the SAM wrapper when `args.optimizer == "sam-adamw"`).

### Trial 2 — SAM rho=0.02 (tighter perturbation)

Same command, change `--sam-rho 0.02`. Run this on a second GPU after Trial 1 starts.

---

Report best `val_primary/surface_rel_l2_pct` for each trial, the epoch it was achieved, and the W&B run IDs. Also paste the `train/sharpness` curve summary (min/max/final). Compare against the AdamW baseline (3.833%) to determine if flat-basin training helps.

## Baseline

Current best metrics from BASELINE.md (DrivAerML):
- `val_primary/surface_rel_l2_pct`: **3.833%** (at epoch 511)
- Best PR: #3072 (eren — EMA=0.9995 + gc=0.5, 4L/512d/8H, AdamW lr=5e-4, T_max=30)
- Baseline W&B run: `ncl1dh88`
- External target: <3.71% (AB-UPT, ~500 epochs) — gap: 0.123 pp

Reproduce command:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995
```