### PR TITLE
DM: self-distillation via EMA teacher consistency loss

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -169,6 +169,7 @@ class TrainConfig:
     volume_loss_weight: float = 1.0
     save_checkpoint: bool = False
     seed: int = 0
+    self_distill_alpha: float = 0.0
 
 
 @dataclass
@@ -1271,6 +1272,7 @@ def train_one_epoch(
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
     volume_loss_weight: float = 1.0,
+    self_distill_alpha: float = 0.0,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1328,6 +1330,46 @@ def train_one_epoch(
                         )
                         loss, _ = loss_grouped(batch, outputs, transform, volume_loss_weight=volume_loss_weight)
 
+            if self_distill_alpha > 0 and ema is not None and model_name != "reference_abupt":
+                with torch.no_grad():
+                    ema.store(model)
+                    ema.copy_to(model)
+                    if isinstance(transform, TandemTargetTransform):
+                        with autocast_context(device, amp_mode):
+                            ema_out = model(
+                                surface_x=prepared.surface_x,
+                                surface_mask=prepared.surface_mask,
+                                volume_x=prepared.volume_x,
+                                volume_mask=prepared.volume_mask,
+                            )
+                        srf_mask = prepared.surface_mask
+                        vol_mask = prepared.volume_mask if prepared.volume_target is not None else None
+                    else:
+                        with autocast_context(device, amp_mode):
+                            ema_out = model(
+                                surface_x=batch.surface_x,
+                                surface_mask=batch.surface_mask,
+                                volume_x=batch.volume_x,
+                                volume_mask=batch.volume_mask,
+                            )
+                        srf_mask = batch.surface_mask
+                        vol_mask = batch.volume_mask if batch.volume_y is not None else None
+                    ema.restore(model)
+                distill = torch.tensor(0.0, device=loss.device)
+                if outputs["surface_preds"] is not None and ema_out["surface_preds"] is not None:
+                    distill = distill + F.mse_loss(
+                        outputs["surface_preds"][srf_mask],
+                        ema_out["surface_preds"][srf_mask],
+                    )
+                if vol_mask is not None and outputs.get("volume_preds") is not None and ema_out.get("volume_preds") is not None:
+                    distill = distill + F.mse_loss(
+                        outputs["volume_preds"][vol_mask],
+                        ema_out["volume_preds"][vol_mask],
+                    )
+                loss = (1 - self_distill_alpha) * loss + self_distill_alpha * distill
+                running.setdefault("distill_loss", 0.0)
+                running["distill_loss"] += float(distill.detach().cpu().item())
+
             accum_loss += float(loss.detach().cpu().item())
             (loss / grad_accum_steps).backward()
             micro_count += 1
@@ -1359,6 +1401,8 @@ def train_one_epoch(
     running["loss"] /= max(steps, 1)
     if "grad_norm_mean" in running:
         running["grad_norm_mean"] /= max(steps, 1)
+    if "distill_loss" in running:
+        running["distill_loss"] /= max(steps, 1)
     running["train_steps"] = float(steps)
     running["micro_batches"] = float(micro_batches_total)
     if scheduler is not None:
@@ -1688,6 +1732,7 @@ def main() -> None:
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
             volume_loss_weight=config.volume_loss_weight,
+            self_distill_alpha=config.self_distill_alpha,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

The EMA model (decay=0.9995) is already computed every step and used only for best-checkpoint selection. We hypothesize that its smoothed predictions carry a richer, lower-variance teaching signal than the raw ground-truth labels alone. By adding a consistency regularization term that nudges the online model toward the EMA model's predictions, we can extract a free training signal — effectively implementing Born Again Neural Networks (Furlanello et al., 2018, https://arxiv.org/abs/1805.04770) within a single training run.

Loss formulation:
```
loss = (1 - alpha) * MSE(pred, target) + alpha * MSE(pred, ema_pred)
```

Where `ema_pred` is computed with `torch.no_grad()` from the EMA model (no gradient flows through the teacher). This adds zero parameters and negligible compute.

Two trials:
- **Trial A**: alpha=0.3 (stronger distillation signal)
- **Trial B**: alpha=0.1 (lighter regularization, closer to baseline)

## Instructions

Start from the DM champion config (PR #3072). Apply the following changes:

**1. Smoke test first** (1–2 epochs, both alpha values) to confirm loss decreases and no NaN/divergence before committing to full runs.

**2. Implementation — add to `train.py`:**

In the training loop, after computing the standard supervised loss, compute the EMA model's prediction on the same batch and add the consistency term:

```python
# After: loss = criterion(pred, target)
with torch.no_grad():
    ema_pred = ema_model(x)  # use whatever the EMA model forward call is
distill_loss = F.mse_loss(pred, ema_pred)
loss = (1 - alpha) * loss + alpha * distill_loss
```

Log `distill_loss` separately in W&B every step so we can track how the teacher-student gap evolves over training.

**3. Run both trials with the champion DM config:**

**Trial A (alpha=0.3):**
```bash
cd target/icml2026
SENPAI_MAX_EPOCHS=9999 python train.py \
    --dataset drivaerml \
    --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 \
    --enable-fourier \
    --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
    --epochs 999 \
    --batch-size 1 \
    --drivaerml-train-surface-points 50000 \
    --drivaerml-eval-surface-points 50000 \
    --max-train-batches 394 --max-eval-batches 200 \
    --ema-decay 0.9995 \
    --self-distill-alpha 0.3 \
    --wandb_group dm-self-distillation
```

**Trial B (alpha=0.1):**
```bash
cd target/icml2026
SENPAI_MAX_EPOCHS=9999 python train.py \
    --dataset drivaerml \
    --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 \
    --enable-fourier \
    --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
    --epochs 999 \
    --batch-size 1 \
    --drivaerml-train-surface-points 50000 \
    --drivaerml-eval-surface-points 50000 \
    --max-train-batches 394 --max-eval-batches 200 \
    --ema-decay 0.9995 \
    --self-distill-alpha 0.1 \
    --wandb_group dm-self-distillation
```

If `--self-distill-alpha` is not yet a CLI flag, implement it and add it. The default should be 0.0 (disabled) so existing runs are unaffected.

**4. Report back with:**
- Best `val_primary/surface_rel_l2_pct` for each trial (from the EMA checkpoint, not the online model)
- W&B run IDs for both trials
- A plot or logged values of `distill_loss` over training to show teacher-student gap evolution
- Whether alpha=0.3 or alpha=0.1 performed better and any intuition why

## Baseline

Current DrivAerML best (target to beat):
- **val** `surface_rel_l2_pct`: **3.833%** (epoch 511)
- **test** `surface_rel_l2_pct`: **4.685%**
- Best PR: #3072 (eren — EMA=0.9995 + gc=0.5, 4L/512d/8H, AdamW lr=5e-4, T_max=30)
- W&B run: `ncl1dh88` (eren/dm-ema-9995-gc05)
- Reproduce command:
```bash
cd target/icml2026
SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml \
    --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 --enable-fourier \
    --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 \
    --batch-size 1 --drivaerml-train-surface-points 50000 \
    --drivaerml-eval-surface-points 50000 --max-train-batches 394 \
    --max-eval-batches 200 --ema-decay 0.9995
```