### PR TITLE
DrivAerML Pre-LayerNorm Architecture Ablation

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -169,6 +169,8 @@ class TrainConfig:
     volume_loss_weight: float = 1.0
     save_checkpoint: bool = False
     seed: int = 0
+    post_layer_norm: bool = False
+    use_rmsnorm: bool = False
 
 
 @dataclass
@@ -497,6 +499,47 @@ def cp_panel_prior_index(config: TrainConfig, bundle: DatasetBundle) -> int | No
         base_dim -= 1
         return base_dim
     return None
+
+
+class RMSNorm(torch.nn.Module):
+    def __init__(self, normalized_shape: int, eps: float = 1e-6):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.ones(normalized_shape))
+        self.eps = eps
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        rms = torch.sqrt(torch.mean(x * x, dim=-1, keepdim=True) + self.eps)
+        return x / rms * self.weight
+
+
+def _apply_post_layer_norm(block: torch.nn.Module) -> None:
+    original_forward = block.forward
+
+    def post_ln_forward(x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+        x = block.norm1(x + block.attention(x, attn_mask=attn_mask))
+        x = block.norm2(x + block.mlp(x))
+        return x
+
+    block.forward = post_ln_forward
+
+
+def apply_norm_config(model: torch.nn.Module, config: TrainConfig) -> None:
+    from core.architectures.transolver_reference import TransformerBlock
+
+    if config.use_rmsnorm:
+        for module in model.modules():
+            if isinstance(module, TransformerBlock):
+                hidden_dim = module.norm1.normalized_shape[0]
+                module.norm1 = RMSNorm(hidden_dim, eps=1e-6)
+                module.norm2 = RMSNorm(hidden_dim, eps=1e-6)
+            elif hasattr(module, "norm") and isinstance(module.norm, torch.nn.LayerNorm) and not isinstance(module, TransformerBlock):
+                hidden_dim = module.norm.normalized_shape[0]
+                module.norm = RMSNorm(hidden_dim, eps=1e-6)
+
+    if config.post_layer_norm:
+        for module in model.modules():
+            if isinstance(module, TransformerBlock):
+                _apply_post_layer_norm(module)
 
 
 def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
@@ -1614,7 +1657,10 @@ def main() -> None:
             )
 
     train_loader, val_loaders, test_loaders = build_loaders(config, bundle, num_workers=resolved_num_workers)
-    model = build_model(config, bundle).to(device)
+    model = build_model(config, bundle)
+    if config.post_layer_norm or config.use_rmsnorm:
+        apply_norm_config(model, config)
+    model = model.to(device)
     forward_model = torch.compile(model) if config.compile_model and device.type == "cuda" else model
     anp_head = None
     if bundle.spec.name == "tandemfoilset" and config.anp_srf:
@@ -1639,15 +1685,6 @@ def main() -> None:
     best_val_primary_metric_name = primary_metric_key(bundle, phase="val")
     best_val_primary_metric: float | None = None
     best_val_metrics: dict[str, float] = {}
-    best_model_state: dict[str, torch.Tensor] | None = None
-    best_anp_state: dict[str, torch.Tensor] | None = None
-
-    if bundle.spec.name == "tandemfoilset":
-        val_primary_key = "val_primary/surface_pressure_mae"
-    else:
-        val_primary_key = f"val_primary/{bundle.spec.default_metric}"
-    best_val_metric = float("inf")
-    best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
     best_ema_shadow: dict[str, torch.Tensor] | None = None
@@ -1718,14 +1755,6 @@ def main() -> None:
             best_val_metrics = dict(eval_metrics)
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
-
-        current_val = eval_metrics.get(val_primary_key)
-        if current_val is not None and current_val < best_val_metric:
-            best_val_metric = current_val
-            best_epoch = epoch
-            best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
-            if anp_head is not None:
-                best_anp_state = {k: v.cpu().clone() for k, v in anp_head.state_dict().items()}
             if ema is not None:
                 best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
             if anp_ema is not None:
@@ -1737,14 +1766,14 @@ def main() -> None:
             anp_ema.restore(anp_head)
 
         epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
-        epoch_metrics["best_val_metric"] = best_val_metric
-        epoch_metrics["best_epoch"] = float(best_epoch)
+        epoch_metrics["best_val_metric"] = best_val_primary_metric
+        epoch_metrics["best_epoch"] = float(best_epoch) if best_epoch is not None else 0.0
         history.append(epoch_metrics)
         if run is not None:
             wandb.log(epoch_metrics, step=epoch)
             run.summary["epoch"] = epoch
             run.summary["best_epoch"] = best_epoch
