### PR TITLE
DrivAerML: Decaying Peak LR at Cosine Restarts (SGDR eta_mult)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -160,6 +160,7 @@ class TrainConfig:
     residual_prediction: bool = False
     re_stratified_sampling: bool = False
     cosine_t_max: int = 150
+    cosine_eta_mult: float = 1.0
     geometry_points: int = 25_000
     geometry_supernodes: int = 4_096
     surface_anchor_points: int = 8_000
@@ -1628,9 +1629,20 @@ def main() -> None:
         params.extend(list(anp_head.parameters()))
     optimizer = build_optimizer(params, config)
     scheduler = None
+    cosine_restart_count = 0
     if config.cosine_t_max > 0:
         base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
-        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
+        if config.cosine_eta_mult < 1.0:
+            t_max = config.cosine_t_max
+            eta_mult = config.cosine_eta_mult
+            def _sgdr_lambda(step: int) -> float:
+                cycle = step // t_max
+                t_cur = step % t_max
+                peak_factor = eta_mult ** cycle
+                return peak_factor * 0.5 * (1.0 + math.cos(math.pi * t_cur / t_max))
+            scheduler = torch.optim.lr_scheduler.LambdaLR(base_optimizer, _sgdr_lambda)
+        else:
+            scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
 
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
@@ -1739,6 +1751,12 @@ def main() -> None:
         epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
         epoch_metrics["best_val_metric"] = best_val_metric
         epoch_metrics["best_epoch"] = float(best_epoch)
+        if scheduler is not None and config.cosine_eta_mult < 1.0 and config.cosine_t_max > 0:
+            total_steps = scheduler.last_epoch
+            restart_count = total_steps // config.cosine_t_max
+            current_peak_lr = config.lr * (config.cosine_eta_mult ** restart_count)
+            epoch_metrics["sgdr_restart_count"] = float(restart_count)
+            epoch_metrics["sgdr_current_peak_lr"] = current_peak_lr
         history.append(epoch_metrics)
         if run is not None:
             wandb.log(epoch_metrics, step=epoch)


### PR DESCRIPTION
## Hypothesis

The DM champion uses cosine annealing with T_max=30 (step-level, ~394 steps/epoch), which means the LR restarts to the full peak (5e-4) repeatedly throughout training. With ~13 restarts per epoch × 500 epochs = ~6500 restarts total, the model keeps getting jolted back to full LR even in late training. These late-stage full-strength restarts may cause the val oscillations we see in the 3.8–4.1% range — the model finds a deep basin but then gets kicked out by the next full-LR restart.

**SGDR** (Loshchilov & Hutter 2017) introduced multiplicative decay of the peak LR after each restart cycle. Each restart uses a lower peak LR:

```
peak_lr_n = initial_lr * (eta_mult ** n)
```

where n is the restart count. This preserves the beneficial exploration in early training while making late restarts progressively gentler — reducing the perturbation that destabilizes the model near convergence.

### Why this is distinct from previous dead ends

- **eta_min tuning** — sets a floor for the minimum LR; doesn't change the peak. Already shown to be ineffective for DM.
- **Monotonic cosine** — removes restarts entirely. Dead end at 4.086%.
- **SAM** — tries to flatten basins; incompatible with restarts. Dead.

This approach **preserves restarts** but makes them progressively gentler over training.

---

## Baseline

Current best DrivAerML (PR #3072, `eren/dm-ema-9995-gc05`):
- `val_primary/surface_rel_l2_pct`: **3.833%** at epoch 511
- Test: 4.685%
- W&B run: `ncl1dh88`
- Config: AdamW lr=5e-4, gc=0.5, no WD, 4L/512d/8H, EMA=0.9995, T_max=30, 394 batches/epoch

External target: **<3.71%** (AB-UPT). Gap to close: ~0.123 pp.

---

## Known Bug Fix

There is a `primary_metric_key` shadowing bug in `train.py` where a local variable (around line ~1646–1648) shadows the function defined at line ~1428, causing an `UnboundLocalError`. If you encounter it, fix by renaming the local variable to `best_tracking_metric_key`.

---

## Implementation Guidance

1. Add a `--cosine-eta-mult` flag (float, default `1.0` = no decay).
2. Track the number of completed cosine cycles (restarts).
3. After each restart, multiply the current peak LR by eta_mult:
   ```python
   current_peak = lr * (eta_mult ** restart_count)
   ```
4. The cosine schedule within each cycle goes from `current_peak` down to 0 (or near-0).
5. Log `current_peak_lr` and `restart_count` to W&B at each restart.

### Restart count math

With T_max=30 (step-level) and ~394 steps/epoch:
- Restarts per epoch ≈ 394 / 30 ≈ 13.1
- Total restarts over 500 epochs ≈ **6,500**

This means eta_mult must be **very close to 1.0**. Example decay curves:

| eta_mult | Peak LR at ep500 | Fraction remaining |
|----------|------------------|--------------------|
| 0.9999   | ~2.61e-4         | ~52%               |
| 0.99995  | ~3.61e-4         | ~72%               |

---

## Trials

### Trial 1 — eta_mult=0.9999 (moderate decay: peak ~2.6e-4 at ep500)

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --cosine-eta-mult 0.9999 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --wandb_group dm-decaying-restart
```

### Trial 2 — eta_mult=0.99995 (gentle decay: peak ~3.6e-4 at ep500)

Same as Trial 1 but with `--cosine-eta-mult 0.99995`:

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --cosine-eta-mult 0.99995 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --wandb_group dm-decaying-restart
```

---

## Reporting

For each trial, report:
- `val_primary/surface_rel_l2_pct` at best epoch
- The epoch at which the best val metric was achieved
- The `current_peak_lr` logged at that epoch (to understand where in the decay curve the model finds its optimum)
- W&B run ID

**Target to beat: 3.833%**

If Trial 1 (eta_mult=0.9999) shows improvement, consider a follow-up with eta_mult=0.9998 (more aggressive decay) in the same PR. If Trial 2 (eta_mult=0.99995) shows improvement but Trial 1 doesn't, consider eta_mult=0.99997 as a midpoint.

Report using `--wandb_group dm-decaying-restart` so both runs appear in the same W&B group.