### PR TITLE
AirfRANS: additive boundary-layer auxiliary volume loss

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -167,6 +167,8 @@ class TrainConfig:
     grad_clip: float = 0.0
     grad_accum_steps: int = 1
     volume_loss_weight: float = 1.0
+    bl_aux_weight: float = 0.0
+    bl_threshold: float = 0.05
     save_checkpoint: bool = False
     seed: int = 0
 
@@ -763,6 +765,8 @@ def loss_grouped(
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
     volume_loss_weight: float = 1.0,
+    bl_aux_weight: float = 0.0,
+    bl_threshold: float = 0.05,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.surface_x.device)
     metrics: dict[str, float] = {}
@@ -776,6 +780,18 @@ def loss_grouped(
         vol_loss = F.mse_loss(outputs["volume_preds"][batch.volume_mask], target[batch.volume_mask])
         total = total + vol_loss * volume_loss_weight
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
+
+        if bl_aux_weight > 0 and batch.volume_x is not None:
+            # AirfRANS: SDF (positive in fluid, zero at wall) at feature index 4
+            sdf = batch.volume_x[..., 4]
+            bl_mask = batch.volume_mask & (sdf < bl_threshold)
+            bl_frac = float(bl_mask.sum().item()) / max(float(batch.volume_mask.sum().item()), 1.0)
+            metrics["bl_point_fraction"] = bl_frac
+            if bl_mask.any():
+                bl_loss = F.mse_loss(outputs["volume_preds"][bl_mask], target[bl_mask])
+                total = total + bl_aux_weight * bl_loss
+                metrics["bl_aux_loss"] = float(bl_loss.detach().cpu().item())
+
     metrics["loss"] = float(total.detach().cpu().item())
     return total, metrics
 
@@ -1271,6 +1287,8 @@ def train_one_epoch(
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
     volume_loss_weight: float = 1.0,
+    bl_aux_weight: float = 0.0,
+    bl_threshold: float = 0.05,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1326,7 +1344,20 @@ def train_one_epoch(
                             volume_x=batch.volume_x,
                             volume_mask=batch.volume_mask,
                         )
-                        loss, _ = loss_grouped(batch, outputs, transform, volume_loss_weight=volume_loss_weight)
+                        loss, batch_metrics = loss_grouped(
+                            batch, outputs, transform,
+                            volume_loss_weight=volume_loss_weight,
+                            bl_aux_weight=bl_aux_weight,
+                            bl_threshold=bl_threshold,
+                        )
+                    if "bl_aux_loss" in batch_metrics:
+                        running.setdefault("bl_aux_loss", 0.0)
+                        running["bl_aux_loss"] += batch_metrics["bl_aux_loss"]
+                    if "bl_point_fraction" in batch_metrics:
+                        running.setdefault("bl_point_fraction_sum", 0.0)
+                        running.setdefault("bl_point_fraction_count", 0.0)
+                        running["bl_point_fraction_sum"] += batch_metrics["bl_point_fraction"]
+                        running["bl_point_fraction_count"] += 1.0
 
             accum_loss += float(loss.detach().cpu().item())
             (loss / grad_accum_steps).backward()
@@ -1359,6 +1390,10 @@ def train_one_epoch(
     running["loss"] /= max(steps, 1)
     if "grad_norm_mean" in running:
         running["grad_norm_mean"] /= max(steps, 1)
+    if "bl_aux_loss" in running:
+        running["bl_aux_loss"] /= max(micro_batches_total, 1)
+    if "bl_point_fraction_sum" in running:
+        running["bl_point_fraction"] = running.pop("bl_point_fraction_sum") / max(running.pop("bl_point_fraction_count"), 1.0)
     running["train_steps"] = float(steps)
     running["micro_batches"] = float(micro_batches_total)
     if scheduler is not None:
@@ -1688,6 +1723,8 @@ def main() -> None:
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
             volume_loss_weight=config.volume_loss_weight,
+            bl_aux_weight=config.bl_aux_weight,
+            bl_threshold=config.bl_threshold,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

PR #3222 showed that proximity-weighted volume loss catastrophically fails — replacing the uniform volume loss with a distance-weighted one starves far-field gradients. But the physical insight is correct: volume errors are highest near the surface (boundary layer, wake region). The fix is to **add** a small auxiliary loss on near-surface volume points **without modifying the main uniform loss**.

**Approach:** Keep the standard uniform vol-weight=10x loss exactly as-is. Additionally, compute a second "boundary layer" MSE loss on volume points within a distance threshold (SDF < 0.05) from the nearest surface point. Weight this auxiliary loss at 0.5-2.0x (much lighter than the main loss). This provides:

1. **Extra supervision on the hardest region** without starving far-field gradients
2. **Physics-motivated targeting** — boundary layer volume is where predictions matter most and errors are largest
3. **No interference with the proven main loss** — the auxiliary is purely additive

This is the clean follow-up directly suggested by rei in the failed proximity PR #3222.

## Instructions

Modify `target/icml2026/train.py`:

1. During training, after computing volume predictions, identify which volume points have SDF (signed distance from nearest surface point) < threshold. If SDF is not directly available, compute min distance from each volume point to the nearest surface point in the batch.

2. Compute the auxiliary boundary layer loss:
   ```python
   bl_mask = (sdf < bl_threshold)  # boolean mask
   if bl_mask.any():
       bl_loss = F.mse_loss(vol_pred[bl_mask], vol_target[bl_mask])
       total_loss = total_loss + bl_aux_weight * bl_loss
   ```

3. Add CLI arguments:
   - `--bl-aux-weight` (float, default 0.0 = disabled)
   - `--bl-threshold` (float, default 0.05 — normalized distance)

4. Log `bl_aux_loss` and `bl_point_fraction` (fraction of volume points within threshold) to W&B.

5. Run 3 trials:

**Trial 1 — Moderate aux weight, standard threshold:**
```
cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 --cosine-t-max 50 \
  --grad-clip 1.0 --weight-decay 1e-2 \
  --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 --ema-decay 0.999 --vol-loss-weight 10.0 \
  --bl-aux-weight 1.0 --bl-threshold 0.05 \
  --wandb_group af-bl-auxiliary
```

**Trial 2 — Lighter aux weight:**
Same but `--bl-aux-weight 0.5`

**Trial 3 — Wider threshold (more BL coverage):**
Same as Trial 1 but `--bl-threshold 0.1`

## Baseline

Current AF best (PR #3135):
- **val surface_mse:** 0.000296 at epoch 704
- **val vol_mse:** 0.002039 at epoch 743
- **Goal:** vol_mse < 0.0017 without regressing surface_mse above 0.000296
- **W&B run:** sh2zyfwr
- **Reproduce:** `cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --ema-decay 0.999 --vol-loss-weight 10.0`