### PR TITLE
DrivAerML: SwiGLU FFN activation (replace GELU with gated linear unit)

### DIFF
--- a/target/icml2026/core/architectures/transolver_reference.py
+++ b/target/icml2026/core/architectures/transolver_reference.py
@@ -84,6 +84,20 @@ class UpActDownMlp(nn.Module):
         return self.fc2(self.act(self.fc1(x)))
 
 
+class SwiGLUFFN(nn.Module):
+    def __init__(self, hidden_dim: int, mlp_hidden_dim: int):
+        super().__init__()
+        swiglu_hidden = int(mlp_hidden_dim * 2 / 3)
+        swiglu_hidden = ((swiglu_hidden + 63) // 64) * 64
+        self.w_gate = nn.Linear(hidden_dim, swiglu_hidden, bias=False)
+        self.w_up = nn.Linear(hidden_dim, swiglu_hidden, bias=False)
+        self.w_down = nn.Linear(swiglu_hidden, hidden_dim, bias=False)
+        self.apply(_init_linear)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.w_down(F.silu(self.w_gate(x)) * self.w_up(x))
+
+
 class TransolverAttention(nn.Module):
     def __init__(self, hidden_dim: int, num_heads: int, num_slices: int, dropout: float = 0.0):
         super().__init__()
@@ -139,6 +153,7 @@ class TransformerBlock(nn.Module):
         mlp_expansion_factor: int | float,
         num_slices: int,
         dropout: float = 0.0,
+        swiglu_ffn: bool = False,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -150,7 +165,10 @@ class TransformerBlock(nn.Module):
             dropout=dropout,
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
-        self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
+        if swiglu_ffn:
+            self.mlp = SwiGLUFFN(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
+        else:
+            self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
 
     def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
         x = x + self.attention(self.norm1(x), attn_mask=attn_mask)
@@ -167,6 +185,7 @@ class Transformer(nn.Module):
         mlp_expansion_factor: int | float,
         num_slices: int,
         dropout: float = 0.0,
+        swiglu_ffn: bool = False,
     ):
         super().__init__()
         self.blocks = nn.ModuleList(
@@ -177,6 +196,7 @@ class Transformer(nn.Module):
                     mlp_expansion_factor=mlp_expansion_factor,
                     num_slices=num_slices,
                     dropout=dropout,
+                    swiglu_ffn=swiglu_ffn,
                 )
                 for _ in range(depth)
             ]
@@ -205,6 +225,7 @@ class ReferenceTransolver(nn.Module):
         n_head: int = 3,
         mlp_ratio: int = 4,
         slice_num: int = 96,
+        swiglu_ffn: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -233,6 +254,7 @@ class ReferenceTransolver(nn.Module):
             mlp_expansion_factor=mlp_ratio,
             num_slices=slice_num,
             dropout=dropout,
+            swiglu_ffn=swiglu_ffn,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.out = LinearProjection(n_hidden, surface_output_dim + volume_output_dim)

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -169,6 +169,7 @@ class TrainConfig:
     volume_loss_weight: float = 1.0
     save_checkpoint: bool = False
     seed: int = 0
+    swiglu_ffn: bool = False
 
 
 @dataclass
@@ -513,6 +514,7 @@ def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
         "n_head": config.model_heads,
         "mlp_ratio": config.model_mlp_ratio,
         "slice_num": config.model_slices,
+        "swiglu_ffn": config.swiglu_ffn,
     }
     if config.model == "reference_transolver":
         return ReferenceTransolver(


### PR DESCRIPTION
## Hypothesis

The DM Transolver uses standard GELU activation in its FFN sublayers. **SwiGLU** (Shazeer, 2020; arXiv:2002.05202) replaces the activation with a gated linear unit: instead of FFN(x) = W2 · GELU(W1 · x), SwiGLU computes FFN(x) = W2 · (SiLU(W_gate · x) ⊙ (W_up · x)), where ⊙ is element-wise multiplication. This adds a learned gating mechanism that selectively activates features.

SwiGLU has become the standard FFN activation in modern LLMs (LLaMA, Mistral, Gemma) because it consistently outperforms GELU across model scales. The key properties:
1. **Multiplicative gating** — the gate branch learns which features to amplify vs suppress, providing richer nonlinear expressivity per parameter
2. **Smoother gradients** — SiLU (swish) activation produces smoother gradient landscapes than GELU
3. **Proven at scale** — not just an LLM trick; SwiGLU shows improvements in vision (MetaFormer), audio, and structured prediction tasks

For DM where the FFN processes 50k surface point tokens independently, the gating mechanism could help the model learn context-dependent feature transformations — amplifying relevant pressure/velocity features while suppressing noise, which directly addresses the systematic spatial bias.

**Important:** SwiGLU uses 3 weight matrices (gate, up, down) instead of 2 (up, down). To keep parameter count roughly equal, the FFN hidden dim should be reduced by 2/3. With the current 512d model, the standard FFN dim is likely 2048 (4x expansion). For SwiGLU, use hidden_dim = 1365 (≈ 2048 × 2/3) to maintain parameter parity.

## Instructions

### Implementation

1. **Add CLI flag:**
   ```python
   parser.add_argument('--swiglu-ffn', action='store_true', default=False,
                       help='Replace GELU FFN with SwiGLU activation in transformer layers')
   ```

2. **Implement SwiGLU FFN module:**
   ```python
   class SwiGLUFFN(nn.Module):
       def __init__(self, dim, hidden_dim=None, bias=True):
           super().__init__()
           hidden_dim = hidden_dim or int(dim * 8 / 3)  # 2/3 of standard 4x expansion
           # Round to nearest multiple of 8 for hardware efficiency
           hidden_dim = ((hidden_dim + 7) // 8) * 8
           self.w_gate = nn.Linear(dim, hidden_dim, bias=bias)
           self.w_up = nn.Linear(dim, hidden_dim, bias=bias)
           self.w_down = nn.Linear(hidden_dim, dim, bias=bias)
       
       def forward(self, x):
           return self.w_down(F.silu(self.w_gate(x)) * self.w_up(x))
   ```

3. **Replace the standard FFN** in each transformer layer when `--swiglu-ffn` is enabled:
   ```python
   if args.swiglu_ffn:
       ffn = SwiGLUFFN(hidden_dim)
   else:
       ffn = existing_ffn  # keep current GELU FFN
   ```

### Trials

**Smoke test first (3 epochs)** — verify shapes, loss finite, gradients normal.

**Trial 1 — SwiGLU, parameter-matched (default hidden dim):**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --swiglu-ffn \
  --wandb_group dm-swiglu-ffn
```

**Trial 2 — SwiGLU + slightly lower LR (4.5e-4):**
SwiGLU's smoother gradients may prefer a slightly different LR. Test the lower end since higher LR already failed on the standard FFN:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 4.5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --swiglu-ffn \
  --wandb_group dm-swiglu-ffn
```

Report `val_primary/surface_rel_l2_pct` for both trials. Target: beat **3.833%**.

## Baseline

Current best DrivAerML metrics (PR #3072, eren/dm-ema-9995-gc05):

| Metric | Value | Epoch |
|--------|-------|-------|
| val_primary/surface_rel_l2_pct | **3.833%** | 511 |
| test_primary/surface_rel_l2_pct | **4.685%** | 511 |

- W&B run: `ncl1dh88`
- Config: 4L/512d/8H, AdamW lr=5e-4, T_max=30, gc=0.5, EMA=0.9995, no WD, Fourier

Reproduce:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --grad-clip 0.5 --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995
```