-            run.summary["best_val_metric"] = best_val_metric
+            run.summary["best_val_metric"] = best_val_primary_metric
         print(json.dumps(epoch_metrics, sort_keys=True), flush=True)
 
     if best_epoch is not None:
@@ -1795,8 +1824,8 @@ def main() -> None:
             wandb.log(final_test_metrics, step=int(history[-1]["epoch"]) if history else 0)
             run.summary.update(final_test_metrics)
             run.summary["best_epoch"] = best_epoch
-            run.summary["best_val_metric"] = best_val_metric
-        print(json.dumps({"final_test_metrics": final_test_metrics, "best_epoch": best_epoch, "best_val_metric": best_val_metric}, sort_keys=True), flush=True)
+            run.summary["best_val_metric"] = best_val_primary_metric
+        print(json.dumps({"final_test_metrics": final_test_metrics, "best_epoch": best_epoch, "best_val_metric": best_val_primary_metric}, sort_keys=True), flush=True)
 
         if best_model_state is not None:
             restore_module_state(model, best_model_state)


### PR DESCRIPTION
## Hypothesis

Standard transformers come in two flavors: Post-LN (original Vaswani et al.) and Pre-LN (GPT-2, LLaMA). Pre-LN applies LayerNorm BEFORE the attention and MLP sub-layers, while Post-LN applies it AFTER. Pre-LN is known to:

1. Reduce gradient variance in deep models (Xiong et al. 2020 "On Layer Normalization in the Transformer Architecture")
2. Improve training stability, especially with aggressive LR schedules
3. Often match or exceed Post-LN performance in practice

The DrivAerML model uses a Transolver architecture. If it uses Post-LN (the default in many implementations), switching to Pre-LN could reduce gradient variance at cosine restart boundaries, enabling better late-stage convergence at the 3.833% frontier. With only 4 layers, the depth isn't extreme, but Pre-LN's gradient stabilization effect is still relevant given the T_max=30 rapid restart schedule.

## Baseline

Current best DrivAerML (PR #3072, eren/dm-ema-9995-gc05):
- **val_primary/surface_rel_l2_pct: 3.833%** at epoch 511
- test: 4.685%
- W&B run: ncl1dh88
- Config: AdamW lr=5e-4, gc=0.5, no WD, 4L/512d/8H, EMA=0.9995, T_max=30, 394 batches/epoch

External target: <3.71% (AB-UPT). Gap: ~0.123 pp.

**Target: beat 3.833%.**

## Known Bug

There's a `primary_metric_key` shadowing bug in train.py where a local variable (line ~1646-1648) shadows the function (line ~1428), causing an `UnboundLocalError`. Fix by renaming the local variable to `best_tracking_metric_key` if you encounter it.

## Instructions

### Step 1: Investigate current architecture

First, read the Transolver model code to determine whether it currently uses Pre-LN or Post-LN. Look at the TransolverBlock/TransolverLayer forward method. Report which norm placement is used in your results comment.

### Step 2: Implement the alternative

- If currently Post-LN: implement Pre-LN (add `--pre-layer-norm` flag)
- If currently Pre-LN: implement Post-LN (add `--post-layer-norm` flag)
- The change is: move the LayerNorm from `x = LN(x + sublayer(x))` to `x = x + sublayer(LN(x))`
- If the model uses a different normalization pattern, describe it and propose the Pre-LN variant

### Trial 1 — Alternative LN placement on champion config

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --pre-layer-norm \
  --wandb_group dm-pre-layernorm
```

(Adjust the flag name based on what you find in Step 1 — use `--post-layer-norm` if the current default is Pre-LN.)

### Trial 2 — Alternative LN + RMSNorm (if Pre-LN is the change)

If changing to Pre-LN, also try replacing LayerNorm with RMSNorm (Root Mean Square Layer Normalization — simpler, no mean centering). RMSNorm is used in LLaMA and is both faster and sometimes more effective than LayerNorm.

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --pre-layer-norm \
  --use-rmsnorm \
  --wandb_group dm-pre-layernorm
```

## Reporting

Report `val_primary/surface_rel_l2_pct` at best epoch for each trial. Include W&B run IDs. Target: beat **3.833%**.