### PR TITLE
zenitsu: DM curvature-weighted loss (per-point MSE weighting by local surface curvature)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "weave",
     "tqdm",
     "matplotlib",
+    "scipy",
 ]
 
 [tool.setuptools.packages.find]

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -15,6 +15,7 @@ from contextlib import nullcontext
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
+import numpy as np
 import torch
 import torch.nn.functional as F
 import wandb
@@ -167,6 +168,7 @@ class TrainConfig:
     grad_clip: float = 0.0
     grad_accum_steps: int = 1
     volume_loss_weight: float = 1.0
+    curvature_loss_weight: float = 0.0
     save_checkpoint: bool = False
     seed: int = 0
 
@@ -607,6 +609,9 @@ def build_loaders(
         train_collate = collate_grouped
         eval_collate = collate_grouped
 
+    if config.curvature_loss_weight > 0 and config.model != "reference_abupt":
+        train_collate = CurvatureCollateWrapper(train_collate, config.curvature_loss_weight)
+
     train_sampler = None
     shuffle = True
     if config.re_stratified_sampling and bundle.sample_weights is not None:
@@ -758,6 +763,50 @@ def _named_channel_metrics(prefix: str, values: torch.Tensor, names: tuple[str, 
     return metrics
 
 
+def _compute_curvature_weights(
+    positions: np.ndarray, normals: np.ndarray, k: int = 8, alpha: float = 1.0,
+) -> np.ndarray:
+    from scipy.spatial import cKDTree
+
+    n = positions.shape[0]
+    if n <= k:
+        return np.ones(n, dtype=np.float32)
+    tree = cKDTree(positions)
+    _, indices = tree.query(positions, k=k + 1)
+    indices = indices[:, 1:]
+    neighbor_normals = normals[indices]
+    normal_var = np.var(neighbor_normals, axis=1).sum(axis=1)
+    curvature = np.sqrt(normal_var + 1e-10)
+    p95 = np.percentile(curvature, 95)
+    curvature = np.minimum(curvature, p95)
+    mean_curv = curvature.mean() + 1e-8
+    weights = 1.0 + alpha * (curvature / mean_curv)
+    return weights.astype(np.float32)
+
+
+class CurvatureCollateWrapper:
+    def __init__(self, inner_collate, curvature_loss_weight: float, curvature_k: int = 8):
+        self.inner = inner_collate
+        self.curvature_loss_weight = curvature_loss_weight
+        self.curvature_k = curvature_k
+
+    def __call__(self, samples):
+        batch = self.inner(samples)
+        if self.curvature_loss_weight <= 0:
+            return batch
+        B = len(samples)
+        max_n = batch.surface_x.shape[1]
+        weights = torch.ones(B, max_n, dtype=torch.float32)
+        for i, sample in enumerate(samples):
+            n = sample.surface_x.shape[0]
+            pos = sample.surface_x[:, :3].numpy()
+            nrm = sample.surface_x[:, 3:6].numpy()
+            w = _compute_curvature_weights(pos, nrm, self.curvature_k, self.curvature_loss_weight)
+            weights[i, :n] = torch.from_numpy(w)
+        batch.curvature_weights = weights
+        return batch
+
+
 def loss_grouped(
     batch: GroupedBatch,
     outputs: dict[str, torch.Tensor | None],
@@ -768,7 +817,17 @@ def loss_grouped(
     metrics: dict[str, float] = {}
     if batch.surface_y is not None and outputs["surface_preds"] is not None:
         target = transform.apply(batch.surface_y)
-        surf_loss = F.mse_loss(outputs["surface_preds"][batch.surface_mask], target[batch.surface_mask])
+        preds = outputs["surface_preds"][batch.surface_mask]
+        target_valid = target[batch.surface_mask]
+        curvature_weights = getattr(batch, "curvature_weights", None)
+        if curvature_weights is not None:
+            w = curvature_weights[batch.surface_mask]
+            pointwise_mse = (preds - target_valid).pow(2)
+            surf_loss = (w.unsqueeze(-1) * pointwise_mse).mean()
+            metrics["mean_curvature_weight"] = float(w.mean().item())
+            metrics["max_curvature_weight"] = float(w.max().item())
+        else:
+            surf_loss = F.mse_loss(preds, target_valid)
         total = total + surf_loss
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
     if batch.volume_y is not None and outputs["volume_preds"] is not None and batch.volume_mask is not None:
@@ -1306,7 +1365,10 @@ def train_one_epoch(
                     )
                     loss, _ = loss_abupt(batch, outputs, transform, volume_loss_weight=volume_loss_weight)
             else:
+                curv_w = getattr(batch, "curvature_weights", None)
                 batch = batch.to(device)
+                if curv_w is not None:
+                    batch.curvature_weights = curv_w.to(device)
                 if isinstance(transform, TandemTargetTransform):
                     prepared = transform.prepare_batch(batch)
                     with autocast_context(device, amp_mode):
@@ -1326,7 +1388,12 @@ def train_one_epoch(
                             volume_x=batch.volume_x,
                             volume_mask=batch.volume_mask,
                         )
-                        loss, _ = loss_grouped(batch, outputs, transform, volume_loss_weight=volume_loss_weight)
+                        loss, loss_metrics = loss_grouped(batch, outputs, transform, volume_loss_weight=volume_loss_weight)
+                    if "mean_curvature_weight" in loss_metrics:
+                        running.setdefault("mean_curvature_weight", 0.0)
+                        running["mean_curvature_weight"] += loss_metrics["mean_curvature_weight"]
+                        running.setdefault("max_curvature_weight", 0.0)
+                        running["max_curvature_weight"] = max(running["max_curvature_weight"], loss_metrics["max_curvature_weight"])
 
             accum_loss += float(loss.detach().cpu().item())
             (loss / grad_accum_steps).backward()
@@ -1359,6 +1426,8 @@ def train_one_epoch(
     running["loss"] /= max(steps, 1)
     if "grad_norm_mean" in running:
         running["grad_norm_mean"] /= max(steps, 1)
+    if "mean_curvature_weight" in running:
+        running["mean_curvature_weight"] /= max(micro_batches_total, 1)
     running["train_steps"] = float(steps)
     running["micro_batches"] = float(micro_batches_total)
     if scheduler is not None:
@@ -1635,18 +1704,14 @@ def main() -> None:
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
     history: list[dict[str, float]] = []
-    best_epoch: int | None = None
-    best_val_primary_metric_name = primary_metric_key(bundle, phase="val")
-    best_val_primary_metric: float | None = None
-    best_val_metrics: dict[str, float] = {}
-    best_model_state: dict[str, torch.Tensor] | None = None
-    best_anp_state: dict[str, torch.Tensor] | None = None
-
     if bundle.spec.name == "tandemfoilset":
         val_primary_key = "val_primary/surface_pressure_mae"
     else:
         val_primary_key = f"val_primary/{bundle.spec.default_metric}"
+    best_val_primary_metric_name = val_primary_key
     best_val_metric = float("inf")
+    best_val_primary_metric: float | None = None
+    best_val_metrics: dict[str, float] = {}
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
@@ -1709,23 +1774,14 @@ def main() -> None:
             phase="val",
         )
 
-        current_primary_metric = eval_metrics.get(best_val_primary_metric_name)
-        if current_primary_metric is not None and (
-            best_val_primary_metric is None or current_primary_metric < best_val_primary_metric
-        ):
-            best_epoch = epoch
-            best_val_primary_metric = current_primary_metric
-            best_val_metrics = dict(eval_metrics)
-            best_model_state = snapshot_module_state(model)
-            best_anp_state = snapshot_module_state(anp_head)
-
         current_val = eval_metrics.get(val_primary_key)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
+            best_val_primary_metric = current_val
+            best_val_metrics = dict(eval_metrics)
             best_epoch = epoch
-            best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
-            if anp_head is not None:
-                best_anp_state = {k: v.cpu().clone() for k, v in anp_head.state_dict().items()}
+            best_model_state = snapshot_module_state(model)
+            best_anp_state = snapshot_module_state(anp_head)
             if ema is not None:
                 best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
             if anp_ema is not None:


### PR DESCRIPTION
## Hypothesis

DrivAerML uses uniform MSE across all 50k surface points — every point contributes equally to the loss regardless of geometric complexity. But prediction errors concentrate at high-curvature regions: leading edges, mirror bases, wheel arches, A-pillar vortex lines. These regions have the steepest pressure gradients and are the hardest to predict.

By weighting the per-point MSE loss by local surface curvature (computed from the input normal vectors), we direct more gradient signal toward these challenging regions. This is different from:

- **Error-weighted SAMPLING** (jet #3243): changes which points are seen each epoch (requires error tracking from previous epoch)
- **Smoothness regularization** (emma #3231, dead): penalizes spatial gradients of predictions
- **This approach**: changes how much gradient each point contributes, using **GEOMETRY** (not prediction error) as the weighting signal

**Curvature estimation:** Surface curvature can be approximated from the normal field. For each point, compute the variance of normals among its K nearest neighbors. High normal variance = high curvature = more loss weight. This is a static geometric property — computed once per mesh, not updated during training.

---

## Baseline

Current best DrivAerML (PR #3072, eren/dm-ema-9995-gc05):
- `val_primary/surface_rel_l2_pct`: **3.833%** at epoch 511
- test: 4.685%
- W&B run: `ncl1dh88`
- Config: AdamW lr=5e-4, gc=0.5, no WD, 4L/512d/8H, EMA=0.9995, T_max=30, 394 batches/epoch

External target: **<3.71%** (AB-UPT). Gap: ~0.123 pp.

---

## Known Bug Fix

There is a `primary_metric_key` shadowing bug in `train.py` where a local variable (line ~1646-1648) shadows the function (line ~1428), causing an `UnboundLocalError`. Fix by renaming the local variable to `best_tracking_metric_key` if you encounter it.

---

## Implementation Guidance

1. Add `--curvature-loss-weight` flag (float, default `0.0` meaning uniform weighting)
2. For each mesh, **precompute** per-point curvature: for each of the 50k sampled points, find K=8 nearest neighbors and compute the standard deviation of their normal vectors. This gives a scalar curvature estimate per point.
3. Normalize curvature weights: `w = 1 + alpha * (curvature / curvature.mean())` where `alpha = curvature_loss_weight`. This ensures:
   - (a) flat regions still get weight 1.0
   - (b) high-curvature regions get extra weight proportional to their curvature
4. Apply per-point weighting to the MSE loss: `loss = (w * (pred - target)^2).mean()`
5. Log `mean_curvature_weight` and `max_curvature_weight` to W&B
6. Curvature can be precomputed during data loading — no per-step overhead beyond the weighted reduction

**IMPORTANT:** The KNN for curvature estimation is done ONCE during data loading, not every training step. This avoids the throughput penalty that killed the pressure gradient reg experiment.

---

## Trials

### Trial 1 — `curvature_loss_weight=1.0` (moderate: high-curvature points get ~2x weight)

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --curvature-loss-weight 1.0 \
  --wandb_group dm-curvature-loss
```

### Trial 2 — `curvature_loss_weight=0.5` (lighter weighting)

Same as Trial 1 but with `--curvature-loss-weight 0.5`

---

## Deliverables

Report `val_primary/surface_rel_l2_pct` at best epoch for both trials.

**Target: beat 3.833%**