### PR TITLE
DrivAerML: Label Smoothing / Target Noise Augmentation

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -169,6 +169,7 @@ class TrainConfig:
     volume_loss_weight: float = 1.0
     save_checkpoint: bool = False
     seed: int = 0
+    label_noise_std: float = 0.0
 
 
 @dataclass
@@ -804,16 +805,21 @@ def loss_abupt(
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
     volume_loss_weight: float = 1.0,
+    label_noise_std: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.geometry_position.device)
     metrics: dict[str, float] = {}
     if batch.surface_anchor_target is not None and outputs["surface_preds"] is not None:
         surf_target = transform.apply(batch.surface_anchor_target)
+        if label_noise_std > 0:
+            surf_target = surf_target + torch.randn_like(surf_target) * label_noise_std
         surf_loss = F.mse_loss(outputs["surface_preds"], surf_target)
         total = total + surf_loss
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
     if batch.volume_anchor_target is not None and outputs["volume_preds"] is not None:
         vol_target = transform.apply(batch.volume_anchor_target)
+        if label_noise_std > 0:
+            vol_target = vol_target + torch.randn_like(vol_target) * label_noise_std
         vol_loss = F.mse_loss(outputs["volume_preds"], vol_target)
         total = total + vol_loss * volume_loss_weight
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
@@ -1271,6 +1277,7 @@ def train_one_epoch(
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
     volume_loss_weight: float = 1.0,
+    label_noise_std: float = 0.0,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1304,7 +1311,7 @@ def train_one_epoch(
                         surface_anchor_position=batch.surface_anchor_position,
                         volume_anchor_position=batch.volume_anchor_position,
                     )
-                    loss, _ = loss_abupt(batch, outputs, transform, volume_loss_weight=volume_loss_weight)
+                    loss, _ = loss_abupt(batch, outputs, transform, volume_loss_weight=volume_loss_weight, label_noise_std=label_noise_std)
             else:
                 batch = batch.to(device)
                 if isinstance(transform, TandemTargetTransform):
@@ -1688,6 +1695,7 @@ def main() -> None:
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
             volume_loss_weight=config.volume_loss_weight,
+            label_noise_std=config.label_noise_std,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

The DrivAerML champion (3.833% val surface_rel_l2_pct) converges tightly around its best epoch but doesn't push further. Label smoothing (adding small Gaussian noise to surface targets during training) acts as a regularizer that widens loss basins and prevents overfitting to measurement noise in the CFD data. This is a fundamentally different regularization approach from everything tried so far (EMA, gc, WD, dropout, SAM, data augmentation) — it targets the **label space** rather than the weight/gradient space.

Specifically: add zero-mean Gaussian noise with σ = {0.001, 0.01} to the surface field targets during training only (not eval). This is equivalent to Tikhonov regularization in the label space and has been shown to improve generalization in regression tasks on physics simulations (Sanchez-Gonzalez et al., 2020).

---

## Baseline (target to beat)

Current best DrivAerML (PR #3072, eren/dm-ema-9995-gc05):
| Metric | Value |
|--------|-------|
| val_primary/surface_rel_l2_pct | **3.833%** at epoch 511 |
| test surface_rel_l2_pct | 4.685% |
| W&B run | ncl1dh88 |

Config: AdamW lr=5e-4, gc=0.5, no WD, 4L/512d/8H, EMA=0.9995, cosine T_max=30, 394 batches/epoch

External target: **<3.71%** (AB-UPT). Gap: ~0.123 pp.

**You must beat 3.833% val_primary/surface_rel_l2_pct to be considered for merge.**

---

## Implementation Guidance

You need to add a `--label-noise-std` flag to `train.py`. The change is minimal:

1. Add argument: `--label-noise-std` (float, default 0.0)
2. During training forward pass, before loss computation, inject noise:
   ```python
   if self.training and label_noise_std > 0:
       target = target + torch.randn_like(target) * label_noise_std
   ```
3. **Never apply noise during eval/test** — only during training
4. Log `label_noise_std` as a hyperparameter to W&B

### Known Bug Fix

There is a `primary_metric_key` shadowing bug in `train.py` where a local variable (around line 1646–1648) shadows the function defined around line 1428, causing an `UnboundLocalError`. Fix by renaming the local variable to `best_tracking_metric_key`.

---

## Trials

### Trial 1 — label-noise-std=0.001 (conservative)

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --label-noise-std 0.001 \
  --wandb_group dm-label-smoothing
```

### Trial 2 — label-noise-std=0.01 (stronger)

Same as Trial 1 but with `--label-noise-std 0.01`:

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --label-noise-std 0.01 \
  --wandb_group dm-label-smoothing
```

---

## What to Report

For each trial, report:
- Best `val_primary/surface_rel_l2_pct` and the epoch it was achieved
- Corresponding test `surface_rel_l2_pct` (eval from best val checkpoint)
- W&B run ID
- Whether training appeared more/less stable vs. baseline

Also note any observations about convergence dynamics — did label noise slow convergence early on? Did validation loss continue to improve in later epochs where the baseline had plateaued?

---

## W&B Group

Use `--wandb_group dm-label-smoothing` for both trials so runs are grouped together in W&B.