### PR TITLE
AF: Extended training via reduced eval frequency (chihiro)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -168,6 +168,7 @@ class TrainConfig:
     grad_accum_steps: int = 1
     volume_loss_weight: float = 1.0
     save_checkpoint: bool = False
+    eval_every_n_epochs: int = 1
     seed: int = 0
 
 
@@ -1669,6 +1670,8 @@ def main() -> None:
     start_time = time.monotonic()
     timeout_seconds = None if not timeout_env else float(timeout_env) * 60.0
 
+    last_eval_epoch = 0
+
     for epoch in range(1, config.epochs + 1):
         if timeout_seconds is not None and epoch > 1 and (time.monotonic() - start_time) >= timeout_seconds:
             break
@@ -1690,6 +1693,77 @@ def main() -> None:
             volume_loss_weight=config.volume_loss_weight,
         )
 
+        should_eval = (
+            config.eval_every_n_epochs <= 1
+            or epoch % config.eval_every_n_epochs == 0
+            or epoch == config.epochs
+        )
+
+        eval_metrics: dict[str, float] = {}
+        if should_eval:
+            if ema is not None:
+                ema.store(model)
+                ema.copy_to(model)
+            if anp_head is not None and anp_ema is not None:
+                anp_ema.store(anp_head)
+                anp_ema.copy_to(anp_head)
+
+            eval_metrics = evaluate_phase_metrics(
+                bundle=bundle,
+                config=config,
+                forward_model=forward_model,
+                anp_head=anp_head,
+                loaders=val_loaders,
+                transform=transform,
+                metric_transform=metric_transform,
+                device=device,
+                phase="val",
+            )
+
+            current_primary_metric = eval_metrics.get(best_val_primary_metric_name)
+            if current_primary_metric is not None and (
+                best_val_primary_metric is None or current_primary_metric < best_val_primary_metric
+            ):
+                best_epoch = epoch
+                best_val_primary_metric = current_primary_metric
+                best_val_metrics = dict(eval_metrics)
+                best_model_state = snapshot_module_state(model)
+                best_anp_state = snapshot_module_state(anp_head)
+
+            current_val = eval_metrics.get(val_primary_key)
+            if current_val is not None and current_val < best_val_metric:
+                best_val_metric = current_val
+                best_epoch = epoch
+                best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
+                if anp_head is not None:
+                    best_anp_state = {k: v.cpu().clone() for k, v in anp_head.state_dict().items()}
+                if ema is not None:
+                    best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
+                if anp_ema is not None:
+                    best_anp_ema_shadow = {k: v.cpu().clone() for k, v in anp_ema.shadow.items()}
+
+            if ema is not None:
+                ema.restore(model)
+            if anp_head is not None and anp_ema is not None:
+                anp_ema.restore(anp_head)
+
+            last_eval_epoch = epoch
+
+        epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
+        epoch_metrics["best_val_metric"] = best_val_metric
+        epoch_metrics["best_epoch"] = float(best_epoch)
+        history.append(epoch_metrics)
+        if run is not None:
+            wandb.log(epoch_metrics, step=epoch)
+            run.summary["epoch"] = epoch
+            run.summary["best_epoch"] = best_epoch
+            run.summary["best_val_metric"] = best_val_metric
+        print(json.dumps(epoch_metrics, sort_keys=True), flush=True)
+
+    # Catch-up eval: if the last trained epoch wasn't evaluated (e.g. timeout),
+    # run one final validation pass to capture terminal metrics.
+    if history and last_eval_epoch < int(history[-1]["epoch"]):
+        catchup_epoch = int(history[-1]["epoch"])
         if ema is not None:
             ema.store(model)
             ema.copy_to(model)
@@ -1713,7 +1787,7 @@ def main() -> None:
         if current_primary_metric is not None and (
             best_val_primary_metric is None or current_primary_metric < best_val_primary_metric
         ):
-            best_epoch = epoch
+            best_epoch = catchup_epoch
             best_val_primary_metric = current_primary_metric
             best_val_metrics = dict(eval_metrics)
             best_model_state = snapshot_module_state(model)
