### PR TITLE
DrivAerML: Input Feature Dropout on Fourier Channels

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -167,6 +167,7 @@ class TrainConfig:
     grad_clip: float = 0.0
     grad_accum_steps: int = 1
     volume_loss_weight: float = 1.0
+    input_feature_dropout: float = 0.0
     save_checkpoint: bool = False
     seed: int = 0
 
@@ -1271,6 +1272,8 @@ def train_one_epoch(
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
     volume_loss_weight: float = 1.0,
+    input_feature_dropout: float = 0.0,
+    fourier_start_idx: int = 0,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1319,11 +1322,25 @@ def train_one_epoch(
                         outputs = maybe_apply_anp(outputs, prepared, anp_head)
                         loss, _ = loss_grouped_tandem(prepared, outputs, volume_loss_weight=volume_loss_weight)
                 else:
+                    train_surface_x = batch.surface_x
+                    train_volume_x = batch.volume_x
+                    if input_feature_dropout > 0 and fourier_start_idx > 0:
+                        B = train_surface_x.shape[0]
+                        n_fourier = train_surface_x.shape[-1] - fourier_start_idx
+                        mask = (torch.rand(B, 1, n_fourier, device=train_surface_x.device) >= input_feature_dropout).to(train_surface_x.dtype)
+                        scale = 1.0 / (1.0 - input_feature_dropout)
+                        fourier_part = train_surface_x[..., fourier_start_idx:] * mask * scale
+                        train_surface_x = torch.cat([train_surface_x[..., :fourier_start_idx], fourier_part], dim=-1)
+                        if train_volume_x is not None and train_volume_x.shape[-1] > fourier_start_idx:
+                            vol_fourier = train_volume_x[..., fourier_start_idx:] * mask * scale
+                            train_volume_x = torch.cat([train_volume_x[..., :fourier_start_idx], vol_fourier], dim=-1)
+                        running.setdefault("input_feat_dropout_active_channels", 0.0)
+                        running["input_feat_dropout_active_channels"] += float(mask.sum() / B)
                     with autocast_context(device, amp_mode):
                         outputs = model(
-                            surface_x=batch.surface_x,
+                            surface_x=train_surface_x,
                             surface_mask=batch.surface_mask,
-                            volume_x=batch.volume_x,
+                            volume_x=train_volume_x,
                             volume_mask=batch.volume_mask,
                         )
                         loss, _ = loss_grouped(batch, outputs, transform, volume_loss_weight=volume_loss_weight)
@@ -1359,6 +1376,8 @@ def train_one_epoch(
     running["loss"] /= max(steps, 1)
     if "grad_norm_mean" in running:
         running["grad_norm_mean"] /= max(steps, 1)
+    if "input_feat_dropout_active_channels" in running:
+        running["input_feat_dropout_active_channels"] /= max(steps, 1)
     running["train_steps"] = float(steps)
     running["micro_batches"] = float(micro_batches_total)
     if scheduler is not None:
@@ -1653,6 +1672,11 @@ def main() -> None:
     best_ema_shadow: dict[str, torch.Tensor] | None = None
     best_anp_ema_shadow: dict[str, torch.Tensor] | None = None
 
+    fourier_start_idx = 0
+    if config.enable_fourier and config.input_feature_dropout > 0:
+        n_fourier = bundle.spec.space_dim * len((0.5, 2.0, 8.0, 32.0)) * 2
+        fourier_start_idx = bundle.spec.surface_input_dim - n_fourier
+
     run = None
     if config.wandb_name:
         run_config = asdict(config)
@@ -1688,6 +1712,8 @@ def main() -> None:
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
             volume_loss_weight=config.volume_loss_weight,
+            input_feature_dropout=config.input_feature_dropout,
+            fourier_start_idx=fourier_start_idx,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

The DM model uses Fourier positional encoding that generates multiple frequency channels (sin/cos at frequencies 0.5, 2.0, 8.0, 32.0) for each xyz coordinate. This produces 24 Fourier features + 3 raw coords + 3 normals = 30 input features per surface point. The model may over-rely on specific frequency bands, making it brittle to noise at those frequencies.

Feature dropout — randomly zeroing out a subset of INPUT feature channels during training — forces the model to learn redundant, robust representations that don't depend on any single frequency band. This is different from:
- Attention dropout (dead — noise at attention level compounds with cosine restarts)
- Model dropout (dead — regularization at the hidden layer level incompatible with EMA)
- **This operates at the INPUT level, before any model computation**

At test time, all features are used (standard dropout inference). The implicit ensemble of feature subsets provides a smoothing effect similar to how random forest feature bagging improves generalization.

## Baseline

Current best DrivAerML (PR #3072, eren/dm-ema-9995-gc05):
- `val_primary/surface_rel_l2_pct`: **3.833%** at epoch 511
- test: 4.685%
- W&B run: ncl1dh88
- Config: AdamW lr=5e-4, gc=0.5, no WD, 4L/512d/8H, EMA=0.9995, T_max=30, 394 batches/epoch

External target: <3.71% (AB-UPT). Gap: ~0.123 pp.

## Known Bug Fix

There's a `primary_metric_key` shadowing bug in train.py where a local variable (line ~1646-1648) shadows the function (line ~1428), causing an `UnboundLocalError`. Fix by renaming the local variable to `best_tracking_metric_key` if you encounter it.

## Implementation

1. Add `--input-feature-dropout` flag (float, default 0.0 meaning no dropout)
2. During training only (not eval), randomly zero out each Fourier feature channel independently with probability p
3. Apply AFTER Fourier encoding, BEFORE feeding into the model
4. Do NOT drop the raw xyz coordinates or normals — only the Fourier-encoded channels (the 24 sin/cos features)
5. Scale surviving features by 1/(1-p) during training (standard dropout scaling)
6. Log effective feature count per step to W&B (for verification)

## Trial 1 — 10% feature dropout

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --input-feature-dropout 0.1 \
  --wandb_group dm-feature-dropout
```

## Trial 2 — 20% feature dropout

Same as Trial 1 but with `--input-feature-dropout 0.2`

## Success Criterion

Report `val_primary/surface_rel_l2_pct` at best epoch. Target: beat **3.833%**.