### PR TITLE
DrivAerML: EMA with Periodic Reset

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -85,6 +85,14 @@ class EMAWithWarmup:
                 param.data.copy_(self.backup[key])
         self.backup = None
 
+    @torch.no_grad()
+    def reset_to_model(self, model: torch.nn.Module) -> None:
+        """Reset EMA shadow weights to current model weights, restarting the running average."""
+        for name, param in model.named_parameters():
+            key = self._clean(name)
+            if param.requires_grad and key in self.shadow:
+                self.shadow[key].copy_(param.detach())
+
 
 LEGACY_VAL_ALIAS = {
     "val_in_dist": "p_in",
@@ -124,6 +132,7 @@ class TrainConfig:
     use_lookahead: bool = True
     use_ema: bool = True
     ema_decay: float = 0.9999
+    ema_reset_interval: int = 0
     num_workers: int = -1
     pin_memory: bool = True
     persistent_workers: bool = True
@@ -1634,6 +1643,7 @@ def main() -> None:
 
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
+    ema_reset_count: int = 0
     history: list[dict[str, float]] = []
     best_epoch: int | None = None
     best_val_primary_metric_name = primary_metric_key(bundle, phase="val")
@@ -1736,9 +1746,19 @@ def main() -> None:
         if anp_head is not None and anp_ema is not None:
             anp_ema.restore(anp_head)
 
+        # Periodic EMA reset: copy current training model weights into the EMA shadow,
+        # allowing the EMA to track only the current optimization basin going forward.
+        if config.ema_reset_interval > 0 and epoch % config.ema_reset_interval == 0:
+            if ema is not None:
+                ema.reset_to_model(model)
+            if anp_head is not None and anp_ema is not None:
+                anp_ema.reset_to_model(anp_head)
+            ema_reset_count += 1
+
         epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
         epoch_metrics["best_val_metric"] = best_val_metric
         epoch_metrics["best_epoch"] = float(best_epoch)
+        epoch_metrics["ema_reset_count"] = float(ema_reset_count)
         history.append(epoch_metrics)
         if run is not None:
             wandb.log(epoch_metrics, step=epoch)


### PR DESCRIPTION
## Hypothesis

The champion DM config uses EMA=0.9995 running continuously from epoch 0 to 500+. The EMA model averages weights across the ENTIRE training trajectory, including many cosine restart cycles (T_max=30 → ~17 restarts in 500 epochs). Late in training, the model oscillates between different local basins during each cosine cycle. The long-running EMA averages over all these basins, which may dilute the quality of the best basin.

By periodically resetting the EMA model to the current training model weights (every N epochs), we allow the EMA to track only the CURRENT optimization basin. In the critical late-training regime (epochs 400-500), a freshly-reset EMA can capture the deepest point in the current basin without being diluted by earlier, shallower basins.

This is conceptually different from all other EMA experiments (which only varied decay rate). It changes the **temporal scope** of weight averaging.

## Baseline

Current best DrivAerML (PR #3072, eren/dm-ema-9995-gc05):
- `val_primary/surface_rel_l2_pct`: **3.833%** at epoch 511
- test: 4.685%
- W&B run: `ncl1dh88`
- Config: AdamW lr=5e-4, gc=0.5, no WD, 4L/512d/8H, EMA=0.9995, T_max=30, 394 batches/epoch

External target: <3.71% (AB-UPT). Gap: ~0.123 pp.

**Target to beat: 3.833% val_primary/surface_rel_l2_pct**

## Implementation Guidance

1. Add a `--ema-reset-interval` flag (integer, default 0 meaning no reset)
2. When set to N > 0, every N epochs: copy the current training model weights to the EMA model (resetting the running average)
3. After reset, EMA resumes accumulating from the new starting point with the same decay=0.9995
4. Track and log `ema_reset_count` to W&B each time a reset occurs
5. Best-checkpoint selection should still use the EMA model's validation metric

## Known Bug Fix

There is a `primary_metric_key` shadowing bug in train.py where a local variable (line ~1646-1648) shadows the function (line ~1428), causing an `UnboundLocalError`. Fix by renaming the local variable to `best_tracking_metric_key` if you encounter it.

## Trial 1 — EMA reset every 100 epochs (3.3 cosine cycles per reset window)

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --ema-reset-interval 100 \
  --wandb_group dm-ema-reset
```

## Trial 2 — EMA reset every 50 epochs (1.67 cosine cycles per reset window)

Same as Trial 1 but with `--ema-reset-interval 50`:

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --ema-reset-interval 50 \
  --wandb_group dm-ema-reset
```

## Reporting

Report `val_primary/surface_rel_l2_pct` at best epoch for both trials. Target: beat **3.833%**.

Also report:
- `ema_reset_count` logged to W&B (confirms resets are firing)
- Best epoch for each trial
- W&B run IDs for both trials