### PR TITLE
DrivAerML: learnable register tokens to absorb attention sinks (N=2/4/8)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -169,6 +169,7 @@ class TrainConfig:
     volume_loss_weight: float = 1.0
     save_checkpoint: bool = False
     seed: int = 0
+    num_register_tokens: int = 0
 
 
 @dataclass
@@ -499,6 +500,26 @@ def cp_panel_prior_index(config: TrainConfig, bundle: DatasetBundle) -> int | No
     return None
 
 
+class BackboneWithRegisters(torch.nn.Module):
+    def __init__(self, backbone: torch.nn.Module, num_tokens: int, hidden_dim: int):
+        super().__init__()
+        self.backbone = backbone
+        self.num_tokens = num_tokens
+        self.register_tokens = torch.nn.Parameter(
+            torch.randn(num_tokens, hidden_dim) * 0.02
+        )
+
+    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+        B = x.shape[0]
+        reg = self.register_tokens.unsqueeze(0).expand(B, -1, -1)
+        x = torch.cat([reg, x], dim=1)
+        if attn_mask is not None:
+            reg_mask = torch.ones(B, self.num_tokens, device=attn_mask.device, dtype=attn_mask.dtype)
+            attn_mask = torch.cat([reg_mask, attn_mask], dim=1)
+        x = self.backbone(x, attn_mask=attn_mask)
+        return x[:, self.num_tokens:, :]
+
+
 def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
     transolver_kwargs = {
         "n_layers": config.model_layers,
@@ -540,6 +561,14 @@ def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
             volume_output_dim=bundle.spec.volume_output_dim,
         )
     raise ValueError(f"Unknown model: {config.model}")
+
+
+def _maybe_wrap_register_tokens(model: torch.nn.Module, config: TrainConfig) -> torch.nn.Module:
+    if config.num_register_tokens > 0 and hasattr(model, "backbone"):
+        model.backbone = BackboneWithRegisters(
+            model.backbone, config.num_register_tokens, model.n_hidden
+        )
+    return model
 
 
 def build_optimizer(params, config: TrainConfig):
@@ -1614,7 +1643,7 @@ def main() -> None:
             )
 
     train_loader, val_loaders, test_loaders = build_loaders(config, bundle, num_workers=resolved_num_workers)
-    model = build_model(config, bundle).to(device)
+    model = _maybe_wrap_register_tokens(build_model(config, bundle), config).to(device)
     forward_model = torch.compile(model) if config.compile_model and device.type == "cuda" else model
     anp_head = None
     if bundle.spec.name == "tandemfoilset" and config.anp_srf:
@@ -1739,6 +1768,9 @@ def main() -> None:
         epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
         epoch_metrics["best_val_metric"] = best_val_metric
         epoch_metrics["best_epoch"] = float(best_epoch)
+        if config.num_register_tokens > 0 and hasattr(model, "backbone") and isinstance(model.backbone, BackboneWithRegisters):
+            reg_norm = float(model.backbone.register_tokens.data.norm().item())
+            epoch_metrics["register_tokens/l2_norm"] = reg_norm
         history.append(epoch_metrics)
         if run is not None:
             wandb.log(epoch_metrics, step=epoch)


### PR DESCRIPTION
## Hypothesis

The remaining DM error at 3.833% is systematic spatial bias — the model consistently misses in specific regions (sharp junctions, underbody far-field, A-pillar) rather than making uniform random errors. We hypothesize this is caused by **attention sink behavior**: high-norm outlier tokens at geometrically anomalous positions (sharp corners, extreme coordinates) absorb disproportionate attention weight from their neighbors, starving physically critical tokens of representation capacity and producing spatial bias in those regions.

**Register tokens** (Darcet et al., NeurIPS 2024 — arXiv:2309.16588) fix this by appending N learnable, geometry-free tokens to the point sequence. The attention mechanism gains designated \"dump targets\" that absorb the sink behavior without interfering with surface predictions. In 2D ViTs, this eliminated spatial artifacts and reduced spatial MSE by 15–40%. The mechanism is architecture-level and geometry-agnostic, making it a direct transfer to 3D point-cloud transformers.

This is a minimal change (2K–4K new parameters) with a clear mechanistic grounding in the literature.

## Instructions

### Implementation (train.py changes)

1. **Add CLI flag:**
   ```python
   parser.add_argument('--num-register-tokens', type=int, default=0,
                       help='Number of learnable register tokens prepended to point sequence (0=disabled)')
   ```

2. **Add register token parameter to the model** (in the model class `__init__`):
   ```python
   if args.num_register_tokens > 0:
       self.register_tokens = nn.Parameter(
           torch.randn(args.num_register_tokens, hidden_dim) * 0.02
       )
   ```

3. **Prepend register tokens before transformer layers** (in the `forward` method, before the first transformer block):
   ```python
   if hasattr(self, 'register_tokens'):
       B = x.shape[0]  # batch size (always 1 for DM)
       reg = self.register_tokens.unsqueeze(0).expand(B, -1, -1)
       x = torch.cat([reg, x], dim=1)  # prepend: [B, N_reg + N_pts, D]
   ```

4. **Strip register tokens before the output projection head** (after transformer layers, before regression MLP):
   ```python
   if hasattr(self, 'register_tokens'):
       x = x[:, args.num_register_tokens:, :]  # remove register tokens from front
   ```

**Critical:** Register tokens must NOT produce predictions — they exist only inside the transformer. Gradient flows through them freely (they are not detached), but the output head only sees surface point tokens.

### Trials

**Smoke test first (3 epochs)** — verify no shape errors, loss is finite, output shape matches baseline.

**Trial 1 — N=4:**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --num-register-tokens 4 \
  --wandb_group dm-register-tokens
```

**Trial 2 — N=8:**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --num-register-tokens 8 \
  --wandb_group dm-register-tokens
```

**Trial 3 — N=2:**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --num-register-tokens 2 \
  --wandb_group dm-register-tokens
```

Report `val_primary/surface_rel_l2_pct` for all three trials. Target: beat **3.833%**.

## Baseline

Current best DrivAerML metrics (PR #3072, eren/dm-ema-9995-gc05):

| Metric | Value | Epoch |
|--------|-------|-------|
| val_primary/surface_rel_l2_pct | **3.833%** | 511 |
| test_primary/surface_rel_l2_pct | **4.685%** | 511 |

- W&B run: `ncl1dh88`
- Config: 4L/512d/8H, AdamW lr=5e-4, T_max=30, gc=0.5, EMA=0.9995, no WD, Fourier

Reproduce:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --grad-clip 0.5 --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995
```