### PR TITLE
Spectral norm on attention layers: Lipschitz-constrained DM training

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -542,6 +542,35 @@ def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
     raise ValueError(f"Unknown model: {config.model}")
 
 
+def apply_spectral_norm(model: torch.nn.Module, mode: str = "qkv") -> int:
+    """Apply spectral norm to attention layers. Returns count of wrapped layers.
+
+    mode="qkv": only QKV projections (Trial 1)
+    mode="all": every nn.Linear in the model (Trial 2)
+    """
+    sn = torch.nn.utils.spectral_norm
+    count = 0
+    if mode == "all":
+        for module in model.modules():
+            if isinstance(module, torch.nn.Linear):
+                sn(module)
+                count += 1
+        return count
+    backbone = getattr(model, "backbone", None)
+    if backbone is None:
+        return 0
+    blocks = getattr(backbone, "blocks", [])
+    for block in blocks:
+        attn = getattr(block, "attention", None)
+        if attn is None:
+            continue
+        qkv = getattr(attn, "qkv", None)
+        if qkv is not None and hasattr(qkv, "project"):
+            sn(qkv.project)
+            count += 1
+    return count
+
+
 def build_optimizer(params, config: TrainConfig):
     if config.optimizer == "lion":
         optimizer = Lion(params, lr=config.lr, weight_decay=config.weight_decay)
@@ -1615,6 +1644,9 @@ def main() -> None:
 
     train_loader, val_loaders, test_loaders = build_loaders(config, bundle, num_workers=resolved_num_workers)
     model = build_model(config, bundle).to(device)
+    sn_count = apply_spectral_norm(model, mode="qkv")
+    if sn_count > 0:
+        print(f"[spectral_norm] Applied to {sn_count} QKV projection(s)", flush=True)
     forward_model = torch.compile(model) if config.compile_model and device.type == "cuda" else model
     anp_head = None
     if bundle.spec.name == "tandemfoilset" and config.anp_srf:
@@ -1739,6 +1771,16 @@ def main() -> None:
         epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
         epoch_metrics["best_val_metric"] = best_val_metric
         epoch_metrics["best_epoch"] = float(best_epoch)
+        backbone = getattr(model, "backbone", None)
+        if backbone is not None:
+            for i, block in enumerate(getattr(backbone, "blocks", [])):
+                attn = getattr(block, "attention", None)
+                if attn is not None:
+                    qkv = getattr(attn, "qkv", None)
+                    if qkv is not None and hasattr(qkv.project, "weight_orig"):
+                        with torch.no_grad():
+                            sigma = torch.linalg.norm(qkv.project.weight_orig, ord=2).item()
+                        epoch_metrics[f"spectral_sigma/block_{i}_qkv"] = sigma
         history.append(epoch_metrics)
         if run is not None:
             wandb.log(epoch_metrics, step=epoch)


### PR DESCRIPTION
## Hypothesis

The DrivAerML DM training diverges at cosine LR restart peaks: gradient norms spike despite gc=0.5 EMA. We hypothesize that **spectral normalization** (Miyato et al., 2018 — [arXiv:1802.05957](https://arxiv.org/abs/1802.05957)) on the transformer attention layers will bound the Lipschitz constant of the network by construction, eliminating the spike-driven divergence.

Spectral norm constrains each weight matrix W by dividing by its largest singular value σ(W):

    W_SN = W / σ(W)

This caps the spectral radius of every linear map to ≤1 regardless of learning rate phase, making gradient norm explosions structurally impossible. Originally developed for GAN discriminators, it is now widely used to stabilize transformer training (e.g. Ding et al., 2021 on stabilizing T5/BERT fine-tuning). In our case the cosine peak at each T_max restart acts like a short burst of high LR — exactly the regime where unbounded Lipschitz constants create instability.

Compared to gradient clipping, which is reactive (clips after the spike occurs), spectral norm is preventive (spike cannot form). The two are orthogonal and should be used together.

## Instructions

**Champion config** (from PR #3072, W&B: ncl1dh88):

```
AdamW lr=5e-4, cosine T_max=30, gc=0.5, EMA=0.9995
4L / 512d / 8H, batch-size=1, 50k surface points
```

Wrap the apply call around the relevant `nn.Linear` layers using `torch.nn.utils.spectral_norm`. You do **not** need to add any new command-line flags — just modify the model construction code to wrap layers.

---

### Trial 1 — QKV projections only (recommended starting point)

Apply spectral norm to the Q, K, V projection linears inside every attention block. Leave the output projection, FFN, and embedding layers unwrapped. This is the minimal intervention targeting the layers most responsible for attention pattern instability.

In the attention module, find the Q/K/V linear layers (names like `q_proj`, `k_proj`, `v_proj`, or `to_q`, `to_k`, `to_v`) and wrap:

```python
import torch.nn.utils as nn_utils

self.q_proj = nn_utils.spectral_norm(nn.Linear(dim, dim))
self.k_proj = nn_utils.spectral_norm(nn.Linear(dim, dim))
self.v_proj = nn_utils.spectral_norm(nn.Linear(dim, dim))
```

Or, if the model builds layers in a loop, iterate and apply after construction:

```python
for name, module in model.named_modules():
    if isinstance(module, nn.MultiheadAttention):
        nn_utils.spectral_norm(module, name='in_proj_weight')
```

Run with the full champion config:

```bash
cd target/icml2026
SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --wandb_group dm-spectral-norm
```

**Smoke test first:** run 10 epochs and confirm `grad_norm` in W&B no longer spikes at the cosine restart boundary (epochs ~30, 60, 90). If grad_norm stays flat through the first restart, proceed to full training.

---

### Trial 2 — All linear layers (if Trial 1 wins)

If Trial 1 beats baseline, extend spectral norm to every `nn.Linear` in the model (QKV + output projection + all FFN layers). This maximises the Lipschitz bound everywhere:

```python
for name, module in model.named_modules():
    if isinstance(module, nn.Linear):
        nn_utils.spectral_norm(module)
```

Same run command as Trial 1. Use `--wandb_group dm-spectral-norm` so both trials appear together.

---

**W&B monitoring:** log `grad_norm` per step. The key diagnostic is whether the cosine-peak spike disappears with spectral norm applied. Report this in the PR comment alongside the primary metric.

## Baseline

Current best DrivAerML metrics (PR #3072, W&B run: ncl1dh88 — eren/dm-ema-9995-gc05):

| Metric | Value |
|--------|-------|
| `val_primary/surface_rel_l2_pct` | **3.833%** (epoch 511) |
| test surface_rel_l2_pct | 4.685% |

External target: **<3.71%** (AB-UPT, ~500 epochs) — gap = 0.123 pp (1.03x)

Reproduce command:
```bash
cd target/icml2026
SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995
```