### PR TITLE
Gradient noise injection for DrivAerML: escape sharp minima, resist cosine restart divergence

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -166,6 +166,8 @@ class TrainConfig:
     volume_anchor_points: int = 8_000
     grad_clip: float = 0.0
     grad_accum_steps: int = 1
+    gn_eta: float = 0.0
+    gn_gamma: float = 0.55
     volume_loss_weight: float = 1.0
     save_checkpoint: bool = False
     seed: int = 0
@@ -1271,6 +1273,9 @@ def train_one_epoch(
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
     volume_loss_weight: float = 1.0,
+    gn_eta: float = 0.0,
+    gn_gamma: float = 0.55,
+    gn_global_step: int = 0,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1344,6 +1349,14 @@ def train_one_epoch(
         if grad_clip > 0 and float(grad_norm) > grad_clip:
             running.setdefault("grad_clip_events", 0.0)
             running["grad_clip_events"] += 1.0
+        if gn_eta > 0:
+            noise_scale = gn_eta / (1 + gn_global_step) ** gn_gamma
+            for p in all_params:
+                if p.grad is not None:
+                    p.grad.add_(torch.randn_like(p.grad) * noise_scale)
+            running.setdefault("gradient_noise_scale_sum", 0.0)
+            running["gradient_noise_scale_sum"] += noise_scale
+            gn_global_step += 1
         optimizer.step()
         if scheduler is not None:
             scheduler.step()
@@ -1363,6 +1376,9 @@ def train_one_epoch(
     running["micro_batches"] = float(micro_batches_total)
     if scheduler is not None:
         running["lr"] = float(optimizer.param_groups[0]["lr"])
+    if gn_eta > 0 and steps > 0:
+        running["train/gradient_noise_scale"] = running.pop("gradient_noise_scale_sum") / steps
+    running["_gn_global_step"] = gn_global_step
     return running
 
 
@@ -1643,9 +1659,9 @@ def main() -> None:
     best_anp_state: dict[str, torch.Tensor] | None = None
 
     if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
+        val_primary_key = "val_primary/surface_pressure_mae"
     else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+        val_primary_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1668,6 +1684,7 @@ def main() -> None:
 
     start_time = time.monotonic()
     timeout_seconds = None if not timeout_env else float(timeout_env) * 60.0
+    gn_global_step = 0
 
     for epoch in range(1, config.epochs + 1):
         if timeout_seconds is not None and epoch > 1 and (time.monotonic() - start_time) >= timeout_seconds:
@@ -1688,7 +1705,11 @@ def main() -> None:
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
             volume_loss_weight=config.volume_loss_weight,
+            gn_eta=config.gn_eta,
+            gn_gamma=config.gn_gamma,
+            gn_global_step=gn_global_step,
         )
+        gn_global_step = train_metrics.pop("_gn_global_step", gn_global_step)
 
         if ema is not None:
             ema.store(model)
@@ -1719,7 +1740,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(val_primary_key)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

Cosine LR restarts push DrivAerML into sharp minima that diverge when LR spikes back up at restart peaks — the core DM instability we've been fighting. Dropout (multiplicative noise) is confirmed dead on DM because it compounds at restart boundaries. Gradient noise injection (Neelakantan et al., 2015) is the additive, decaying alternative: after each backward pass we inject `noise ~ N(0, η/(1+t)^γ)` into every gradient tensor before the optimizer step. Because noise is additive (not multiplicative like dropout) and decays monotonically with training steps `t`, it is inherently compatible with cosine scheduling — high noise early flattens the loss landscape, and by the time later restarts arrive, noise has decayed to near-zero so it doesn't destabilise the refined trajectory.

Paper reference: Neelakantan et al. (2015) "Adding Gradient Noise Improves Learning for Very Deep Networks" — https://arxiv.org/abs/1511.06807

## Instructions

Add gradient noise injection to `target/icml2026/train.py`. After each `loss.backward()` (or wherever the backward pass completes), before `optimizer.step()`, inject decaying Gaussian noise into all parameter gradients:

```python
# Gradient noise injection — Neelakantan et al. 2015
# Place this block after loss.backward(), before optimizer.step()
noise_scale = gn_eta / (1 + global_step) ** gn_gamma
for p in model.parameters():
    if p.grad is not None:
        p.grad.add_(torch.randn_like(p.grad) * noise_scale)
# Log to W&B each step:
# wandb.log({"train/gradient_noise_scale": noise_scale}, step=global_step)
```

Add CLI args `--gn-eta` (default 0.0, float) and `--gn-gamma` (default 0.55, float). When `gn_eta == 0.0` the injection is skipped (no-op, backward-compatible).

**Run two trials** using the full DM champion config. Smoke test each first (`--max-train-batches 10 --max-eval-batches 5 --epochs 2`) before committing to a full run.

**Trial 1 — paper defaults (eta=0.1, gamma=0.55):**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --grad-clip 0.5 --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --gn-eta 0.1 --gn-gamma 0.55 \
  --wandb_group dm-gradient-noise
```

**Trial 2 — lighter noise (eta=0.01, gamma=0.55):**
(In case eta=0.1 is too aggressive in combination with gc=0.5)
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --grad-clip 0.5 --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --gn-eta 0.01 --gn-gamma 0.55 \
  --wandb_group dm-gradient-noise
```

**Logging:** Log `train/gradient_noise_scale` to W&B each step so we can see the noise decay curve. Also watch for any training instability — if either run diverges at a cosine restart, report which epoch/step it happened and the noise scale at that moment.

Report results from both trials. If Trial 1 (eta=0.1) diverges, Trial 2 (eta=0.01) is the fallback.

## Baseline

Current best DrivAerML metrics (PR #3072, W&B run: ncl1dh88):
- **val_primary/surface_rel_l2_pct: 3.833%** (beat this to merge)
- test surface_rel_l2_pct: 4.685%
- Config: AdamW lr=5e-4, T_max=30, gc=0.5, EMA=0.9995, 4L/512d/8H, Fourier
- External target: <3.71% (AB-UPT, ~500 epochs) — gap: 0.123 pp

Reproduce baseline:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --grad-clip 0.5 --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995
```

W&B baseline run: ncl1dh88