### PR TITLE
Focal-MSE loss for AirfRANS volume — upweight hard vol predictions

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -167,6 +167,7 @@ class TrainConfig:
     grad_clip: float = 0.0
     grad_accum_steps: int = 1
     volume_loss_weight: float = 1.0
+    focal_vol_gamma: float = 0.0
     save_checkpoint: bool = False
     seed: int = 0
 
@@ -763,6 +764,7 @@ def loss_grouped(
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
     volume_loss_weight: float = 1.0,
+    focal_vol_gamma: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.surface_x.device)
     metrics: dict[str, float] = {}
@@ -773,7 +775,16 @@ def loss_grouped(
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
     if batch.volume_y is not None and outputs["volume_preds"] is not None and batch.volume_mask is not None:
         target = transform.apply(batch.volume_y)
-        vol_loss = F.mse_loss(outputs["volume_preds"][batch.volume_mask], target[batch.volume_mask])
+        pred_masked = outputs["volume_preds"][batch.volume_mask]
+        tgt_masked = target[batch.volume_mask]
+        if focal_vol_gamma > 0.0:
+            per_point_mse = (pred_masked - tgt_masked) ** 2
+            error_max = per_point_mse.detach().max().clamp(min=1e-8)
+            normalized = per_point_mse.detach() / error_max
+            focal_weight = normalized ** focal_vol_gamma
+            vol_loss = (focal_weight * per_point_mse).mean()
+        else:
+            vol_loss = F.mse_loss(pred_masked, tgt_masked)
         total = total + vol_loss * volume_loss_weight
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
@@ -1271,6 +1282,7 @@ def train_one_epoch(
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
     volume_loss_weight: float = 1.0,
+    focal_vol_gamma: float = 0.0,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1326,7 +1338,7 @@ def train_one_epoch(
                             volume_x=batch.volume_x,
                             volume_mask=batch.volume_mask,
                         )
-                        loss, _ = loss_grouped(batch, outputs, transform, volume_loss_weight=volume_loss_weight)
+                        loss, _ = loss_grouped(batch, outputs, transform, volume_loss_weight=volume_loss_weight, focal_vol_gamma=focal_vol_gamma)
 
             accum_loss += float(loss.detach().cpu().item())
             (loss / grad_accum_steps).backward()
@@ -1688,6 +1700,7 @@ def main() -> None:
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
             volume_loss_weight=config.volume_loss_weight,
+            focal_vol_gamma=config.focal_vol_gamma,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

Volume predictions have high variance across cells — easy regions (freestream) dominate the MSE while hard regions (near-wall, wake, separation zones) contribute relatively little to the gradient signal. Focal loss (Lin et al., 2017, https://arxiv.org/abs/1708.02002) addresses this by upweighting hard examples: `focal_mse = (error / error_max)^gamma * error^2`. Applied to the volume loss, this should push the model to reduce errors in the high-error cells that matter most for physical accuracy, without touching the surface loss at all.

The gamma parameter controls the strength of the upweighting:
- **gamma=2** (Trial 1): strong focus on hardest predictions — similar to the original focal loss for classification
- **gamma=1** (Trial 2): moderate / linear upweighting — softer version, less aggressive

We keep vol-loss-weight=10x (the current champion config) so the absolute scale of the volume loss is unchanged. The focal weighting only redistributes attention *within* the volume loss toward harder cells.

## Instructions

**Implementation (5 steps):**

1. Compute per-point squared error for volume predictions:
   ```python
   per_point_mse = (pred_vol - target_vol) ** 2  # shape: [N, C]
   ```

2. Normalize by the max error (detached from gradient graph):
   ```python
   error_max = per_point_mse.detach().max().clamp(min=1e-8)
   normalized = per_point_mse.detach() / error_max  # shape: [N, C], in [0, 1]
   ```

3. Compute the focal weight (also detached):
   ```python
   focal_weight = normalized ** gamma  # gamma is a hyperparameter
   ```

4. Apply the focal weight to the actual (non-detached) per-point MSE:
   ```python
   focal_mse = focal_weight * per_point_mse  # gradient flows through per_point_mse only
   ```

5. Use the mean as the volume loss, with vol-loss-weight=10x:
   ```python
   vol_loss = focal_mse.mean()
   ```

**Critical:** `focal_weight` must be detached. The gradient should only flow through `per_point_mse`, not through the normalisation. This is the same trick used in focal loss for detection.

---

**Smoke test first (3 epochs)** to verify no NaN / shape errors before launching full runs.

---

**Trial 1 — gamma=2 (strong focus):**
```bash
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 \
  --cosine-t-max 50 \
  --grad-clip 1.0 \
  --weight-decay 1e-2 \
  --enable-fourier \
  --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 \
  --ema-decay 0.999 \
  --vol-loss-weight 10.0 \
  --focal-vol-gamma 2.0 \
  --wandb_group af-focal-volume-loss
```

**Trial 2 — gamma=1 (moderate/linear upweighting):**
```bash
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 \
  --cosine-t-max 50 \
  --grad-clip 1.0 \
  --weight-decay 1e-2 \
  --enable-fourier \
  --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 \
  --ema-decay 0.999 \
  --vol-loss-weight 10.0 \
  --focal-vol-gamma 1.0 \
  --wandb_group af-focal-volume-loss
```

**Note:** If `--focal-vol-gamma` is not yet a CLI flag, add it to `train.py` (argparse + plumb into the volume loss computation). The implementation should be entirely within the loss function — no changes to the model architecture.

Report `val_primary/surface_mse` and `val_primary/vol_mse` for both trials. The target is `vol_mse < 0.0017` with no regression on `surface_mse` (must stay <= 0.000296).

## Baseline

Current best AirfRANS metrics (PR #3135, nezuko/af-ema-vol-weight-10x):

| Metric | Value | Epoch |
|--------|-------|-------|
| val_primary/surface_mse | **0.000296** | 704 |
| val_primary/vol_mse | **0.002039** | 743 |

- Baseline W&B run: `sh2zyfwr` (https://wandb.ai/run/sh2zyfwr)
- Config: 2L/256d/4H, AdamW lr=6e-4, T_max=50, gc=1.0, WD=1e-2, EMA=0.999, vol-weight=10x, Fourier

Reproduce command:
```bash
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 \
  --cosine-t-max 50 \
  --grad-clip 1.0 \
  --weight-decay 1e-2 \
  --enable-fourier \
  --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 \
  --ema-decay 0.999 \
  --vol-loss-weight 10.0
```