### PR TITLE
DrivAerML: Sparse Mixture-of-Experts FFN (K=4/8 experts, top-2 routing)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -169,6 +169,9 @@ class TrainConfig:
     volume_loss_weight: float = 1.0
     save_checkpoint: bool = False
     seed: int = 0
+    moe_num_experts: int = 0
+    moe_top_k: int = 2
+    moe_balance_coeff: float = 0.01
 
 
 @dataclass
@@ -497,6 +500,107 @@ def cp_panel_prior_index(config: TrainConfig, bundle: DatasetBundle) -> int | No
         base_dim -= 1
         return base_dim
     return None
+
+
+class MoEFFN(torch.nn.Module):
+    """Sparse Mixture-of-Experts FFN: each token routed to top-k of K experts."""
+
+    def __init__(self, hidden_dim: int, ffn_dim: int, num_experts: int, top_k: int = 2):
+        super().__init__()
+        self.num_experts = num_experts
+        self.top_k = top_k
+        self.router = torch.nn.Linear(hidden_dim, num_experts, bias=False)
+        torch.nn.init.normal_(self.router.weight, std=0.01)
+        self.experts = torch.nn.ModuleList([
+            torch.nn.Sequential(
+                torch.nn.Linear(hidden_dim, ffn_dim),
+                torch.nn.GELU(),
+                torch.nn.Linear(ffn_dim, hidden_dim),
+            )
+            for _ in range(num_experts)
+        ])
+        self.balance_loss = torch.tensor(0.0)
+        self.register_buffer("_routing_counts", torch.zeros(num_experts), persistent=False)
+        self.jitter_noise = 1.0
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        B, N, D = x.shape
+        x_flat = x.reshape(B * N, D)
+        router_logits = self.router(x_flat)  # [B*N, K]
+
+        if self.training and self.jitter_noise > 0:
+            noise = torch.randn_like(router_logits) * self.jitter_noise
+            router_logits = router_logits + noise
+
+        top_k_logits, top_k_indices = router_logits.topk(self.top_k, dim=-1)
+        top_k_weights = F.softmax(top_k_logits, dim=-1)  # [B*N, top_k]
+
+        output = torch.zeros_like(x_flat)
+        for k_idx in range(self.top_k):
+            indices = top_k_indices[:, k_idx]  # [B*N]
+            weights = top_k_weights[:, k_idx].unsqueeze(-1)  # [B*N, 1]
+            for e in range(self.num_experts):
+                mask = indices == e
+                if mask.any():
+                    expert_out = self.experts[e](x_flat[mask])
+                    output[mask] = output[mask] + weights[mask] * expert_out
+
+        routing_probs = F.softmax(router_logits, dim=-1)  # [B*N, K]
+        tokens_per_expert = F.one_hot(top_k_indices[:, 0], self.num_experts).float().mean(dim=0)
+        avg_prob = routing_probs.mean(dim=0)
+        # Switch Transformer load balance + entropy regularization for anti-collapse
+        switch_loss = (tokens_per_expert * avg_prob * self.num_experts).sum()
+        entropy = -(avg_prob * (avg_prob + 1e-8).log()).sum()
+        max_entropy = math.log(self.num_experts)
+        entropy_penalty = max_entropy - entropy
+        self.balance_loss = switch_loss + entropy_penalty
+
+        self._routing_counts = tokens_per_expert.detach()
+
+        return output.reshape(B, N, D)
+
+
+def _replace_ffn_with_moe(model: torch.nn.Module, config: TrainConfig) -> None:
+    """Replace UpActDownMlp in each TransformerBlock with MoEFFN."""
+    if config.moe_num_experts <= 0:
+        return
+    backbone = model.backbone
+    hidden_dim = model.n_hidden
+    ffn_dim = int(math.ceil(hidden_dim * config.model_mlp_ratio))
+    for block in backbone.blocks:
+        block.mlp = MoEFFN(hidden_dim, ffn_dim, config.moe_num_experts, config.moe_top_k)
+
+
+def _collect_moe_balance_loss(model: torch.nn.Module) -> torch.Tensor:
+    """Sum balance losses from all MoE layers."""
+    total = torch.tensor(0.0, device=next(model.parameters()).device)
+    raw = model._orig_mod if hasattr(model, '_orig_mod') else model
+    backbone = getattr(raw, 'backbone', None)
+    if backbone is None:
+        return total
+    for block in backbone.blocks:
+        if isinstance(block.mlp, MoEFFN):
+            total = total + block.mlp.balance_loss
+    return total
+
+
+def _log_moe_routing_stats(model: torch.nn.Module, run, epoch: int) -> dict[str, float]:
+    """Log per-layer expert routing distribution and router norms to W&B."""
+    raw = model._orig_mod if hasattr(model, '_orig_mod') else model
+    backbone = getattr(raw, 'backbone', None)
+    if backbone is None:
+        return {}
+    metrics: dict[str, float] = {}
+    for i, block in enumerate(backbone.blocks):
+        if not isinstance(block.mlp, MoEFFN):
+            continue
+        counts = block.mlp._routing_counts.detach().cpu()
+        for e in range(block.mlp.num_experts):
+            metrics[f"moe/layer{i}_expert{e}_frac"] = float(counts[e])
+        metrics[f"moe/layer{i}_routing_entropy"] = float(
+            -(counts * (counts + 1e-8).log()).sum()
+        )
+    return metrics
 
 
 def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
