### PR TITLE
DrivAerML: Learnable Fourier Encoding Frequencies

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -96,6 +96,40 @@ AIRFRANS_FIELD_NAMES = ("Ux", "Uy", "p", "nut")
 TANDEM_FIELD_NAMES = ("Ux", "Uy", "p")
 
 
+class LearnableFourierWrapper(torch.nn.Module):
+    def __init__(self, model: torch.nn.Module, space_dim: int, freq_init: list[float]):
+        super().__init__()
+        self.model = model
+        self.space_dim = space_dim
+        self.fourier_freqs = torch.nn.Parameter(torch.tensor(freq_init, dtype=torch.float32))
+        self.fourier_dim = space_dim * len(freq_init) * 2
+
+    def _replace_fourier(self, x: torch.Tensor) -> torch.Tensor:
+        coords = x[..., : self.space_dim]
+        base = x[..., : -self.fourier_dim]
+        scaled = coords.unsqueeze(-1) * self.fourier_freqs
+        fourier = torch.cat([scaled.sin().flatten(-2), scaled.cos().flatten(-2)], dim=-1)
+        return torch.cat([base, fourier], dim=-1)
+
+    def forward(
+        self,
+        *,
+        surface_x: torch.Tensor,
+        surface_mask: torch.Tensor,
+        volume_x: torch.Tensor | None = None,
+        volume_mask: torch.Tensor | None = None,
+    ) -> dict[str, torch.Tensor | None]:
+        surface_x = self._replace_fourier(surface_x)
+        if volume_x is not None:
+            volume_x = self._replace_fourier(volume_x)
+        return self.model(
+            surface_x=surface_x,
+            surface_mask=surface_mask,
+            volume_x=volume_x,
+            volume_mask=volume_mask,
+        )
+
+
 @dataclass
 class TrainConfig:
     dataset: str = "tandemfoil"
@@ -141,6 +175,8 @@ class TrainConfig:
     tandemfoil_paper_manifest: str = ""
     tandemfoil_paper_stats: str = ""
     enable_fourier: bool = False
+    learnable_fourier_freqs: bool = False
+    fourier_freq_init: str = ""
     enable_te_coord_frame: bool = False
     enable_cp_panel: bool = False
     enable_cp_panel_tandem_only: bool = False
@@ -1615,6 +1651,11 @@ def main() -> None:
 
     train_loader, val_loaders, test_loaders = build_loaders(config, bundle, num_workers=resolved_num_workers)
     model = build_model(config, bundle).to(device)
+    if config.learnable_fourier_freqs and config.enable_fourier:
+        freq_init = [0.5, 2.0, 8.0, 32.0]
+        if config.fourier_freq_init:
+            freq_init = [float(v) for v in config.fourier_freq_init.split(",")]
+        model = LearnableFourierWrapper(model, bundle.spec.space_dim, freq_init).to(device)
     forward_model = torch.compile(model) if config.compile_model and device.type == "cuda" else model
     anp_head = None
     if bundle.spec.name == "tandemfoilset" and config.anp_srf:
@@ -1657,6 +1698,8 @@ def main() -> None:
     if config.wandb_name:
         run_config = asdict(config)
         run_config["effective_batch_size"] = config.batch_size * config.grad_accum_steps
