### PR TITLE
DrivAerML: Weight Standardization on linear layers (bs=1 optimization)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -86,6 +86,45 @@ class EMAWithWarmup:
         self.backup = None
 
 
+class WSLinear(torch.nn.Linear):
+    """Weight Standardization applied to nn.Linear (Qiao et al., 2019)."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        weight = self.weight
+        mean = weight.mean(dim=1, keepdim=True)
+        std = weight.std(dim=1, keepdim=True).clamp(min=1e-5)
+        weight = (weight - mean) / std
+        return F.linear(x, weight, self.bias)
+
+
+def apply_weight_standardization(model: torch.nn.Module) -> int:
+    """Replace nn.Linear with WSLinear in transformer layers, skipping output heads."""
+    exclude = {"out.project", "surface_head"}
+    count = 0
+    for name, module in list(model.named_modules()):
+        if any(ex in name for ex in exclude):
+            continue
+        if not isinstance(module, torch.nn.Linear) or isinstance(module, WSLinear):
+            continue
+        ws = WSLinear(module.in_features, module.out_features, bias=module.bias is not None)
+        ws.weight = module.weight
+        if module.bias is not None:
+            ws.bias = module.bias
+        parts = name.rsplit(".", 1)
+        if len(parts) == 2:
+            parent_name, attr_name = parts
+            parent = dict(model.named_modules())[parent_name]
+        else:
+            parent = model
+            attr_name = parts[0]
+        if isinstance(parent, torch.nn.Sequential):
+            parent[int(attr_name)] = ws
+        else:
+            setattr(parent, attr_name, ws)
+        count += 1
+    return count
+
+
 LEGACY_VAL_ALIAS = {
     "val_in_dist": "p_in",
     "val_ood_cond": "p_oodc",
@@ -169,6 +208,7 @@ class TrainConfig:
     volume_loss_weight: float = 1.0
     save_checkpoint: bool = False
     seed: int = 0
+    weight_standardization: bool = False
 
 
 @dataclass
@@ -1615,6 +1655,9 @@ def main() -> None:
 
     train_loader, val_loaders, test_loaders = build_loaders(config, bundle, num_workers=resolved_num_workers)
     model = build_model(config, bundle).to(device)
+    if config.weight_standardization:
+        ws_count = apply_weight_standardization(model)
+        print(f"[WS] Replaced {ws_count} Linear layers with WSLinear")
     forward_model = torch.compile(model) if config.compile_model and device.type == "cuda" else model
     anp_head = None
     if bundle.spec.name == "tandemfoilset" and config.anp_srf:


### PR DESCRIPTION
## Hypothesis

DrivAerML training uses **batch-size=1**, the most extreme small-batch scenario possible. With bs=1, batch statistics are maximally noisy and the loss landscape is rough, forcing the optimizer to navigate through high-variance gradient estimates. We hypothesize that **Weight Standardization (WS)** (Qiao et al., 2019, arXiv:1903.10520) will smooth the loss landscape and improve convergence by standardizing the weight matrices of all linear layers.

WS reparametrizes each weight matrix W as: `W_hat = (W - mean(W)) / std(W)`. This normalizes the weights to have zero mean and unit variance across the fan-in dimension, which:
1. **Smooths the loss landscape** — the Lipschitz constant of the loss is reduced, making gradient descent more stable
2. **Reduces sensitivity to learning rate** — the standardized weights create more uniform gradient magnitudes across layers
3. **Synergizes with LayerNorm** — WS on weights + LN on activations gives comprehensive normalization at both levels

In Big Transfer (BiT) models, WS was essential for achieving SOTA with GroupNorm at small batch sizes. The DM Transolver already uses LayerNorm but lacks weight-level normalization. At bs=1, WS may provide the stability improvement that allows the model to navigate deeper into the loss basin.

**Key difference from spectral norm (dead, #3224):** Spectral norm constrains the max singular value (σ_max=1), which over-restricts attention capacity. WS standardizes the full weight distribution without capping capacity — it reshapes the loss landscape without limiting what the model can express.

## Instructions

### Implementation

1. **Create a WeightStandardizedLinear module:**
   ```python
   class WSLinear(nn.Linear):
       def forward(self, x):
           # Standardize weights along fan_in dimension
           weight = self.weight
           mean = weight.mean(dim=1, keepdim=True)
           std = weight.std(dim=1, keepdim=True).clamp(min=1e-5)
           weight = (weight - mean) / std
           return F.linear(x, weight, self.bias)
   ```

2. **Add CLI flag:**
   ```python
   parser.add_argument('--weight-standardization', action='store_true', default=False,
                       help='Apply weight standardization to all linear layers in transformer')
   ```

3. **Replace nn.Linear with WSLinear in transformer layers** when `--weight-standardization` is enabled. Apply to:
   - Q, K, V projection matrices in self-attention
   - Output projection in self-attention  
   - Both linear layers in each FFN
   - Do NOT apply to the final output regression head (keep that standard)

   The simplest approach: after model construction, iterate through modules and swap:
   ```python
   if args.weight_standardization:
       for name, module in model.named_modules():
           if isinstance(module, nn.Linear) and 'output_head' not in name:
               # Replace with WSLinear (copy weights and bias)
               ws = WSLinear(module.in_features, module.out_features, bias=module.bias is not None)
               ws.weight = module.weight
               if module.bias is not None:
                   ws.bias = module.bias
               # Set the WSLinear in place of the original
               parent = dict(model.named_modules())[name.rsplit('.', 1)[0] if '.' in name else '']
               setattr(parent, name.split('.')[-1], ws)
   ```
   
   **Alternative (simpler):** Just add the standardization directly in the model's forward pass for QKV and FFN layers, wrapped in an `if args.weight_standardization:` check. Either approach works — pick whichever is cleaner for the codebase.

### Trials

**Smoke test first (3 epochs)** — verify loss is finite, no shape errors, gradients flow.

**Trial 1 — WS on all transformer linear layers (champion config):**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --weight-standardization \
  --wandb_group dm-weight-standardization
```

**Trial 2 — WS + slightly higher LR (6e-4):**
WS smooths the loss landscape, which often allows higher learning rates. Since the LR neighborhood above 5e-4 was previously dead WITHOUT WS, this tests whether WS unlocks that region:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 6e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --weight-standardization \
  --wandb_group dm-weight-standardization
```

Report `val_primary/surface_rel_l2_pct` for both trials. Target: beat **3.833%**.

## Baseline

Current best DrivAerML metrics (PR #3072, eren/dm-ema-9995-gc05):

| Metric | Value | Epoch |
|--------|-------|-------|
| val_primary/surface_rel_l2_pct | **3.833%** | 511 |
| test_primary/surface_rel_l2_pct | **4.685%** | 511 |

- W&B run: `ncl1dh88`
- Config: 4L/512d/8H, AdamW lr=5e-4, T_max=30, gc=0.5, EMA=0.9995, no WD, Fourier

Reproduce:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --grad-clip 0.5 --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995
```