@@ -1271,11 +1375,14 @@ def train_one_epoch(
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
     volume_loss_weight: float = 1.0,
+    moe_balance_coeff: float = 0.0,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
         anp_head.train()
     running = {"loss": 0.0}
+    if moe_balance_coeff > 0:
+        running["moe_balance_loss"] = 0.0
     steps = 0
     micro_batches_total = 0
     batches = loader if max_batches <= 0 else itertools.islice(loader, max_batches)
@@ -1328,6 +1435,10 @@ def train_one_epoch(
                         )
                         loss, _ = loss_grouped(batch, outputs, transform, volume_loss_weight=volume_loss_weight)
 
+            if moe_balance_coeff > 0:
+                bal = _collect_moe_balance_loss(model)
+                loss = loss + moe_balance_coeff * bal
+                running["moe_balance_loss"] += float(bal.detach().cpu().item())
             accum_loss += float(loss.detach().cpu().item())
             (loss / grad_accum_steps).backward()
             micro_count += 1
@@ -1359,6 +1470,8 @@ def train_one_epoch(
     running["loss"] /= max(steps, 1)
     if "grad_norm_mean" in running:
         running["grad_norm_mean"] /= max(steps, 1)
+    if "moe_balance_loss" in running:
+        running["moe_balance_loss"] /= max(micro_batches_total, 1)
     running["train_steps"] = float(steps)
     running["micro_batches"] = float(micro_batches_total)
     if scheduler is not None:
@@ -1614,8 +1727,11 @@ def main() -> None:
             )
 
     train_loader, val_loaders, test_loaders = build_loaders(config, bundle, num_workers=resolved_num_workers)
-    model = build_model(config, bundle).to(device)
-    forward_model = torch.compile(model) if config.compile_model and device.type == "cuda" else model
+    model = build_model(config, bundle)
+    _replace_ffn_with_moe(model, config)
+    model = model.to(device)
+    use_compile = config.compile_model and device.type == "cuda" and config.moe_num_experts <= 0
+    forward_model = torch.compile(model) if use_compile else model
     anp_head = None
     if bundle.spec.name == "tandemfoilset" and config.anp_srf:
         anp_head = ANPSurfaceDecoder(
@@ -1663,7 +1779,7 @@ def main() -> None:
             name=config.wandb_name,
             group=config.wandb_group or None,
             config=run_config,
-            tags=[config.dataset, config.model],
+            tags=[config.dataset, config.model] + ([f"moe-{config.moe_num_experts}experts"] if config.moe_num_experts > 0 else []),
         )
 
     start_time = time.monotonic()
@@ -1688,6 +1804,7 @@ def main() -> None:
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
             volume_loss_weight=config.volume_loss_weight,
+            moe_balance_coeff=config.moe_balance_coeff if config.moe_num_experts > 0 else 0.0,
         )
 
         if ema is not None:
@@ -1739,6 +1856,9 @@ def main() -> None:
         epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
         epoch_metrics["best_val_metric"] = best_val_metric
         epoch_metrics["best_epoch"] = float(best_epoch)
+        if config.moe_num_experts > 0:
+            moe_stats = _log_moe_routing_stats(forward_model, run, epoch)
+            epoch_metrics.update(moe_stats)
         history.append(epoch_metrics)
         if run is not None:
             wandb.log(epoch_metrics, step=epoch)


### PR DESCRIPTION
## Hypothesis

The remaining DM error at 3.833% is systematic spatial bias — the model consistently under/over-predicts in specific aerodynamic regions (stagnation zone, A-pillar vortex, underbody separation, rear wake). The current architecture uses a **single shared FFN** in each transformer layer, forcing the same nonlinear transformation on tokens from fundamentally different flow regimes. We hypothesize that allowing **regime-specific computation** via sparse Mixture-of-Experts (MoE) FFN layers will reduce spatial bias by letting different experts specialize in different flow physics.

**MoE replaces each FFN with K expert FFNs and a learned router.** Each surface point token is routed to the top-2 experts based on its representation — the router learns which "flow regime" each token belongs to. This allows stagnation-zone tokens to use different nonlinear mappings than wake tokens, directly addressing the structural heterogeneity in the prediction error.

MoE is well-established in LLMs (Switch Transformer, Mixtral) and recently applied to scientific ML (FourCastNet-MoE for weather, arXiv 2409.16295). With 50k tokens per sample and only K=4-8 experts, each expert sees 6-25k tokens — plenty of signal for routing to specialize. Total compute stays similar to baseline since each token uses only top-2 experts rather than all K.

## Instructions

### Implementation

