### PR TITLE
DrivAerML: hidden-space noise regularization (post-Fourier perturbation)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -169,6 +169,8 @@ class TrainConfig:
     volume_loss_weight: float = 1.0
     save_checkpoint: bool = False
     seed: int = 0
+    hidden_noise_std: float = 0.0
+    hidden_noise_layers: str = "all"
 
 
 @dataclass
@@ -540,6 +542,32 @@ def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
             volume_output_dim=bundle.spec.volume_output_dim,
         )
     raise ValueError(f"Unknown model: {config.model}")
+
+
+def register_hidden_noise(model: torch.nn.Module, config: TrainConfig):
+    if config.hidden_noise_std <= 0:
+        return
+    backbone = getattr(model, "backbone", None)
+    if backbone is None:
+        return
+    blocks = list(backbone.blocks)
+    num_layers = len(blocks)
+    if config.hidden_noise_layers == "all":
+        apply_at = [True] * num_layers
+    elif config.hidden_noise_layers == "first":
+        apply_at = [True] + [False] * (num_layers - 1)
+    elif config.hidden_noise_layers == "last":
+        apply_at = [False] * (num_layers - 1) + [True]
+    else:
+        indices = {int(i) for i in config.hidden_noise_layers.split(",")}
+        apply_at = [i in indices for i in range(num_layers)]
+    std = config.hidden_noise_std
+    for i, block in enumerate(blocks):
+        if apply_at[i]:
+            def _hook(mod, inp, out, _std=std):
+                if mod.training:
+                    return out + torch.randn_like(out) * _std
+            block.register_forward_hook(_hook)
 
 
 def build_optimizer(params, config: TrainConfig):
@@ -1615,6 +1643,7 @@ def main() -> None:
 
     train_loader, val_loaders, test_loaders = build_loaders(config, bundle, num_workers=resolved_num_workers)
     model = build_model(config, bundle).to(device)
+    register_hidden_noise(model, config)
     forward_model = torch.compile(model) if config.compile_model and device.type == "cuda" else model
     anp_head = None
     if bundle.spec.name == "tandemfoilset" and config.anp_srf:


### PR DESCRIPTION
## Hypothesis

Your coordinate noise experiment (#3256) revealed that Fourier positional encoding amplifies input-space perturbations by up to 32x, making coordinate-level augmentation structurally incompatible with the DM architecture. However, the **underlying regularization motivation is sound** — injecting controlled noise during training forces the model to learn smoother, more robust representations. The fix is to apply noise AFTER the Fourier encoding and input projection, directly in the hidden representation space where the scale is well-controlled.

**Hidden-space noise** (also called "representation perturbation" or "R-Drop without KL") adds Gaussian noise with small standard deviation to the hidden representations between transformer layers during training only. This:
1. **Avoids Fourier amplification entirely** — the noise is in the 512-dim hidden space, not the coordinate space
2. **Acts as implicit regularization** — similar to dropout but continuous and differentiable, preserving smooth gradient flow
3. **Encourages flat loss basins** — the model must produce correct predictions despite small perturbations, selecting for solutions that are robust to representation noise

This is related to "Noisy Nodes" (Godwin et al., ICLR 2022) which showed that adding noise to node features in GNNs for molecular property prediction improved generalization by 10-15%. The key is that hidden-space noise is scale-appropriate by construction — the perturbation magnitude is relative to the activation norms, not amplified by encoding frequencies.

## Instructions

### Implementation

1. **Add CLI flags:**
   ```python
   parser.add_argument('--hidden-noise-std', type=float, default=0.0,
                       help='Std of Gaussian noise added to hidden representations during training (0=disabled)')
   parser.add_argument('--hidden-noise-layers', type=str, default='all',
                       help='Which layers to apply noise: "all", "first", "last", or comma-separated indices like "0,1"')
   ```

2. **Add noise injection in the transformer forward pass.** After each transformer layer's output (post-residual, post-LayerNorm), during training only:
   ```python
   if self.training and args.hidden_noise_std > 0:
       noise = torch.randn_like(x) * args.hidden_noise_std
       x = x + noise
   ```

   Place this **after** each transformer layer's full computation (self-attention + FFN + residual + LayerNorm) but **before** the next layer. Apply only during training (the `self.training` check handles this automatically via `model.train()` / `model.eval()`).

3. **Layer selection logic** (if implementing `--hidden-noise-layers`):
   ```python
   if args.hidden_noise_layers == 'all':
       apply_noise = [True] * num_layers
   elif args.hidden_noise_layers == 'first':
       apply_noise = [True] + [False] * (num_layers - 1)
   elif args.hidden_noise_layers == 'last':
       apply_noise = [False] * (num_layers - 1) + [True]
   else:
       indices = set(int(i) for i in args.hidden_noise_layers.split(','))
       apply_noise = [i in indices for i in range(num_layers)]
   ```

### Trials

**Smoke test first (3 epochs)** — verify loss is finite, no NaN, gradients normal.

**Trial 1 — σ=0.01, all layers (moderate noise):**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --hidden-noise-std 0.01 \
  --hidden-noise-layers all \
  --wandb_group dm-hidden-noise-reg
```

**Trial 2 — σ=0.05, all layers (stronger noise):**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --hidden-noise-std 0.05 \
  --hidden-noise-layers all \
  --wandb_group dm-hidden-noise-reg
```

**Trial 3 — σ=0.02, last layer only (targeted late-stage regularization):**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --hidden-noise-std 0.02 \
  --hidden-noise-layers last \
  --wandb_group dm-hidden-noise-reg
```

Report `val_primary/surface_rel_l2_pct` for all trials. Target: beat **3.833%**.

## Baseline

Current best DrivAerML metrics (PR #3072, eren/dm-ema-9995-gc05):

| Metric | Value | Epoch |
|--------|-------|-------|
| val_primary/surface_rel_l2_pct | **3.833%** | 511 |
| test_primary/surface_rel_l2_pct | **4.685%** | 511 |

- W&B run: `ncl1dh88`
- Config: 4L/512d/8H, AdamW lr=5e-4, T_max=30, gc=0.5, EMA=0.9995, no WD, Fourier

Reproduce:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --grad-clip 0.5 --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995
```