### PR TITLE
DrivAerML Progressive Surface Point Training (Resolution Curriculum)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -167,6 +167,7 @@ class TrainConfig:
     grad_clip: float = 0.0
     grad_accum_steps: int = 1
     volume_loss_weight: float = 1.0
+    progressive_points_schedule: str = ""
     save_checkpoint: bool = False
     seed: int = 0
 
@@ -452,6 +453,27 @@ def parse_args() -> TrainConfig:
             parser.add_argument(arg_name, type=type(field_value), default=field_value)
     namespace = parser.parse_args()
     return TrainConfig(**vars(namespace))
+
+
+def parse_progressive_points_schedule(schedule: str) -> list[tuple[int, int]]:
+    if not schedule.strip():
+        return []
+    stages: list[tuple[int, int]] = []
+    for part in schedule.split(","):
+        part = part.strip()
+        points_str, epoch_str = part.split(":")
+        stages.append((int(points_str), int(epoch_str)))
+    stages.sort(key=lambda s: s[1])
+    return stages
+
+
+def get_progressive_train_points(stages: list[tuple[int, int]], epoch: int) -> int | None:
+    if not stages:
+        return None
+    for points, until_epoch in stages:
+        if epoch <= until_epoch:
+            return points
+    return stages[-1][0]
 
 
 def build_bundle(config: TrainConfig) -> DatasetBundle:
@@ -1643,13 +1665,13 @@ def main() -> None:
     best_anp_state: dict[str, torch.Tensor] | None = None
 
     if bundle.spec.name == "tandemfoilset":
-        val_primary_key = "val_primary/surface_pressure_mae"
+        best_tracking_metric_key = "val_primary/surface_pressure_mae"
     else:
-        val_primary_key = f"val_primary/{bundle.spec.default_metric}"
+        best_tracking_metric_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
     best_epoch = 0
-    best_model_state: dict[str, torch.Tensor] | None = None
-    best_anp_state: dict[str, torch.Tensor] | None = None
+    best_model_state = None
+    best_anp_state = None
     best_ema_shadow: dict[str, torch.Tensor] | None = None
     best_anp_ema_shadow: dict[str, torch.Tensor] | None = None
 
@@ -1666,12 +1688,25 @@ def main() -> None:
             tags=[config.dataset, config.model],
         )
 
+    progressive_stages = parse_progressive_points_schedule(config.progressive_points_schedule)
+    prev_train_points: int | None = None
+
     start_time = time.monotonic()
     timeout_seconds = None if not timeout_env else float(timeout_env) * 60.0
 
     for epoch in range(1, config.epochs + 1):
         if timeout_seconds is not None and epoch > 1 and (time.monotonic() - start_time) >= timeout_seconds:
             break
+
+        current_train_points = get_progressive_train_points(progressive_stages, epoch)
+        if current_train_points is not None:
+            train_ds = bundle.train_dataset
+            if hasattr(train_ds, "max_surface_points"):
+                if current_train_points != prev_train_points:
+                    print(f"[progressive] epoch {epoch}: train surface points {prev_train_points} -> {current_train_points}", flush=True)
+                    prev_train_points = current_train_points
+                train_ds.max_surface_points = current_train_points
+
         train_metrics = train_one_epoch(
             model=forward_model,
             anp_head=anp_head,
@@ -1719,7 +1754,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(val_primary_key)
+        current_val = eval_metrics.get(best_tracking_metric_key)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch
@@ -1739,6 +1774,8 @@ def main() -> None:
         epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
         epoch_metrics["best_val_metric"] = best_val_metric
         epoch_metrics["best_epoch"] = float(best_epoch)
+        if current_train_points is not None:
+            epoch_metrics["current_train_points"] = float(current_train_points)
         history.append(epoch_metrics)
         if run is not None:
             wandb.log(epoch_metrics, step=epoch)


### PR DESCRIPTION
## Hypothesis

DrivAerML trains with 50,000 surface points per mesh, using 394 meshes per epoch. At 4L/512d, each epoch takes ~1 minute. The champion reached its best (3.833%) at epoch 511 of 517 total — still improving at timeout. More epochs would likely push the result lower.

Progressive training (curriculum learning on resolution) exploits the observation that early training learns COARSE surface patterns that don't require full 50k-point resolution. By training with fewer points (e.g., 25k or 30k) for the first N epochs, we get:
1. **Faster epochs** — roughly 40-50% faster per epoch at 25k vs 50k points
2. **More total epochs** in the same wall-clock budget
3. **Implicit regularization** — lower resolution forces the model to learn smoother, more generalizable representations first
4. **Full-resolution fine-tuning** — switching to 50k points in late training refines predictions at the detailed level

This is a training efficiency technique, not a model change. The model architecture stays exactly the same — only the number of sampled points per mesh changes during training.

## Baseline

Current best DrivAerML (PR #3072, eren/dm-ema-9995-gc05):
- `val_primary/surface_rel_l2_pct`: **3.833%** at epoch 511
- test: 4.685%
- W&B run: `ncl1dh88`
- Config: AdamW lr=5e-4, gc=0.5, no WD, 4L/512d/8H, EMA=0.9995, T_max=30, 394 batches/epoch
- Trained 517 epochs in ~360 minutes (~0.7 min/epoch at 50k points)

External target: <3.71% (AB-UPT). Gap: ~0.123 pp.

**Target: beat 3.833%**

## Known Bug Fix

There is a `primary_metric_key` shadowing bug in `train.py` where a local variable (lines ~1646-1648) shadows the function (line ~1428), causing an `UnboundLocalError`. Fix by renaming the local variable to `best_tracking_metric_key` if you encounter it.

## Implementation

1. Add `--progressive-points-schedule` flag (string, e.g., `"25000:200,50000:999"` meaning 25k points for epochs 0–200, 50k for 201–999)
2. Parse the schedule and change `drivaerml_train_surface_points` at the appropriate epoch boundaries
3. **Eval points must ALWAYS stay at 50k** (consistent evaluation)
4. Log `current_train_points` to W&B each epoch

## Trial 1 — 25k points for first 200 epochs, then 50k

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --progressive-points-schedule "25000:200,50000:999" \
  --wandb_group dm-progressive-resolution
```

## Trial 2 — 30k points for first 100 epochs, then 50k

Same as Trial 1 but with:
```
--progressive-points-schedule "30000:100,50000:999"
```

## Key Measurements

- Compare total wall-clock training time and total epochs reached vs baseline
- Report both the best val metric AND the total number of epochs trained within the timeout
- Report `val_primary/surface_rel_l2_pct` at best epoch
- Both trials should use `--wandb_group dm-progressive-resolution`

## Expected Outcome

At 25k points, epochs should run ~40–50% faster, allowing ~700–800 epochs within the same ~360-minute budget vs the baseline's 517. Even if full-resolution performance is modestly below what pure 50k training achieves, the extra epochs in the fine-tuning phase should more than compensate. The implicit regularization from coarse early training may also improve generalization.