### PR TITLE
DrivAerML Coordinate Noise Augmentation (Input Perturbation Regularization)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -165,6 +165,7 @@ class TrainConfig:
     surface_anchor_points: int = 8_000
     volume_anchor_points: int = 8_000
     grad_clip: float = 0.0
+    coord_noise_std: float = 0.0
     grad_accum_steps: int = 1
     volume_loss_weight: float = 1.0
     save_checkpoint: bool = False
@@ -1254,6 +1255,27 @@ def evaluate_abupt(
     return {"surface_mae": total_surface / max(count_surface, 1), "volume_mae": total_volume / max(count_volume, 1)}
 
 
+def _apply_coord_noise(
+    surface_x: torch.Tensor,
+    noise_std: float,
+    space_dim: int,
+    enable_fourier: bool,
+    fourier_freqs: tuple[float, ...] = (0.5, 2.0, 8.0, 32.0),
+) -> torch.Tensor:
+    surface_x = surface_x.clone()
+    surface_x[..., :space_dim] = surface_x[..., :space_dim] + torch.randn_like(surface_x[..., :space_dim]) * noise_std
+    if enable_fourier:
+        fourier_dim = space_dim * len(fourier_freqs) * 2
+        base_dim = surface_x.shape[-1] - fourier_dim
+        noisy_coords = surface_x[..., :space_dim]
+        fourier_pieces = []
+        for freq in fourier_freqs:
+            fourier_pieces.append(torch.sin(noisy_coords * freq))
+            fourier_pieces.append(torch.cos(noisy_coords * freq))
+        surface_x = torch.cat([surface_x[..., :base_dim], torch.cat(fourier_pieces, dim=-1)], dim=-1)
+    return surface_x
+
+
 def train_one_epoch(
     model: torch.nn.Module,
     anp_head: ANPSurfaceDecoder | None,
@@ -1271,6 +1293,9 @@ def train_one_epoch(
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
     volume_loss_weight: float = 1.0,
+    coord_noise_std: float = 0.0,
+    space_dim: int = 3,
+    enable_fourier: bool = False,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1319,9 +1344,14 @@ def train_one_epoch(
                         outputs = maybe_apply_anp(outputs, prepared, anp_head)
                         loss, _ = loss_grouped_tandem(prepared, outputs, volume_loss_weight=volume_loss_weight)
                 else:
+                    noisy_surface_x = (
+                        _apply_coord_noise(batch.surface_x, coord_noise_std, space_dim, enable_fourier)
+                        if coord_noise_std > 0
+                        else batch.surface_x
+                    )
                     with autocast_context(device, amp_mode):
                         outputs = model(
-                            surface_x=batch.surface_x,
+                            surface_x=noisy_surface_x,
                             surface_mask=batch.surface_mask,
                             volume_x=batch.volume_x,
                             volume_mask=batch.volume_mask,
@@ -1688,6 +1718,9 @@ def main() -> None:
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
             volume_loss_weight=config.volume_loss_weight,
+            coord_noise_std=config.coord_noise_std,
+            space_dim=bundle.spec.space_dim,
+            enable_fourier=config.enable_fourier,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

DrivAerML trains on 50k surface points per mesh, where each point has xyz coordinates and surface normals. The model uses Fourier positional encoding on the coordinates. Currently, the model sees the EXACT same point coordinates every time it processes a given mesh.

By adding small Gaussian noise (σ=0.001–0.005 in normalized coordinate space) to the xyz coordinates during training, we force the model to learn surface field predictions that are locally smooth and robust to small position perturbations. This is:

1. **A form of data augmentation** — each epoch sees slightly different point positions, increasing effective data diversity
2. **Implicit regularization** — forces smooth learned representations
3. **Physics-motivated** — aerodynamic surface fields should be spatially continuous; if moving a point by 0.1mm changes the prediction dramatically, the model has overfit to exact positions
4. **Affects Fourier features** — noise on coordinates creates noisy Fourier features, preventing over-reliance on specific frequency components

At test time, use clean (unperturbed) coordinates.

## Baseline

Current best DrivAerML (PR #3072, eren/dm-ema-9995-gc05):
- `val_primary/surface_rel_l2_pct`: **3.833%** at epoch 511
- test: 4.685%
- W&B run: ncl1dh88
- Config: AdamW lr=5e-4, gc=0.5, no WD, 4L/512d/8H, EMA=0.9995, T_max=30, 394 batches/epoch

**Target to beat: 3.833%**. External target: <3.71% (AB-UPT). Gap: ~0.123 pp.

## Known Bug Fix

There is a `primary_metric_key` shadowing bug in `train.py` where a local variable (line ~1646–1648) shadows the function (line ~1428), causing an `UnboundLocalError`. Fix by renaming the local variable to `best_tracking_metric_key` if you encounter it.

## Implementation

1. Add `--coord-noise-std` flag (float, default 0.0 — no noise)
2. During training only (not eval), add Gaussian noise to xyz coordinates:
   ```python
   xyz = xyz + torch.randn_like(xyz) * noise_std
   ```
3. Apply noise **BEFORE** Fourier encoding (so the Fourier features are computed on noisy positions)
4. Do **NOT** add noise to normals or target values — only to position coordinates
5. Log `coord_noise_std` to W&B config

## Trial 1 — σ=0.001 (conservative: ~0.1% of coordinate range)

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --coord-noise-std 0.001 \
  --wandb_group dm-coord-noise
```

## Trial 2 — σ=0.005 (moderate: ~0.5% of coordinate range)

Same as Trial 1 but with `--coord-noise-std 0.005`:

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --coord-noise-std 0.005 \
  --wandb_group dm-coord-noise
```

## Reporting

Report `val_primary/surface_rel_l2_pct` at best epoch for both trials. Target: beat **3.833%**.

Use `--wandb_group dm-coord-noise` so both trials appear together in W&B.