### PR TITLE
DrivAerML: layer-wise learning rate decay (LLRD) across transformer layers

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -169,6 +169,7 @@ class TrainConfig:
     volume_loss_weight: float = 1.0
     save_checkpoint: bool = False
     seed: int = 0
+    layer_lr_decay: float = 1.0
 
 
 @dataclass
@@ -548,7 +549,26 @@ def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
     raise ValueError(f"Unknown model: {config.model}")
 
 
-def build_optimizer(params, config: TrainConfig):
+def build_optimizer(params, config: TrainConfig, *, model: torch.nn.Module | None = None):
+    if config.layer_lr_decay < 1.0 and model is not None:
+        blocks = model.backbone.blocks
+        num_layers = len(blocks)
+        transformer_param_ids: set[int] = set()
+        param_groups = []
+        for i, block in enumerate(blocks):
+            layer_lr = config.lr * (config.layer_lr_decay ** (num_layers - 1 - i))
+            block_params = list(block.parameters())
+            transformer_param_ids.update(id(p) for p in block_params)
+            param_groups.append({"params": block_params, "lr": layer_lr, "layer_index": i})
+        other_params = [p for p in params if id(p) not in transformer_param_ids]
+        if other_params:
+            param_groups.append({"params": other_params, "lr": config.lr, "layer_index": -1})
+        for i, pg in enumerate(param_groups):
+            li = pg.pop("layer_index")
+            label = f"layer_{li}" if li >= 0 else "other"
+            print(f"  LLRD param group {i} ({label}): lr={pg['lr']:.6e}, params={sum(p.numel() for p in pg['params'])}")
+        params = param_groups
+
     if config.optimizer == "lion":
         optimizer = Lion(params, lr=config.lr, weight_decay=config.weight_decay)
     elif config.optimizer == "adamw":
@@ -1369,6 +1389,9 @@ def train_one_epoch(
     running["micro_batches"] = float(micro_batches_total)
     if scheduler is not None:
         running["lr"] = float(optimizer.param_groups[0]["lr"])
+        if len(optimizer.param_groups) > 1:
+            for gi, pg in enumerate(optimizer.param_groups):
+                running[f"lr/group_{gi}"] = float(pg["lr"])
     return running
 
 
@@ -1632,7 +1655,7 @@ def main() -> None:
     params = list(model.parameters())
     if anp_head is not None:
         params.extend(list(anp_head.parameters()))
-    optimizer = build_optimizer(params, config)
+    optimizer = build_optimizer(params, config, model=model)
     scheduler = None
     if config.cosine_t_max > 0:
         base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer


### PR DESCRIPTION
## Hypothesis

The DM Transolver uses a single learning rate (5e-4) for all 4 transformer layers. However, different layers learn different abstractions — early layers capture low-level spatial patterns, later layers build high-level flow structures. **Layer-wise Learning Rate Decay (LLRD)** assigns progressively lower learning rates to earlier layers, allowing later layers to adapt faster while earlier layers change more conservatively.

LLRD is standard practice in NLP fine-tuning (Clark et al. ELECTRA, He et al. DeBERTa) where it consistently improves over uniform LR. The mechanism: early layers learn stable, reusable features that shouldn't change rapidly, while later layers are more task-specific and need faster adaptation. This is directly analogous to the DM Transolver where early layers build geometric representations and later layers predict surface quantities.

With only 4 layers, LLRD creates a modest but meaningful gradient: layer 0 (closest to input) gets lr × decay^3, layer 3 (closest to output) gets the full lr. With decay=0.8 and lr=5e-4: layer 0=2.56e-4, layer 1=3.2e-4, layer 2=4e-4, layer 3=5e-4. This is a gentle modulation, not a dramatic change.

## Instructions

### Implementation

1. **Add CLI flag:**
   ```python
   parser.add_argument('--layer-lr-decay', type=float, default=1.0,
                       help='Per-layer LR decay factor (1.0=uniform, 0.8=recommended). Layer i gets lr * decay^(num_layers-1-i)')
   ```

2. **Create parameter groups with per-layer LR** (replace the single optimizer construction):
   ```python
   if args.layer_lr_decay < 1.0:
       param_groups = []
       num_layers = args.model_layers
       for i, layer in enumerate(model.transformer_layers):
           layer_lr = args.lr * (args.layer_lr_decay ** (num_layers - 1 - i))
           param_groups.append({'params': layer.parameters(), 'lr': layer_lr})
       # Non-transformer params (input projection, output head, Fourier, etc) get full LR
       transformer_params = set()
       for layer in model.transformer_layers:
           transformer_params.update(layer.parameters())
       other_params = [p for p in model.parameters() if p not in transformer_params]
       param_groups.append({'params': other_params, 'lr': args.lr})
       
       optimizer = torch.optim.AdamW(param_groups, weight_decay=args.weight_decay)
   else:
       optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr, weight_decay=args.weight_decay)
   ```

3. **Ensure the cosine scheduler still works.** The scheduler should apply to the base LR of the optimizer. With parameter groups, `CosineAnnealingLR` will scale each group's LR proportionally — verify this by printing LRs at a few steps during smoke test.

### Trials

**Smoke test first (3 epochs)** — verify loss finite, print per-layer LRs at step 0 and step 30 (first restart) to confirm they scale correctly.

**Trial 1 — decay=0.8 (moderate gradient):**
Layer LRs: [2.56e-4, 3.2e-4, 4e-4, 5e-4]
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --layer-lr-decay 0.8 \
  --wandb_group dm-layer-lr-decay
```

**Trial 2 — decay=0.65 (stronger gradient):**
Layer LRs: [1.37e-4, 2.11e-4, 3.25e-4, 5e-4]
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --layer-lr-decay 0.65 \
  --wandb_group dm-layer-lr-decay
```

Report `val_primary/surface_rel_l2_pct` for both trials. Target: beat **3.833%**.

## Baseline

Current best DrivAerML metrics (PR #3072):

| Metric | Value | Epoch |
|--------|-------|-------|
| val_primary/surface_rel_l2_pct | **3.833%** | 511 |
| test_primary/surface_rel_l2_pct | **4.685%** | 511 |

- W&B run: `ncl1dh88`
- Config: 4L/512d/8H, AdamW lr=5e-4, T_max=30, gc=0.5, EMA=0.9995, no WD, Fourier

Reproduce:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --grad-clip 0.5 --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995
```