@@ -1722,7 +1796,7 @@ def main() -> None:
         current_val = eval_metrics.get(val_primary_key)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
-            best_epoch = epoch
+            best_epoch = catchup_epoch
             best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
             if anp_head is not None:
                 best_anp_state = {k: v.cpu().clone() for k, v in anp_head.state_dict().items()}
@@ -1736,16 +1810,10 @@ def main() -> None:
         if anp_head is not None and anp_ema is not None:
             anp_ema.restore(anp_head)
 
-        epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
-        epoch_metrics["best_val_metric"] = best_val_metric
-        epoch_metrics["best_epoch"] = float(best_epoch)
-        history.append(epoch_metrics)
         if run is not None:
-            wandb.log(epoch_metrics, step=epoch)
-            run.summary["epoch"] = epoch
+            wandb.log(eval_metrics, step=catchup_epoch)
             run.summary["best_epoch"] = best_epoch
             run.summary["best_val_metric"] = best_val_metric
-        print(json.dumps(epoch_metrics, sort_keys=True), flush=True)
 
     if best_epoch is not None:
         print(


### PR DESCRIPTION
## Hypothesis

The AF champion (PR #3135, W&B run: sh2zyfwr) was still actively improving at timeout:
- Best surface at epoch 704 out of 763 total epochs
- Best volume at epoch 743 out of 763 total epochs
- Both metrics still on a downward trajectory at cutoff

AirfRANS evaluation is expensive — computing surface and volume metrics over the full dataset takes significant time per epoch. By reducing eval frequency from every epoch to every 3 epochs, we save ~67% of eval compute. This translates directly to MORE training epochs within the same wall-clock budget.

If the champion can train to 900–1000+ epochs (vs 763), the continued descent could naturally close the volume gap (0.002039 → target 0.0017, a 17% improvement) without any model or loss changes. This is the simplest possible approach to volume closure.

## Baseline (PR #3135, run sh2zyfwr)

| Metric | Value | Epoch |
|--------|-------|-------|
| val_primary/surface_mse | 0.000296 | 704 |
| vol_mse | 0.002039 | 743 |
| Total epochs | 763 (timeout) | — |

Config: 2L/256d/4H, AdamW lr=6e-4, T_max=50, gc=1.0, WD=1e-2, EMA=0.999, vol-weight=10x, Fourier

**Volume target: vol_mse < 0.0017 (SpiderSolver benchmark). Gap: 17%.**

## Known Bug Fix

There is a `primary_metric_key` shadowing bug in train.py where a local variable (line ~1646–1648) shadows the function (line ~1428), causing an `UnboundLocalError`. Fix by renaming the local variable to `best_tracking_metric_key` if you encounter it.

## Implementation

Add an `--eval-every-n-epochs` flag (integer, default 1):
1. Only run validation every N epochs. Skip eval on non-eval epochs.
2. Best-checkpoint saving still works — just updates less frequently.
3. Always eval on the LAST epoch before timeout (to capture terminal metrics).
4. Log `eval_every_n_epochs` to W&B config.

## Trials

### Trial 1 — Eval every 3 epochs (champion config)

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 \
  --cosine-t-max 50 \
  --grad-clip 1.0 \
  --weight-decay 1e-2 \
  --enable-fourier \
  --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 \
  --ema-decay 0.999 \
  --vol-loss-weight 10.0 \
  --eval-every-n-epochs 3 \
  --wandb_group af-extended-training
```

### Trial 2 — Eval every 5 epochs (more aggressive savings)

Same as Trial 1 but with `--eval-every-n-epochs 5`

## Results to Report

- Total epochs trained and wall-clock time for each trial
- Best val surface_mse and epoch for each trial
- Best val vol_mse and epoch for each trial
- Direct comparison to baseline sh2zyfwr (763 epochs, surface=0.000296 at ep704, vol=0.002039 at ep743)

Target: **vol_mse < 0.0017** while maintaining **surface_mse < 0.000350**.