### PR TITLE
AirfRANS: joint checkpoint selection + vol-weight 11x/12x/13x fine sweep

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -167,6 +167,7 @@ class TrainConfig:
     grad_clip: float = 0.0
     grad_accum_steps: int = 1
     volume_loss_weight: float = 1.0
+    checkpoint_metric: str = "surface"
     save_checkpoint: bool = False
     seed: int = 0
 
@@ -1713,13 +1714,16 @@ def main() -> None:
         if current_primary_metric is not None and (
             best_val_primary_metric is None or current_primary_metric < best_val_primary_metric
         ):
-            best_epoch = epoch
             best_val_primary_metric = current_primary_metric
             best_val_metrics = dict(eval_metrics)
-            best_model_state = snapshot_module_state(model)
-            best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(val_primary_key)
+        if config.checkpoint_metric == "joint":
+            _surf = next((v for k, v in eval_metrics.items() if k.endswith("/surface_mse")), None)
+            _vol = next((v for k, v in eval_metrics.items() if k.endswith("/volume_mse")), None)
+            current_val = (_surf + _vol) if (_surf is not None and _vol is not None) else eval_metrics.get(val_primary_key)
+        else:
+            current_val = eval_metrics.get(val_primary_key)
+
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch
@@ -1737,6 +1741,8 @@ def main() -> None:
             anp_ema.restore(anp_head)
 
         epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
+        if config.checkpoint_metric == "joint" and current_val is not None:
+            epoch_metrics["joint_checkpoint_metric"] = current_val
         epoch_metrics["best_val_metric"] = best_val_metric
         epoch_metrics["best_epoch"] = float(best_epoch)
         history.append(epoch_metrics)

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -168,6 +168,7 @@ class TrainConfig:
     grad_accum_steps: int = 1
     volume_loss_weight: float = 1.0
     checkpoint_metric: str = "surface"
+    eval_interval: int = 1
     save_checkpoint: bool = False
     seed: int = 0
 
@@ -1691,54 +1692,59 @@ def main() -> None:
             volume_loss_weight=config.volume_loss_weight,
         )
 
-        if ema is not None:
-            ema.store(model)
-            ema.copy_to(model)
-        if anp_head is not None and anp_ema is not None:
-            anp_ema.store(anp_head)
-            anp_ema.copy_to(anp_head)
+        do_eval = (epoch % config.eval_interval == 0) or (epoch == config.epochs)
+        eval_metrics: dict[str, float] = {}
+        current_val = None
 
-        eval_metrics = evaluate_phase_metrics(
-            bundle=bundle,
-            config=config,
-            forward_model=forward_model,
-            anp_head=anp_head,
-            loaders=val_loaders,
-            transform=transform,
-            metric_transform=metric_transform,
-            device=device,
-            phase="val",
-        )
-
-        current_primary_metric = eval_metrics.get(best_val_primary_metric_name)
-        if current_primary_metric is not None and (
-            best_val_primary_metric is None or current_primary_metric < best_val_primary_metric
-        ):
-            best_val_primary_metric = current_primary_metric
-            best_val_metrics = dict(eval_metrics)
-
-        if config.checkpoint_metric == "joint":
-            _surf = next((v for k, v in eval_metrics.items() if k.endswith("/surface_mse")), None)
-            _vol = next((v for k, v in eval_metrics.items() if k.endswith("/volume_mse")), None)
-            current_val = (_surf + _vol) if (_surf is not None and _vol is not None) else eval_metrics.get(val_primary_key)
-        else:
-            current_val = eval_metrics.get(val_primary_key)
-
-        if current_val is not None and current_val < best_val_metric:
-            best_val_metric = current_val
-            best_epoch = epoch
-            best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
-            if anp_head is not None:
-                best_anp_state = {k: v.cpu().clone() for k, v in anp_head.state_dict().items()}
+        if do_eval:
             if ema is not None:
-                best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
-            if anp_ema is not None:
-                best_anp_ema_shadow = {k: v.cpu().clone() for k, v in anp_ema.shadow.items()}
+                ema.store(model)
+                ema.copy_to(model)
+            if anp_head is not None and anp_ema is not None:
+                anp_ema.store(anp_head)
+                anp_ema.copy_to(anp_head)
 
