### PR TITLE
AirfRANS: vol-weight warm-up schedule (1x→10x linear ramp)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -167,6 +167,7 @@ class TrainConfig:
     grad_clip: float = 0.0
     grad_accum_steps: int = 1
     volume_loss_weight: float = 1.0
+    vol_weight_warmup_epochs: int = 0
     save_checkpoint: bool = False
     seed: int = 0
 
@@ -1672,6 +1673,11 @@ def main() -> None:
     for epoch in range(1, config.epochs + 1):
         if timeout_seconds is not None and epoch > 1 and (time.monotonic() - start_time) >= timeout_seconds:
             break
+        if config.vol_weight_warmup_epochs > 0 and epoch < config.vol_weight_warmup_epochs:
+            current_vol_weight = 1.0 + (config.volume_loss_weight - 1.0) * (epoch / config.vol_weight_warmup_epochs)
+        else:
+            current_vol_weight = config.volume_loss_weight
+
         train_metrics = train_one_epoch(
             model=forward_model,
             anp_head=anp_head,
@@ -1687,7 +1693,7 @@ def main() -> None:
             max_batches=config.max_train_batches,
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
-            volume_loss_weight=config.volume_loss_weight,
+            volume_loss_weight=current_vol_weight,
         )
 
         if ema is not None:
@@ -1736,7 +1742,7 @@ def main() -> None:
         if anp_head is not None and anp_ema is not None:
             anp_ema.restore(anp_head)
 
-        epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
+        epoch_metrics = {"epoch": float(epoch), "current_vol_weight": current_vol_weight, **train_metrics, **eval_metrics}
         epoch_metrics["best_val_metric"] = best_val_metric
         epoch_metrics["best_epoch"] = float(best_epoch)
         history.append(epoch_metrics)


### PR DESCRIPTION
## Hypothesis

Current AF champion uses a fixed `--vol-loss-weight 10.0` from epoch 1. But early in training when predictions are poor, the volume loss gradient is extremely noisy — upweighting it 10x from the start may corrupt early surface learning and slow convergence to the surface basin that EMA then stabilizes.

**Proposed fix:** Implement a linear warm-up of vol-loss-weight from 1.0 to 10.0 over the first 200 epochs, then hold at 10.0 for the remainder. This lets the model first learn reasonable surface representations (where the signal-to-noise ratio is higher), then gradually shift focus to volume predictions once the model has a stable foundation.

**Why this is different from chihiro #3226 (20x→10x decay):** Chihiro tests *decreasing* vol-weight (front-loading volume attention then relaxing). This experiment tests the *opposite direction* — starting gentle and ramping up. These are complementary hypotheses about whether early or late volume emphasis is more effective.

**Physics motivation:** The surface boundary layer must be resolved first before volume predictions can be accurate (volume fields are physically determined by surface conditions via the Navier-Stokes equations). Training the surface first, then shifting to volume, follows the physical causality.

## Instructions

Modify `target/icml2026/train.py` to implement dynamic vol-weight scheduling:

1. Add a `--vol-weight-warmup-epochs` argument (default: 0 = disabled, i.e., fixed vol-weight as before).

2. When `--vol-weight-warmup-epochs N` is set, linearly interpolate `vol_loss_weight` from 1.0 to the target `--vol-loss-weight` value over the first N epochs:
   ```python
   if epoch < vol_weight_warmup_epochs:
       current_vol_weight = 1.0 + (vol_loss_weight - 1.0) * (epoch / vol_weight_warmup_epochs)
   else:
       current_vol_weight = vol_loss_weight
   ```

3. Log the current `vol_loss_weight` to W&B each epoch so we can verify the schedule.

4. Run 3 trials:

**Trial 1 — 200-epoch warm-up (recommended):**
```
cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 \
  --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 --ema-decay 0.999 --vol-loss-weight 10.0 \
  --vol-weight-warmup-epochs 200 --wandb_group af-vol-warmup
```

**Trial 2 — 100-epoch warm-up (faster ramp):**
Same as Trial 1 but `--vol-weight-warmup-epochs 100`

**Trial 3 — 50-epoch warm-up (aggressive ramp):**
Same as Trial 1 but `--vol-weight-warmup-epochs 50`

All other hyperparameters must match the champion config exactly.

## Baseline

Current AF best (PR #3135):
- **val surface_mse:** 0.000296 at epoch 704
- **val vol_mse:** 0.002039 at epoch 743
- **Goal:** vol_mse < 0.0017 without regressing surface_mse above 0.000296
- **W&B run:** sh2zyfwr
- **Reproduce:** `cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --ema-decay 0.999 --vol-loss-weight 10.0`