### PR TITLE
DrivAerML: surface pressure gradient smoothness regularization

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -167,6 +167,8 @@ class TrainConfig:
     grad_clip: float = 0.0
     grad_accum_steps: int = 1
     volume_loss_weight: float = 1.0
+    gradient_reg_weight: float = 0.0
+    gradient_reg_k: int = 8
     save_checkpoint: bool = False
     seed: int = 0
 
@@ -758,11 +760,49 @@ def _named_channel_metrics(prefix: str, values: torch.Tensor, names: tuple[str, 
     return metrics
 
 
+def _compute_surface_gradient_reg(
+    coords: torch.Tensor,
+    preds: torch.Tensor,
+    mask: torch.Tensor,
+    k: int = 8,
+    chunk_size: int = 2048,
+) -> torch.Tensor:
+    """k-NN smoothness regularization: penalizes deviation of each point's
+    prediction from the mean of its k nearest spatial neighbors."""
+    B = coords.shape[0]
+    results = []
+    for b in range(B):
+        m = mask[b]
+        c = coords[b, m, :3].float()
+        p = preds[b, m, 0]
+        n = c.shape[0]
+        if n <= k:
+            continue
+        all_knn_idx = torch.empty(n, k, dtype=torch.long, device=c.device)
+        with torch.no_grad():
+            for i in range(0, n, chunk_size):
+                end = min(i + chunk_size, n)
+                clen = end - i
+                dists = torch.cdist(c[i:end], c)
+                dists[torch.arange(clen, device=dists.device),
+                      torch.arange(i, end, device=dists.device)] = float('inf')
+                _, idx = dists.topk(k, dim=1, largest=False)
+                all_knn_idx[i:end] = idx
+                del dists
+        neighbor_mean = p[all_knn_idx].mean(dim=1)
+        results.append(((p - neighbor_mean) ** 2).mean())
+    if not results:
+        return torch.tensor(0.0, device=coords.device)
+    return torch.stack(results).mean()
+
+
 def loss_grouped(
     batch: GroupedBatch,
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
     volume_loss_weight: float = 1.0,
+    gradient_reg_weight: float = 0.0,
+    gradient_reg_k: int = 8,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.surface_x.device)
     metrics: dict[str, float] = {}
@@ -776,6 +816,12 @@ def loss_grouped(
         vol_loss = F.mse_loss(outputs["volume_preds"][batch.volume_mask], target[batch.volume_mask])
         total = total + vol_loss * volume_loss_weight
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
+    if gradient_reg_weight > 0 and outputs["surface_preds"] is not None:
+        grad_reg = _compute_surface_gradient_reg(
+            batch.surface_x, outputs["surface_preds"], batch.surface_mask, k=gradient_reg_k,
+        )
+        total = total + gradient_reg_weight * grad_reg
+        metrics["gradient_reg_loss"] = float(grad_reg.detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
     return total, metrics
 
@@ -1271,6 +1317,8 @@ def train_one_epoch(
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
     volume_loss_weight: float = 1.0,
+    gradient_reg_weight: float = 0.0,
+    gradient_reg_k: int = 8,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1294,6 +1342,7 @@ def train_one_epoch(
                 exhausted = True
                 break
 
+            loss_metrics: dict[str, float] = {}
             if model_name == "reference_abupt":
                 batch = batch.to(device)
                 with autocast_context(device, amp_mode):
@@ -1326,9 +1375,17 @@ def train_one_epoch(
                             volume_x=batch.volume_x,
                             volume_mask=batch.volume_mask,
                         )
-                        loss, _ = loss_grouped(batch, outputs, transform, volume_loss_weight=volume_loss_weight)
+                        loss, loss_metrics = loss_grouped(
+                            batch, outputs, transform,
+                            volume_loss_weight=volume_loss_weight,
+                            gradient_reg_weight=gradient_reg_weight,
+                            gradient_reg_k=gradient_reg_k,
+                        )
 
             accum_loss += float(loss.detach().cpu().item())
+            if "gradient_reg_loss" in loss_metrics:
+                running.setdefault("gradient_reg_loss", 0.0)
+                running["gradient_reg_loss"] += loss_metrics["gradient_reg_loss"]
             (loss / grad_accum_steps).backward()
             micro_count += 1
 
@@ -1359,6 +1416,8 @@ def train_one_epoch(
     running["loss"] /= max(steps, 1)
     if "grad_norm_mean" in running:
         running["grad_norm_mean"] /= max(steps, 1)
+    if "gradient_reg_loss" in running:
+        running["gradient_reg_loss"] /= max(steps, 1)
     running["train_steps"] = float(steps)
     running["micro_batches"] = float(micro_batches_total)
     if scheduler is not None:
@@ -1688,6 +1747,8 @@ def main() -> None:
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
             volume_loss_weight=config.volume_loss_weight,
+            gradient_reg_weight=config.gradient_reg_weight,
+            gradient_reg_k=config.gradient_reg_k,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

The DrivAerML champion has been stuck at 3.833% since PR #3072. The local neighborhood of recipe tuning (T_max, heads, EMA decay, LR, noam features) is exhausted. This experiment introduces a **physics-informed regularization loss** that penalizes unphysically large spatial gradients of predicted pressure fields.

**Physics motivation:** In attached flows at moderate Reynolds number, surface pressure is a smooth function except at specific geometric features (leading edge suction peak, trailing edge, separation bubbles). The Euler pressure equation requires dp/dn = 0 at the wall for flat plates — smooth variations are physically expected. High-frequency prediction noise in pressure is physically implausible and may be a source of generalization error on unseen car geometries.

**Implementation:** Add a regularization term to the loss:

```python
L_total = L_prediction + lambda_grad * L_gradient_reg
L_gradient_reg = mean(||∇p_pred||²)
```

where `∇p_pred` is computed using the mesh connectivity (neighbor differences between surface points). The gradient is approximated as the mean squared difference between each point's predicted pressure and the mean of its k nearest neighbors' predictions.

**Hypothesis:** This smoothness prior will reduce high-frequency prediction noise, improve generalization to test geometries, and potentially break through the 3.833% barrier.

## Instructions

Implement the surface pressure gradient regularization in `target/icml2026/train.py`:

1. In the training loop, after computing the standard prediction loss, add:
   - Find the k=8 nearest neighbors for each surface point using the existing coordinate data
   - Compute `p_pred` = predicted pressure for current surface points
   - Compute `L_grad_reg = mean((p_pred - mean_neighbor_p_pred)^2)` over all points
   - Add `lambda_grad * L_grad_reg` to the total loss

2. Run 3 trials with different `lambda_grad` values:
   - **Trial 1:** `lambda_grad = 0.01` (light regularization)
   - **Trial 2:** `lambda_grad = 0.1` (moderate regularization)
   - **Trial 3:** `lambda_grad = 1.0` (strong regularization)

3. All trials use the exact DM champion config:
```
python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --grad-clip 0.5 --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 --wandb_group dm-pressure-gradient-reg
```

4. Monitor: If `L_grad_reg` grows large (>10x prediction loss), reduce `lambda_grad`. If the model diverges at a cosine LR peak, note the epoch and stop.

5. **Note for implementation:** If computing k-NN on-the-fly per batch is expensive, you can approximate the smoothness regularization using the Transolver slice structure — compute mean pressure within each spatial slice and penalize deviations from the slice mean. This is faster and conceptually similar.

## Baseline

Current DM best (PR #3072 — eren):
- **val surface_rel_l2_pct:** 3.833% at epoch 511
- **test surface_rel_l2_pct:** 4.685%
- **External target:** < 3.71% (AB-UPT)
- **W&B run:** ncl1dh88
- **Reproduce:** `cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --ema-decay 0.9995`