### PR TITLE
DrivAerML: Decaying Weight Decay Schedule

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -120,6 +120,7 @@ class TrainConfig:
     batch_size: int = 2
     lr: float = 3e-4
     weight_decay: float = 1e-4
+    wd_decay_epochs: int = 0
     optimizer: str = "lion"
     use_lookahead: bool = True
     use_ema: bool = True
@@ -1669,9 +1670,18 @@ def main() -> None:
     start_time = time.monotonic()
     timeout_seconds = None if not timeout_env else float(timeout_env) * 60.0
 
+    initial_wd = config.weight_decay
+
     for epoch in range(1, config.epochs + 1):
         if timeout_seconds is not None and epoch > 1 and (time.monotonic() - start_time) >= timeout_seconds:
             break
+
+        if config.wd_decay_epochs > 0:
+            current_wd = initial_wd * max(0.0, 1.0 - epoch / config.wd_decay_epochs)
+            opt = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
+            for pg in opt.param_groups:
+                pg["weight_decay"] = current_wd
+
         train_metrics = train_one_epoch(
             model=forward_model,
             anp_head=anp_head,
@@ -1737,6 +1747,8 @@ def main() -> None:
             anp_ema.restore(anp_head)
 
         epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
+        if config.wd_decay_epochs > 0:
+            epoch_metrics["current_wd"] = initial_wd * max(0.0, 1.0 - epoch / config.wd_decay_epochs)
         epoch_metrics["best_val_metric"] = best_val_metric
         epoch_metrics["best_epoch"] = float(best_epoch)
         history.append(epoch_metrics)


### PR DESCRIPTION
## Hypothesis

The DrivAerML champion uses NO weight decay (WD=0, val=3.833%). Previous experiments with **constant WD=1e-3 got 4.44%** — worse than baseline. The problem with constant WD is well understood: it penalizes large weights equally throughout training, but in late training the model needs precise, possibly large weights to fit high-curvature surface regions.

A **decaying weight decay schedule** provides regularization during early training (helping the model explore and avoid sharp minima) while annealing to zero in late training (allowing unconstrained convergence to the deepest basin). This is conceptually similar to how learning rate decay works — strong regularization early, none late.

**Key comparison:**
- WD=1e-3 constant: **4.44%** — WD too strong, maintained throughout, penalizes late convergence
- WD=0 (champion): **3.833%** — no regularization benefit at all
- **This experiment:** WD starts small and decays to zero — gets early regularization benefit without late-training penalty

---

## Baseline

Current best DrivAerML (PR #3072, `eren/dm-ema-9995-gc05`):
- `val_primary/surface_rel_l2_pct`: **3.833%** at epoch 511
- test: 4.685%
- W&B run: `ncl1dh88`
- Config: AdamW lr=5e-4, gc=0.5, NO WD, 4L/512d/8H, EMA=0.9995, T_max=30, 394 batches/epoch

**External target:** <3.71% (AB-UPT). Gap: ~0.123 pp.

**Target: beat 3.833%.**

---

## Known Bug Fix

There is a `primary_metric_key` shadowing bug in `train.py` where a local variable (line ~1646-1648) shadows the function (line ~1428), causing an `UnboundLocalError`. Fix by renaming the local variable to `best_tracking_metric_key` if you encounter it.

---

## Implementation

1. Add `--wd-decay-epochs` flag (integer, default 0 meaning constant WD / no decay)
2. When set to N > 0, linearly decay the weight decay from its initial value to 0 over N epochs
3. At epoch e: `current_wd = initial_wd * max(0, 1 - e/N)`
4. After epoch N, WD = 0 for the remainder of training
5. Update the optimizer's WD parameter group at each epoch
6. Log `current_wd` to W&B each epoch

---

## Trial Commands

### Trial 1 — WD=1e-4 decaying to 0 over 300 epochs

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --weight-decay 1e-4 \
  --wd-decay-epochs 300 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --wandb_group dm-decaying-wd
```

### Trial 2 — WD=5e-5 decaying to 0 over 300 epochs

Same as Trial 1 but with `--weight-decay 5e-5`:

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --weight-decay 5e-5 \
  --wd-decay-epochs 300 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --wandb_group dm-decaying-wd
```

---

## Reporting

Report `val_primary/surface_rel_l2_pct` at best epoch for both trials. Include W&B run IDs and note the epoch at which you achieved best validation. Also note at which epoch WD reached 0 and whether training dynamics visibly changed at that point (check the loss curves in W&B around epoch 300).