### PR TITLE
AirfRANS: volume smoothness regularization to cut vol_mse

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -167,6 +167,9 @@ class TrainConfig:
     grad_clip: float = 0.0
     grad_accum_steps: int = 1
     volume_loss_weight: float = 1.0
+    vol_smooth_lambda: float = 0.0
+    vol_smooth_k: int = 4
+    vol_smooth_formulation: str = "A"
     save_checkpoint: bool = False
     seed: int = 0
 
@@ -821,6 +824,62 @@ def loss_abupt(
     return total, metrics
 
 
+_MAX_SMOOTH_NODES = 4000
+
+
+def compute_vol_smooth_loss(
+    batch: GroupedBatch,
+    outputs: dict[str, torch.Tensor | None],
+    transform: TargetTransform,
+    k: int = 4,
+    formulation: str = "A",
+) -> torch.Tensor | None:
+    if batch.volume_x is None or batch.volume_y is None or batch.volume_mask is None:
+        return None
+    vol_preds = outputs.get("volume_preds")
+    if vol_preds is None:
+        return None
+
+    vol_target = transform.apply(batch.volume_y)
+    B = batch.volume_mask.shape[0]
+    smooth_total = torch.tensor(0.0, device=batch.volume_x.device)
+    count = 0
+
+    for i in range(B):
+        mask_i = batch.volume_mask[i]
+        valid_idx = mask_i.nonzero(as_tuple=True)[0]
+        n_valid = valid_idx.shape[0]
+        if n_valid <= k:
+            continue
+
+        if n_valid > _MAX_SMOOTH_NODES:
+            perm = torch.randperm(n_valid, device=valid_idx.device)[:_MAX_SMOOTH_NODES]
+            valid_idx = valid_idx[perm]
+            n_valid = _MAX_SMOOTH_NODES
+
+        pos_i = batch.volume_x[i, valid_idx, :batch.space_dim].float()
+        pred_i = vol_preds[i, valid_idx]
+        target_i = vol_target[i, valid_idx]
+
+        with torch.no_grad():
+            dist = torch.cdist(pos_i, pos_i)
+            dist.fill_diagonal_(float("inf"))
+            _, knn_idx = dist.topk(k, dim=1, largest=False)
+
+        src = torch.arange(n_valid, device=dist.device).unsqueeze(1).expand_as(knn_idx).reshape(-1)
+        dst = knn_idx.reshape(-1)
+
+        if formulation == "A":
+            smooth_total = smooth_total + ((pred_i[src] - pred_i[dst]) ** 2 - (target_i[src] - target_i[dst]) ** 2).pow(2).mean()
+        else:
+            smooth_total = smooth_total + ((pred_i[src] - pred_i[dst]) ** 2).mean()
+        count += 1
+
+    if count == 0:
+        return None
+    return smooth_total / count
+
+
 def maybe_apply_anp(
     outputs: dict[str, torch.Tensor | None],
     prepared: TandemPreparedBatch,
@@ -1271,6 +1330,9 @@ def train_one_epoch(
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
     volume_loss_weight: float = 1.0,
+    vol_smooth_lambda: float = 0.0,
+    vol_smooth_k: int = 4,
+    vol_smooth_formulation: str = "A",
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1327,6 +1389,12 @@ def train_one_epoch(
                             volume_mask=batch.volume_mask,
                         )
                         loss, _ = loss_grouped(batch, outputs, transform, volume_loss_weight=volume_loss_weight)
+                    if vol_smooth_lambda > 0:
+                        smooth = compute_vol_smooth_loss(batch, outputs, transform, k=vol_smooth_k, formulation=vol_smooth_formulation)
+                        if smooth is not None:
+                            loss = loss + vol_smooth_lambda * smooth
+                            running.setdefault("vol_smooth_loss", 0.0)
+                            running["vol_smooth_loss"] += float(smooth.detach().cpu().item())
 
             accum_loss += float(loss.detach().cpu().item())
             (loss / grad_accum_steps).backward()
@@ -1359,6 +1427,8 @@ def train_one_epoch(
     running["loss"] /= max(steps, 1)
     if "grad_norm_mean" in running:
         running["grad_norm_mean"] /= max(steps, 1)
+    if "vol_smooth_loss" in running:
+        running["vol_smooth_loss"] /= max(steps, 1)
     running["train_steps"] = float(steps)
     running["micro_batches"] = float(micro_batches_total)
     if scheduler is not None:
@@ -1688,6 +1758,9 @@ def main() -> None:
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
             volume_loss_weight=config.volume_loss_weight,
+            vol_smooth_lambda=config.vol_smooth_lambda,
+            vol_smooth_k=config.vol_smooth_k,
+            vol_smooth_formulation=config.vol_smooth_formulation,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

Smooth volume field predictions should reduce `vol_mse`. The current champion (PR #3135) achieves `vol_mse=0.002039` but physical intuition tells us CFD volume fields are spatially smooth — adjacent points in the domain share similar pressure/velocity values. By penalizing spatial discontinuities in predicted volume fields, we may teach the model to respect this physical prior and reduce `vol_mse` toward <0.0017.

Proposed smoothness regularization: for each batch of volume points, find k-nearest neighbours among the volume nodes (k=4 or k=8), then penalize large prediction differences between adjacent pairs.

## Instructions

Start from the champion config (PR #3135):

```bash
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 \
  --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 \
  --enable-fourier \
  --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 --ema-decay 0.999 --vol-loss-weight 10.0
```

**Step 0: smoke test first.** Run 3 epochs on Trial 1 (below) before committing to full runs. Confirm training doesn't diverge and vol smoothness loss is non-zero.

### Implementation — Volume Smoothness Regularizer

Add the following logic to `train.py` (in the volume-node loss computation block):

1. **Find neighbours** (do this on the batch of volume node positions `pos_vol`):

```python
from torch_geometric.nn import knn_graph  # or use torch cdist + topk

# k=4 neighbours within the volume batch
edge_index = knn_graph(pos_vol, k=4, batch=batch_vol, loop=False)
src, dst = edge_index[0], edge_index[1]
```

2. **Compute smoothness loss** — two formulations to try:

**Formulation A — difference-of-differences (physics-aware):**
```python
# Penalise predictions that are *more* different than the target is
smooth_loss = ((pred_vol[src] - pred_vol[dst])**2 - (target_vol[src] - target_vol[dst])**2).pow(2).mean()
```

**Formulation B — strict smoothness:**
```python
# Penalise any prediction difference between neighbours
smooth_loss = ((pred_vol[src] - pred_vol[dst])**2).mean()
```

3. **Add to total loss:**
```python
total_loss = primary_loss + lambda_smooth * smooth_loss
```

### Trial configurations

Add a `--vol-smooth-lambda` argument (default 0.0) and a `--vol-smooth-k` argument (default 4). Use `--wandb_group af-volume-smooth-regularization` on every run.

| Trial | Formulation | lambda | k |
|-------|-------------|--------|---|
| 1     | A (diff-of-diff) | 0.01 | 4 |
| 2     | A (diff-of-diff) | 0.001 | 4 |
| 3     | B (strict) | 0.001 | 4 |
| 4     | B (strict) | 0.0001 | 8 |

Run all four trials to full convergence (or until the `SENPAI_TIMEOUT_MINUTES` limit).

**Hard constraints:**
- `surface_mse` must NOT regress beyond 0.000296 (the current baseline). If any trial increases surface_mse, discard it regardless of vol_mse.
- Target: `vol_mse < 0.002039`, ideally `vol_mse < 0.0017`.

Report the best `surface_mse` and `vol_mse` (from best val checkpoint) for each trial, plus W&B run IDs.

## Baseline

Current AirfRANS champion metrics (PR #3135, nezuko):
- `val_primary/surface_mse`: **0.000296** (epoch 704)
- `val_primary/vol_mse`: **0.002039** (epoch 743)
- Baseline W&B run: `sh2zyfwr`
- Config: 2L/256d/4H, AdamW lr=6e-4, T_max=50, gc=1.0, WD=1e-2, EMA=0.999, vol-weight=10x, Fourier

Reproduce command:
```bash
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 \
  --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 \
  --enable-fourier \
  --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 --ema-decay 0.999 --vol-loss-weight 10.0
```