+        if isinstance(model, LearnableFourierWrapper):
+            run_config["fourier_freq_init"] = model.fourier_freqs.detach().cpu().tolist()
         run = wandb.init(
             project=os.getenv("WANDB_PROJECT", "senpai-v1"),
             entity=os.getenv("WANDB_ENTITY"),
@@ -1745,7 +1788,19 @@ def main() -> None:
             run.summary["epoch"] = epoch
             run.summary["best_epoch"] = best_epoch
             run.summary["best_val_metric"] = best_val_metric
+            if isinstance(model, LearnableFourierWrapper) and epoch % 50 == 0:
+                freqs = model.fourier_freqs.detach().cpu().tolist()
+                freq_log = {f"fourier_freq/{i}": v for i, v in enumerate(freqs)}
+                wandb.log(freq_log, step=epoch)
         print(json.dumps(epoch_metrics, sort_keys=True), flush=True)
+
+    if isinstance(model, LearnableFourierWrapper):
+        final_freqs = model.fourier_freqs.detach().cpu().tolist()
+        print(json.dumps({"final_learned_fourier_freqs": final_freqs}), flush=True)
+        if run is not None:
+            freq_log = {f"final_fourier_freq/{i}": v for i, v in enumerate(final_freqs)}
+            run.summary.update(freq_log)
+            run.summary["final_learned_fourier_freqs"] = final_freqs
 
     if best_epoch is not None:
         print(


### PR DESCRIPTION
## Hypothesis

The DM champion uses fixed Fourier encoding frequencies **[0.5, 2.0, 8.0, 32.0]** for positional encoding of xyz coordinates. These were chosen as reasonable defaults spanning ~2 orders of magnitude. But DrivAerML car surfaces may have preferred spatial scales that don't align with these fixed frequencies.

By making the 4 frequency values learnable parameters (initialized to [0.5, 2.0, 8.0, 32.0]), the model can adapt them during training to the spatial scales most informative for surface field prediction. This is a 4-parameter change — minimal complexity, potentially high impact if the fixed frequencies are suboptimal.

**Key differences from prior Fourier experiments:**
- Fourier NORMALS (brook #3217, dead): added new Fourier features from normal vectors — normals don't benefit from lifting
- This: changes the EXISTING coordinate encoding frequencies from fixed to learnable

---

## Baseline

Current best DrivAerML (PR #3072):
- `val_primary/surface_rel_l2_pct`: **3.833%** at epoch 511
- `test`: 4.685%
- W&B run: `ncl1dh88`
- Config: AdamW lr=5e-4, gc=0.5, no WD, 4L/512d/8H, EMA=0.9995, T_max=30, Fourier freqs=[0.5,2.0,8.0,32.0]

External target: <3.71% (AB-UPT). Gap: ~0.123 pp.

---

## Known Bug Fix

There's a `primary_metric_key` shadowing bug in train.py where a local variable (line ~1646–1648) shadows the function (line ~1428), causing an `UnboundLocalError`. Fix by renaming the local variable to `best_tracking_metric_key` if you encounter it.

---

## Implementation Guidance

1. Find the Fourier frequency definition in the model code (likely in the `FourierFeatures` or similar class).
2. Replace the fixed frequency tensor with `nn.Parameter(torch.tensor([0.5, 2.0, 8.0, 32.0]))` — learnable, initialized to current values.
3. Log the learned frequencies to W&B every 50 epochs (so we can see how they evolve).
4. Use the same learning rate as the rest of the model (no separate LR needed for 4 params).

---

## Trial 1 — Learnable frequencies from default init

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --learnable-fourier-freqs \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --wandb_group dm-learnable-fourier
```

Frequencies initialized to: `[0.5, 2.0, 8.0, 32.0]` (baseline values).

---

## Trial 2 — Learnable frequencies from wider init

Same as Trial 1 but initialize frequencies to `[0.1, 1.0, 10.0, 100.0]` (broader range, let the model compress if needed). Add `--fourier-freq-init "0.1,1.0,10.0,100.0"`.

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --learnable-fourier-freqs \
  --fourier-freq-init "0.1,1.0,10.0,100.0" \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --wandb_group dm-learnable-fourier
```

---

## Key Measurement

Log the **final learned frequencies** for both trials — these tell us which spatial scales the model finds most informative for DrivAerML. This is diagnostically valuable even if the experiment doesn't beat baseline.

---

## Target Metric

Report `val_primary/surface_rel_l2_pct` at best epoch. Target: beat **3.833%**.