1. **Add CLI flags:**
   ```python
   parser.add_argument('--moe-num-experts', type=int, default=0,
                       help='Number of MoE experts per FFN layer (0=disabled, standard FFN)')
   parser.add_argument('--moe-top-k', type=int, default=2,
                       help='Number of experts each token is routed to')
   parser.add_argument('--moe-balance-coeff', type=float, default=0.01,
                       help='Load-balancing auxiliary loss coefficient')
   ```

2. **Implement the MoE FFN module** (new class):
   ```python
   class MoEFFN(nn.Module):
       def __init__(self, hidden_dim, ffn_dim, num_experts, top_k=2):
           super().__init__()
           self.num_experts = num_experts
           self.top_k = top_k
           # Router: linear projection to num_experts logits
           self.router = nn.Linear(hidden_dim, num_experts, bias=False)
           # K independent FFN experts (same architecture as baseline FFN)
           self.experts = nn.ModuleList([
               nn.Sequential(
                   nn.Linear(hidden_dim, ffn_dim),
                   nn.GELU(),
                   nn.Linear(ffn_dim, hidden_dim)
               ) for _ in range(num_experts)
           ])
       
       def forward(self, x):
           # x: [B, N, D]
           B, N, D = x.shape
           # Router logits and top-k selection
           router_logits = self.router(x)  # [B, N, K]
           top_k_logits, top_k_indices = router_logits.topk(self.top_k, dim=-1)  # [B, N, top_k]
           top_k_weights = F.softmax(top_k_logits, dim=-1)  # [B, N, top_k]
           
           # Compute expert outputs (loop over top-k selected experts)
           output = torch.zeros_like(x)
           for i in range(self.top_k):
               expert_idx = top_k_indices[:, :, i]  # [B, N]
               weight = top_k_weights[:, :, i].unsqueeze(-1)  # [B, N, 1]
               for e in range(self.num_experts):
                   mask = (expert_idx == e)  # [B, N]
                   if mask.any():
                       # Gather tokens for this expert
                       expert_input = x[mask]  # [num_tokens, D]
                       expert_output = self.experts[e](expert_input)  # [num_tokens, D]
                       output[mask] += weight[mask] * expert_output
           
           # Load-balancing loss (stored as attribute, added to total loss)
           # Fraction of tokens routed to each expert
           routing_probs = F.softmax(router_logits, dim=-1)  # [B, N, K]
           density = routing_probs.mean(dim=1)  # [B, K] — avg prob per expert
           # Ideal uniform: 1/K per expert
           self.balance_loss = (density * self.num_experts).var(dim=-1).mean()
           
           return output
   ```

3. **Replace FFN in each transformer layer** when `--moe-num-experts > 0`:
   In the model init, where the standard FFN is created for each transformer layer, check:
   ```python
   if args.moe_num_experts > 0:
       ffn = MoEFFN(hidden_dim, ffn_dim, args.moe_num_experts, args.moe_top_k)
   else:
       ffn = standard_ffn  # existing code
   ```

4. **Add load-balancing loss to total loss:**
   After computing the main MSE loss, accumulate the balance losses from all MoE layers:
   ```python
   if args.moe_num_experts > 0:
       balance_loss = sum(layer.ffn.balance_loss for layer in self.transformer_layers 
                         if hasattr(layer.ffn, 'balance_loss'))
       total_loss = main_loss + args.moe_balance_coeff * balance_loss
   ```

5. **Log expert utilization** (optional but helpful for analysis):
   Log the routing distribution per layer to W&B every 50 steps — this tells us whether experts are actually specializing.

### Trials

**Smoke test first (3 epochs)** — verify shapes, loss is finite, experts get non-degenerate routing.

**Trial 1 — K=4 experts, top-2 (regime-scale):**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --moe-num-experts 4 --moe-top-k 2 --moe-balance-coeff 0.01 \
  --wandb_group dm-moe-ffn
```

**Trial 2 — K=8 experts, top-2 (finer-grained):**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --moe-num-experts 8 --moe-top-k 2 --moe-balance-coeff 0.01 \
  --wandb_group dm-moe-ffn
```

**Note on throughput:** MoE with expert loops may be slower than a single FFN. If throughput drops >30%, consider using `torch.compile` on the expert modules or implementing a fused scatter/gather. But start with the simple loop — correctness first.

Report `val_primary/surface_rel_l2_pct` for both trials. Also log the expert routing distribution (which experts get which fraction of tokens) — this tells us whether the MoE is actually learning regime-specific specialization or just converging to a uniform split.

## Baseline

Current best DrivAerML metrics (PR #3072, eren/dm-ema-9995-gc05):

| Metric | Value | Epoch |
|--------|-------|-------|
| val_primary/surface_rel_l2_pct | **3.833%** | 511 |
| test_primary/surface_rel_l2_pct | **4.685%** | 511 |

- W&B run: `ncl1dh88`
- Config: 4L/512d/8H, AdamW lr=5e-4, T_max=30, gc=0.5, EMA=0.9995, no WD, Fourier

Reproduce:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --grad-clip 0.5 --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995
```