### PR TITLE
AirfRANS: vol-weight curriculum 20x→10x decay (front-load volume)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -167,6 +167,8 @@ class TrainConfig:
     grad_clip: float = 0.0
     grad_accum_steps: int = 1
     volume_loss_weight: float = 1.0
+    vol_weight_start: float = 0.0
+    vol_weight_end: float = 0.0
     save_checkpoint: bool = False
     seed: int = 0
 
@@ -1669,9 +1671,24 @@ def main() -> None:
     start_time = time.monotonic()
     timeout_seconds = None if not timeout_env else float(timeout_env) * 60.0
 
+    use_vol_curriculum = (
+        config.vol_weight_start > 0.0
+        and config.vol_weight_end > 0.0
+        and config.vol_weight_start != config.vol_weight_end
+    )
+    vol_decay_epochs = int(0.5 * config.epochs) if use_vol_curriculum else 0
+
     for epoch in range(1, config.epochs + 1):
         if timeout_seconds is not None and epoch > 1 and (time.monotonic() - start_time) >= timeout_seconds:
             break
+
+        if use_vol_curriculum:
+            ep0 = epoch - 1
+            t = min(1.0, ep0 / vol_decay_epochs) if vol_decay_epochs > 0 else 1.0
+            current_vol_weight = config.vol_weight_start - (config.vol_weight_start - config.vol_weight_end) * t
+        else:
+            current_vol_weight = config.volume_loss_weight
+
         train_metrics = train_one_epoch(
             model=forward_model,
             anp_head=anp_head,
@@ -1687,7 +1704,7 @@ def main() -> None:
             max_batches=config.max_train_batches,
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
-            volume_loss_weight=config.volume_loss_weight,
+            volume_loss_weight=current_vol_weight,
         )
 
         if ema is not None:
@@ -1736,7 +1753,7 @@ def main() -> None:
         if anp_head is not None and anp_ema is not None:
             anp_ema.restore(anp_head)
 
-        epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
+        epoch_metrics = {"epoch": float(epoch), "vol_weight": current_vol_weight, **train_metrics, **eval_metrics}
         epoch_metrics["best_val_metric"] = best_val_metric
         epoch_metrics["best_epoch"] = float(best_epoch)
         history.append(epoch_metrics)


### PR DESCRIPTION
## Hypothesis

The static `--vol-loss-weight 10.0` used in the AF champion (PR #3135) applies the same volume penalty throughout training. We hypothesize that **front-loading volume learning early** — starting at 20x and linearly decaying to 10x over the first 50% of epochs — will push the model to learn volumetric structure faster, then let the surface loss dominate refinement in the second half.

This is a curriculum learning approach: high vol-weight early prevents the model from locking into a surface-only attractor; decay prevents the vol-weight from suppressing surface accuracy at convergence.

Target: **vol_mse < 0.0017** with **surface_mse ≤ 0.000296** (no regression).

## Instructions

Implement a dynamic volume weight schedule in `target/icml2026/train.py`. The formula is:

```python
vol_weight(epoch) = start_weight - (start_weight - end_weight) * min(1.0, epoch / decay_epochs)
```

Where:
- `start_weight` = trial-specific starting value (see trials below)
- `end_weight` = 10.0 (the champion static value)
- `decay_epochs` = 50% of total training epochs (i.e. `int(0.5 * args.epochs)`)
- `epoch` is 0-indexed

Add `--vol-weight-start` and `--vol-weight-end` CLI flags (floats). If `--vol-weight-start` is not provided (or equals `--vol-loss-weight`), fall back to the existing static behaviour.

**Log `vol_weight` to W&B each epoch** (e.g. `wandb.log({"vol_weight": current_vol_weight}, step=epoch)`).

**Smoke test first** (3 epochs) to confirm vol_weight logs correctly and loss is finite before launching full runs.

### Trial 1 — Aggressive curriculum (20x → 10x)

Start at 20x, decay to champion 10x over first 50% of epochs. Use the full champion config:

```bash
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 \
  --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 \
  --enable-fourier \
  --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 \
  --ema-decay 0.999 \
  --vol-weight-start 20.0 --vol-weight-end 10.0 \
  --wandb_group af-volume-weight-curriculum
```

### Trial 2 — Gentle curriculum (15x → 10x)

Same config, gentler starting weight:

```bash
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 \
  --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 \
  --enable-fourier \
  --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 \
  --ema-decay 0.999 \
  --vol-weight-start 15.0 --vol-weight-end 10.0 \
  --wandb_group af-volume-weight-curriculum
```

**EMA is critical** — keep `--ema-decay 0.999`. The upweighted volume gradient early in training causes instability without EMA smoothing.

Report both trials in the PR. Primary metric: `vol_mse` (lower is better). Hard constraint: `surface_mse ≤ 0.000296`.

## Baseline

Current AF champion: PR #3135 (nezuko — EMA=0.999 + vol-weight=10x static)

| Metric | Value | Epoch |
|---|---|---|
| surface_mse (val) | 0.000296 | 704 |
| vol_mse (val) | 0.002039 | 743 |

- Baseline W&B run: `sh2zyfwr`
- Reproduce: `cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --ema-decay 0.999 --vol-loss-weight 10.0`