### PR TITLE
DrivAerML: stochastic weight perturbation at cosine troughs

### DIFF
--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 00:15 (advisor cycle 53)
+- **Date:** 2026-04-24 00:30 (advisor cycle 54)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -12,7 +12,7 @@
 **Innovation track (new physics-aware/ML ideas per directive):**
 - `#3224` fern: spectral normalization on attention layers — INNOVATION
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
-- `#3216` canute: attention distance bias (ALiBi-inspired spatial prior) — INNOVATION
+- canute: self-distillation with EMA teacher — INNOVATION (PR pending)
 - `#3214` kakashi: auxiliary gradient prediction (∂p/∂x,y,z) — INNOVATION
 - `#3217` brook: Fourier encoding of surface normals — INNOVATION
 - `#3203` vegeta: attention temperature annealing — INNOVATION
@@ -21,10 +21,10 @@
 
 **Noam-pivot experiments:**
 - `#3199` megumi: EMA=0.9999/0.99995 (noam optimal decay) — NOAM ABLATION
-- `#3192` casca: asinh-pressure alone (scale=0.75/0.5) — NOAM ABLATION
+- casca: → AF focal-MSE volume loss (PR pending)
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3194` bulma: higher LR sweep (5.5e-4/6e-4)
-- `#3188` chihiro: 2H/16H heads sweep — NOAM ABLATION
+- chihiro: → AF vol-weight curriculum (PR pending)
 - `#3181` himmel: asinh+residual on champion — NOAM ABLATION
 - `#3219` hinata: SAM optimizer (flat-basin restart robustness) — INNOVATION
 
@@ -52,7 +52,7 @@
 - `#3197` gojo: residual-prediction alone — NOAM ABLATION
 - `#3196` zenitsu: EMA decay sweep (0.9999/0.99995) — NOAM ABLATION
 - `#3189` emma: asinh+physics features — NOAM ABLATION
-- `#3180` chopper: ANP decoder alone — NOAM ABLATION
+- chopper: → DM weight perturbation at troughs (PR pending)
 - `#3150` yuji: clean test row — PAPER-FACING
 
 ### TandemFoil Paper WIP (9 PRs) — STABILIZATION CRISIS
@@ -180,7 +180,9 @@
 - OneCycleLR (no troughs): 8.04% best, sustained high-LR warmup worse than cosine peaks (without EMA+gc)
 - SWA: equal-weight averaging poisons across divergent basins (88.98%)
 - T_max≠30: ALL tested — 15→4.406%, 20→4.943%, 30→3.833% CHAMPION, 45→4.638%, 50→diverge, 60→4.409%. T_max=30 is definitive sweet spot
