### PR TITLE
AirfRANS: surface-proximity volume weighting for vol_mse

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -167,6 +167,9 @@ class TrainConfig:
     grad_clip: float = 0.0
     grad_accum_steps: int = 1
     volume_loss_weight: float = 1.0
+    vol_proximity_mode: str = "none"
+    vol_proximity_eps: float = 0.01
+    vol_proximity_scale: float = 0.1
     save_checkpoint: bool = False
     seed: int = 0
 
@@ -758,11 +761,32 @@ def _named_channel_metrics(prefix: str, values: torch.Tensor, names: tuple[str, 
     return metrics
 
 
+def _proximity_weights(
+    sdf: torch.Tensor,
+    mode: str,
+    eps: float = 0.01,
+    scale: float = 0.1,
+) -> torch.Tensor:
+    d = sdf.abs()
+    if mode == "inverse":
+        w = 1.0 / (d + eps)
+        w = w.clamp(max=w.median() * 20.0)
+    elif mode == "exponential":
+        w = torch.exp(-d / scale)
+    else:
+        raise ValueError(f"Unknown proximity mode: {mode}")
+    w = w / (w.mean() + 1e-12)
+    return w
+
+
 def loss_grouped(
     batch: GroupedBatch,
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
     volume_loss_weight: float = 1.0,
+    vol_proximity_mode: str = "none",
+    vol_proximity_eps: float = 0.01,
+    vol_proximity_scale: float = 0.1,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.surface_x.device)
     metrics: dict[str, float] = {}
@@ -773,7 +797,18 @@ def loss_grouped(
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
     if batch.volume_y is not None and outputs["volume_preds"] is not None and batch.volume_mask is not None:
         target = transform.apply(batch.volume_y)
-        vol_loss = F.mse_loss(outputs["volume_preds"][batch.volume_mask], target[batch.volume_mask])
+        preds_masked = outputs["volume_preds"][batch.volume_mask]
+        target_masked = target[batch.volume_mask]
+        if vol_proximity_mode != "none" and batch.volume_x is not None and batch.dataset_name == "airfrans":
+            sdf = batch.volume_x[batch.volume_mask][:, 4]
+            w = _proximity_weights(sdf, vol_proximity_mode, vol_proximity_eps, vol_proximity_scale)
+            per_point_mse = ((preds_masked - target_masked) ** 2).mean(dim=-1)
+            vol_loss = (w * per_point_mse).mean()
+            metrics["proximity_weight_max"] = float(w.max().item())
+            metrics["proximity_weight_min"] = float(w.min().item())
+            metrics["proximity_weight_std"] = float(w.std().item())
+        else:
+            vol_loss = F.mse_loss(preds_masked, target_masked)
         total = total + vol_loss * volume_loss_weight
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
@@ -1271,6 +1306,9 @@ def train_one_epoch(
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
     volume_loss_weight: float = 1.0,
+    vol_proximity_mode: str = "none",
+    vol_proximity_eps: float = 0.01,
+    vol_proximity_scale: float = 0.1,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1326,7 +1364,17 @@ def train_one_epoch(
                             volume_x=batch.volume_x,
                             volume_mask=batch.volume_mask,
                         )
-                        loss, _ = loss_grouped(batch, outputs, transform, volume_loss_weight=volume_loss_weight)
+                        loss, batch_metrics = loss_grouped(
+                            batch, outputs, transform,
+                            volume_loss_weight=volume_loss_weight,
+                            vol_proximity_mode=vol_proximity_mode,
+                            vol_proximity_eps=vol_proximity_eps,
+                            vol_proximity_scale=vol_proximity_scale,
+                        )
+                        if "proximity_weight_max" in batch_metrics:
+                            for k in ("proximity_weight_max", "proximity_weight_min", "proximity_weight_std"):
+                                running.setdefault(k, 0.0)
+                                running[k] += batch_metrics[k]
 
             accum_loss += float(loss.detach().cpu().item())
             (loss / grad_accum_steps).backward()
@@ -1359,6 +1407,9 @@ def train_one_epoch(
     running["loss"] /= max(steps, 1)
     if "grad_norm_mean" in running:
         running["grad_norm_mean"] /= max(steps, 1)
+    for k in ("proximity_weight_max", "proximity_weight_min", "proximity_weight_std"):
+        if k in running:
+            running[k] /= max(steps, 1)
     running["train_steps"] = float(steps)
     running["micro_batches"] = float(micro_batches_total)
     if scheduler is not None:
@@ -1635,17 +1686,9 @@ def main() -> None:
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
     history: list[dict[str, float]] = []
-    best_epoch: int | None = None
     best_val_primary_metric_name = primary_metric_key(bundle, phase="val")
     best_val_primary_metric: float | None = None
     best_val_metrics: dict[str, float] = {}
-    best_model_state: dict[str, torch.Tensor] | None = None
-    best_anp_state: dict[str, torch.Tensor] | None = None
-
-    if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
-    else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1688,6 +1731,9 @@ def main() -> None:
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
             volume_loss_weight=config.volume_loss_weight,
+            vol_proximity_mode=config.vol_proximity_mode,
+            vol_proximity_eps=config.vol_proximity_eps,
+            vol_proximity_scale=config.vol_proximity_scale,
         )
 
         if ema is not None:
@@ -1719,7 +1765,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(best_val_primary_metric_name)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis
In CFD, near-surface volume predictions (boundary layer, wake region) are more physically important than far-field predictions where the flow is close to freestream. The current volume loss weights all volume points equally, but errors near the airfoil surface matter much more for accurate drag/lift prediction. By weighting the volume loss inversely proportional to distance from the nearest surface point, we focus the model's capacity on the most physically meaningful volume regions.

AF champion (#3135): surface_mse=0.000296, vol_mse=0.002039. Target: vol_mse < 0.0017. Human directive: ALL new AF experiments must target vol_mse < 0.0017.

## Instructions
Champion config baseline: AdamW lr=6e-4, T_max=50, gc=1.0, WD=1e-2, EMA=0.999, 2L/256d, --model-heads 4, --vol-loss-weight 10.0, --enable-fourier

Implementation:
1. For each volume point, compute the minimum Euclidean distance to any surface point in the same sample.
2. Create a weight: `w_i = 1 / (d_i + epsilon)` where epsilon=0.01. Normalize weights to mean=1.0 to preserve the overall loss scale.
3. Apply: `vol_loss = mean(w_i * (pred_i - target_i)^2)`
4. Alternative form: `w_i = exp(-d_i / scale)` (also normalized to mean=1.0), with scale=0.1 (tight BL focus) or scale=0.5 (broader near-surface region).

Run a smoke test (3 epochs) first to verify shapes and loss values are sensible before running full trials.
Use `--wandb_group af-proximity-volume-weighting` for all runs.

**Trial 1**: Inverse-distance weighting 1/(d+eps), eps=0.01. Full champion config:
```
cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 \
  --weight-decay 1e-2 --enable-fourier --model-layers 2 --model-hidden-dim 256 \
  --model-heads 4 --epochs 999 --ema-decay 0.999 --vol-loss-weight 10.0 \
  --wandb_group af-proximity-volume-weighting
```

**Trial 2**: Exponential decay weighting, scale=0.1 (tight boundary layer). Same champion config as Trial 1 but with exp(-d/0.1) weights instead of 1/(d+eps).

**Trial 3** (conditional — only run if T1 or T2 improves over baseline): Take the better-performing weighting scheme from T1/T2 and try scale=0.5 for the exponential form, or eps=0.05 for the inverse-distance form. This tests whether a broader near-surface region performs better than a tighter one.

Hard constraint: surface_mse must not regress beyond 0.000296 — if any trial shows surface regression, stop and report.

## Baseline
- val_primary/surface_mse: 0.000296 (HARD CONSTRAINT — no regressions allowed)
- val_primary/vol_mse: 0.002039 (target: < 0.0017 per human directive)
- Best PR: #3135 (nezuko — EMA=0.999 + vol-weight=10x, 2L/256d, AdamW lr=6e-4, gc=1.0, WD=1e-2)
- W&B baseline run: sh2zyfwr (nezuko/af-ema-vol-weight-10x)
- Reproduce command:
```
cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 \
  --weight-decay 1e-2 --enable-fourier --model-layers 2 --model-hidden-dim 256 \
  --model-heads 4 --epochs 999 --ema-decay 0.999 --vol-loss-weight 10.0
```