### PR TITLE
DrivAerML: stochastic depth (LayerDrop) regularization

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -159,6 +159,7 @@ class TrainConfig:
     asinh_scale: float = 0.75
     residual_prediction: bool = False
     re_stratified_sampling: bool = False
+    stochastic_depth_rate: float = 0.0
     cosine_t_max: int = 150
     geometry_points: int = 25_000
     geometry_supernodes: int = 4_096
@@ -540,6 +541,35 @@ def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
             volume_output_dim=bundle.spec.volume_output_dim,
         )
     raise ValueError(f"Unknown model: {config.model}")
+
+
+_stochastic_depth_active_layers: list[int] = []
+
+
+def patch_stochastic_depth(model: torch.nn.Module, rate: float) -> None:
+    backbone = getattr(model, "backbone", None)
+    if backbone is None:
+        return
+    blocks = getattr(backbone, "blocks", None)
+    if blocks is None:
+        return
+    num_layers = len(blocks)
+
+    def _forward_with_stochastic_depth(
+        x: torch.Tensor, attn_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        active = 0
+        for layer_idx, block in enumerate(blocks):
+            if backbone.training and rate > 0:
+                layer_keep_prob = 1.0 - (layer_idx / num_layers) * rate
+                if random.random() > layer_keep_prob:
+                    continue
+            x = block(x, attn_mask=attn_mask)
+            active += 1
+        _stochastic_depth_active_layers.append(active)
+        return x
+
+    backbone.forward = _forward_with_stochastic_depth
 
 
 def build_optimizer(params, config: TrainConfig):
@@ -1615,6 +1645,8 @@ def main() -> None:
 
     train_loader, val_loaders, test_loaders = build_loaders(config, bundle, num_workers=resolved_num_workers)
     model = build_model(config, bundle).to(device)
+    if config.stochastic_depth_rate > 0:
+        patch_stochastic_depth(model, config.stochastic_depth_rate)
     forward_model = torch.compile(model) if config.compile_model and device.type == "cuda" else model
     anp_head = None
     if bundle.spec.name == "tandemfoilset" and config.anp_srf:
@@ -1737,6 +1769,9 @@ def main() -> None:
             anp_ema.restore(anp_head)
 
         epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
+        if config.stochastic_depth_rate > 0 and _stochastic_depth_active_layers:
+            epoch_metrics["stochastic_depth_active_layers"] = sum(_stochastic_depth_active_layers) / len(_stochastic_depth_active_layers)
+            _stochastic_depth_active_layers.clear()
         epoch_metrics["best_val_metric"] = best_val_metric
         epoch_metrics["best_epoch"] = float(best_epoch)
         history.append(epoch_metrics)


### PR DESCRIPTION
## Hypothesis

The DM champion (3.833%) suffers from late-training divergence — training is stable until ~ep400-500, then overfitting and gradient instability at cosine LR peaks cause regression. Current stabilization (EMA+gc=0.5) manages symptoms but doesn't prevent the underlying overfitting.

**Stochastic depth** (Huang et al. 2016 "Deep Networks with Stochastic Depth") randomly drops entire transformer layers during training with probability p. At test time, all layers are used. This provides:

1. **Implicit ensemble** — each forward pass uses a different sub-network, averaging over exponentially many architectures
2. **Regularization without gradient noise** — unlike attention dropout (confirmed dead on DM), stochastic depth doesn't inject per-element noise into gradients. It cleanly removes entire layers, preserving gradient signal quality in active layers
3. **Reduced effective depth** — shorter gradient paths for some passes reduce vanishing/exploding gradient risk at cosine LR peaks
4. **Throughput bonus** — dropped layers save compute during training, allowing more epochs in the same wall-clock budget

This is a fundamentally different regularization mechanism from everything tested on DM so far (EMA, gc, dropout, WD). It targets the late-training overfitting root cause rather than managing instability symptoms.

**Reference:** Huang et al. (2016) "Deep Networks with Stochastic Depth" (ECCV); Fan et al. (2019) "Reducing Transformer Depth on Demand with Structured Dropout" (ICLR).

## Instructions

Implement stochastic depth in `target/icml2026/train.py`:

1. Add a `--stochastic-depth-rate` argument (float, default 0.0 = disabled).

2. In the Transolver forward pass, wrap each transformer layer with a stochastic skip:
   ```python
   if self.training and stochastic_depth_rate > 0:
       keep_prob = 1.0 - stochastic_depth_rate
       # Linear decay: first layer has keep_prob=1.0, last layer has keep_prob=(1-rate)
       layer_keep_prob = 1.0 - (layer_idx / num_layers) * stochastic_depth_rate
       if torch.rand(1).item() > layer_keep_prob:
           continue  # skip this layer (use residual connection only)
   ```
   The linear decay schedule means earlier layers (which learn general features) are dropped less often, while later layers (which overfit more) are dropped more often.

3. At test time (model.eval()), all layers are always used — no changes to evaluation.

4. Run 3 trials with different drop rates on the DM champion config:

**Trial 1 — Light (p=0.1):**
```
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 \
  --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 --stochastic-depth-rate 0.1 \
  --wandb_group dm-stochastic-depth
```

**Trial 2 — Moderate (p=0.2):**
Same but `--stochastic-depth-rate 0.2`

**Trial 3 — Aggressive (p=0.3):**
Same but `--stochastic-depth-rate 0.3`

5. Monitor: Log `stochastic_depth_active_layers` per step to W&B so we can verify the schedule is working. Watch for divergence — if a trial diverges before ep200, note the epoch and stop it.

## Baseline

Current DM best (PR #3072):
- **val surface_rel_l2_pct:** 3.833% at epoch 511
- **test surface_rel_l2_pct:** 4.685%
- **External target:** < 3.71% (AB-UPT)
- **W&B run:** ncl1dh88
- **Reproduce:** `cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --ema-decay 0.9995`