-        if ema is not None:
-            ema.restore(model)
-        if anp_head is not None and anp_ema is not None:
-            anp_ema.restore(anp_head)
+            eval_metrics = evaluate_phase_metrics(
+                bundle=bundle,
+                config=config,
+                forward_model=forward_model,
+                anp_head=anp_head,
+                loaders=val_loaders,
+                transform=transform,
+                metric_transform=metric_transform,
+                device=device,
+                phase="val",
+            )
+
+            current_primary_metric = eval_metrics.get(best_val_primary_metric_name)
+            if current_primary_metric is not None and (
+                best_val_primary_metric is None or current_primary_metric < best_val_primary_metric
+            ):
+                best_val_primary_metric = current_primary_metric
+                best_val_metrics = dict(eval_metrics)
+
+            if config.checkpoint_metric == "joint":
+                _surf = next((v for k, v in eval_metrics.items() if k.endswith("/surface_mse")), None)
+                _vol = next((v for k, v in eval_metrics.items() if k.endswith("/volume_mse")), None)
+                current_val = (_surf + _vol) if (_surf is not None and _vol is not None) else eval_metrics.get(val_primary_key)
+            else:
+                current_val = eval_metrics.get(val_primary_key)
+
+            if current_val is not None and current_val < best_val_metric:
+                best_val_metric = current_val
+                best_epoch = epoch
+                best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
+                if anp_head is not None:
+                    best_anp_state = {k: v.cpu().clone() for k, v in anp_head.state_dict().items()}
+                if ema is not None:
+                    best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
+                if anp_ema is not None:
+                    best_anp_ema_shadow = {k: v.cpu().clone() for k, v in anp_ema.shadow.items()}
+
+            if ema is not None:
+                ema.restore(model)
+            if anp_head is not None and anp_ema is not None:
+                anp_ema.restore(anp_head)
 
         epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
         if config.checkpoint_metric == "joint" and current_val is not None:


### PR DESCRIPTION
## Hypothesis

PR #3204 revealed a critical insight: the AF best-checkpoint logic selects on \`val_primary/surface_mse\`, but our target is vol_mse < 0.0017. At epoch 763, gilbert's 15x run had vol_mse=0.002378 (only 16.6% above baseline!) but surface_mse=0.000594 — the surface-anchored checkpoint selection HIDES vol improvements behind surface regression.

**Two complementary fixes:**

### Fix 1: Joint checkpoint selection
Change the best-checkpoint metric from pure surface_mse to a weighted combination:
\`\`\`
joint_metric = surface_mse + alpha * vol_mse
\`\`\`
With alpha=1.0, both metrics contribute equally. This ensures the checkpoint that balances surface and volume quality is saved, not just the surface-optimal one.

### Fix 2: Fine vol-weight sweep (11x/12x/13x)
The vol-weight sweep has a gap: 10x=champion, 15x=worse, 20x=crashed, 30x=catastrophic. The 10x→15x transition is too coarse. A fine sweep at 11x, 12x, 13x may find a sweet spot that nudges volume lower without the regression seen at 15x.

Combining both fixes means we: (a) find the right vol-weight in the 10x-15x gap, AND (b) evaluate from the checkpoint that actually optimizes for both metrics.

## Instructions

### Step 1: Implement joint checkpoint selection

In \`target/icml2026/train.py\`, add a \`--checkpoint-metric\` argument:
- \`surface\` (default, current behavior): select best checkpoint on \`val_primary/surface_mse\`
- \`joint\`: select best checkpoint on \`surface_mse + vol_mse\` (equal weight)

### Step 2: Run 3 trials with joint selection + fine vol-weight

**Trial 1 — vol-weight=11x + joint checkpoint:**
\`\`\`
cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full \\
  --optimizer adamw --lr 6e-4 --cosine-t-max 50 \\
  --grad-clip 1.0 --weight-decay 1e-2 \\
  --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 \\
  --epochs 999 --ema-decay 0.999 --vol-loss-weight 11.0 \\
  --checkpoint-metric joint --wandb_group af-joint-ckpt-vol
\`\`\`

**Trial 2 — vol-weight=12x + joint checkpoint:**
Same but \`--vol-loss-weight 12.0\`

**Trial 3 — vol-weight=13x + joint checkpoint:**
Same but \`--vol-loss-weight 13.0\`

For each trial, report BOTH the joint-selected checkpoint metrics AND the surface-selected checkpoint metrics so we can compare the two selection strategies.

## Baseline

Current AF best (PR #3135):
- **val surface_mse:** 0.000296 at epoch 704
- **val vol_mse:** 0.002039 at epoch 743
- **Goal:** vol_mse < 0.0017 without regressing surface_mse above 0.000296
- **W&B run:** sh2zyfwr
- **Reproduce:** \`cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --ema-decay 0.999 --vol-loss-weight 10.0\`