-- Noam feature stack on DM: full stack→4.447%, asinh-only→4.421%, residual-only→4.651%/15.0%(crashed). All diverge. Features tuned for T_max=150/3H/no-gc regime. Residual-pred requires asinh as hard prerequisite; even combined→3.999% (doesn't beat 3.833%)
+- Noam features on DM: DEFINITIVELY DEAD. Asinh triple-confirmed (4.072%/4.421%/4.475%), residual needs asinh+still→3.999%, full stack→4.447%. Features tuned for T_max=150/3H/no-gc regime
+- Attention distance bias (ALiBi): linear diverges, log=5.511% at timeout. Redundant with slice-based spatial grouping
+- Head count sweep complete: 2H=catastrophic, 4H=6.650%, 8H=3.833% CHAMPION, 16H=4.099%. 8H (64d/head) is definitive
 - 10-ep warmup+gc=1.0: 11.2% then diverged
 - 5-ep warmup+gc=1.0: pending (chopper)
 - LR warmup + EMA+gc=0.5: 5-ep=11.325% diverged, 10-ep=3.918% plateaued (didn't beat 3.833%)

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -169,6 +169,7 @@ class TrainConfig:
     volume_loss_weight: float = 1.0
     save_checkpoint: bool = False
     seed: int = 0
+    weight_perturbation_sigma: float = 0.0
 
 
 @dataclass
@@ -1254,6 +1255,17 @@ def evaluate_abupt(
     return {"surface_mae": total_surface / max(count_surface, 1), "volume_mae": total_volume / max(count_volume, 1)}
 
 
+def _apply_weight_perturbation(model: torch.nn.Module, sigma: float) -> int:
+    perturbed = 0
+    with torch.no_grad():
+        for p in model.parameters():
+            if p.requires_grad:
+                noise_scale = sigma * p.data.abs().mean()
+                p.data += torch.randn_like(p.data) * noise_scale
+                perturbed += 1
+    return perturbed
+
+
 def train_one_epoch(
     model: torch.nn.Module,
     anp_head: ANPSurfaceDecoder | None,
@@ -1746,6 +1758,22 @@ def main() -> None:
             run.summary["best_epoch"] = best_epoch
             run.summary["best_val_metric"] = best_val_metric
         print(json.dumps(epoch_metrics, sort_keys=True), flush=True)
+
+        if (
+            config.cosine_t_max > 0
+            and config.weight_perturbation_sigma > 0
+            and epoch % config.cosine_t_max == config.cosine_t_max - 1
+        ):
+            n_perturbed = _apply_weight_perturbation(model, config.weight_perturbation_sigma)
+            swp_log = {
+                "weight_perturbation/fired": 1,
+                "weight_perturbation/sigma": config.weight_perturbation_sigma,
+                "weight_perturbation/epoch": epoch,
+                "weight_perturbation/params_perturbed": n_perturbed,
+            }
+            if run is not None:
+                wandb.log(swp_log, step=epoch)
+            print(json.dumps(swp_log), flush=True)
 
     if best_epoch is not None:
         print(


### PR DESCRIPTION
## Hypothesis

At each cosine annealing trough (LR=0, every T_max=30 epochs), add small Gaussian noise to all online model parameters:

```python
p.data += torch.randn_like(p.data) * sigma * p.data.abs().mean()
```

**Why this is different from SWA:** SWA (#3149 on DM, val=88.98%) *averages* weights across cycle endpoints — it combines multiple basins, which destroyed DM performance. Stochastic Weight Perturbation (SWP) stays in a *single* basin but nudges the optimizer out of sharp local minima at the moment the LR hits zero. The EMA model is NOT perturbed — it naturally smooths over the perturbation via its own exponential averaging. The perturbation acts like a controlled random restart at the basin floor, potentially escaping narrow minima and finding flatter, better-generalizing regions.

Motivation: at cosine troughs the model is maximally "settled" (LR≈0, no gradient step pulling it away), making it the ideal moment for a small kick. The EMA's inertia (decay=0.9995) means the perturbation is effectively annealed into the EMA over ~2000 steps, acting as a soft diversification signal.

Reference: Inspired by "Stochastic Weight Averaging" (Izmailov et al. 2018) but inverts the mechanism — perturbation rather than averaging.

## Instructions

**Step 1 — Add a cosine trough detector.** In `train.py`, after the scheduler step each epoch, detect when the cosine LR has just reached its minimum. The trough occurs every `T_max` epochs. A reliable check:

```python
# After scheduler.step()
if args.cosine_t_max and args.weight_perturbation_sigma > 0:
    epoch_in_cycle = epoch % args.cosine_t_max
    if epoch_in_cycle == (args.cosine_t_max - 1):  # last epoch of cycle = trough
        _apply_weight_perturbation(model, args.weight_perturbation_sigma)
```

**Step 2 — Implement the perturbation function** (online model only, NOT the EMA):

```python
def _apply_weight_perturbation(model, sigma):
    with torch.no_grad():
        for p in model.parameters():
            if p.requires_grad:
                noise_scale = sigma * p.data.abs().mean()
                p.data += torch.randn_like(p.data) * noise_scale
```

**Step 3 — Add CLI argument:**

```python
parser.add_argument('--weight-perturbation-sigma', type=float, default=0.0,
                    help='Sigma for stochastic weight perturbation at cosine troughs (0=disabled)')
```

**Step 4 — W&B logging.** Log perturbation events so we can verify they fired:

```python
# inside _apply_weight_perturbation, or at call site:
wandb.log({'weight_perturbation/fired': 1, 'weight_perturbation/sigma': sigma,
           'weight_perturbation/epoch': epoch}, step=global_step)
```

**Run two trials** using the DrivAerML champion config:

**Trial 1 — sigma=0.01:**
```bash
cd target/icml2026
SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 \
  --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --weight-perturbation-sigma 0.01 \
  --wandb_group dm-weight-perturbation \
  --wandb_run_name dm-swp-sigma0.01
```

**Trial 2 — sigma=0.001:**
```bash
cd target/icml2026
SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 \
  --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --weight-perturbation-sigma 0.001 \
  --wandb_group dm-weight-perturbation \
  --wandb_run_name dm-swp-sigma0.001
```

**Smoke test first** — run 5 epochs with `--max-train-batches 10 --max-eval-batches 5` and confirm `weight_perturbation/fired=1` appears in W&B at epoch 29 (or epoch 4 if using T_max=5 for the smoke test). Verify the EMA model is NOT perturbed by checking that `ema_model.parameters()` are untouched by `_apply_weight_perturbation`.

Report: best `val_primary/surface_rel_l2_pct` for each sigma, the epoch it occurred, and confirm perturbation events fired in W&B logs.

## Baseline

Current DrivAerML best (PR #3072 — eren, EMA=0.9995 + gc=0.5, 4L/512d/8H, AdamW lr=5e-4, T_max=30):

| Metric | Value |
|--------|-------|
| val_primary/surface_rel_l2_pct | **3.833%** (epoch 511) |
| test_primary/surface_rel_l2_pct | 4.685% |

- W&B run: `ncl1dh88`
- External target: <3.71% (AB-UPT, ~500 epochs) — gap: 0.123 pp

Reproduce command:
```bash
cd target/icml2026
SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 \
  --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995
```