### PR TITLE
DrivAerML: quadratic position features (pairwise coordinate products)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -86,6 +86,16 @@ class EMAWithWarmup:
         self.backup = None
 
 
+def _cat_quadratic(x: torch.Tensor, space_dim: int) -> torch.Tensor:
+    """Append pairwise coordinate products (x², y², z², xy, xz, yz) to features."""
+    coords = x[..., :space_dim]
+    quads = []
+    for i in range(space_dim):
+        for j in range(i, space_dim):
+            quads.append(coords[..., i : i + 1] * coords[..., j : j + 1])
+    return torch.cat([x] + quads, dim=-1)
+
+
 LEGACY_VAL_ALIAS = {
     "val_in_dist": "p_in",
     "val_ood_cond": "p_oodc",
@@ -169,6 +179,7 @@ class TrainConfig:
     volume_loss_weight: float = 1.0
     save_checkpoint: bool = False
     seed: int = 0
+    quadratic_pos_features: bool = False
 
 
 @dataclass
@@ -860,6 +871,7 @@ def evaluate_grouped(
     *,
     amp_mode: str = "none",
     max_batches: int = 0,
+    quadratic_pos_features: bool = False,
 ) -> dict[str, float]:
     model.eval()
     if anp_head is not None:
@@ -889,6 +901,10 @@ def evaluate_grouped(
     for batch in batches:
         batch = batch.to(device)
         dataset_name = batch.dataset_name
+        if quadratic_pos_features:
+            batch.surface_x = _cat_quadratic(batch.surface_x, batch.space_dim)
+            if batch.volume_x is not None:
+                batch.volume_x = _cat_quadratic(batch.volume_x, batch.space_dim)
 
         if isinstance(transform, TandemTargetTransform):
             prepared = transform.prepare_batch(batch)
@@ -1277,6 +1293,7 @@ def train_one_epoch(
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
     volume_loss_weight: float = 1.0,
+    quadratic_pos_features: bool = False,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1313,6 +1330,10 @@ def train_one_epoch(
                     loss, _ = loss_abupt(batch, outputs, transform, volume_loss_weight=volume_loss_weight)
             else:
                 batch = batch.to(device)
+                if quadratic_pos_features:
+                    batch.surface_x = _cat_quadratic(batch.surface_x, batch.space_dim)
+                    if batch.volume_x is not None:
+                        batch.volume_x = _cat_quadratic(batch.volume_x, batch.space_dim)
                 if isinstance(transform, TandemTargetTransform):
                     prepared = transform.prepare_batch(batch)
                     with autocast_context(device, amp_mode):
@@ -1487,6 +1508,7 @@ def evaluate_phase_metrics(
                 device,
                 amp_mode=config.amp_mode,
                 max_batches=config.max_eval_batches,
+                quadratic_pos_features=config.quadratic_pos_features,
             )
         metrics.update({f"{split_name}/{name}": value for name, value in split_metrics.items()})
         if phase == "val" and split_name in LEGACY_VAL_ALIAS and "mae_surf_p" in split_metrics:
@@ -1619,6 +1641,13 @@ def main() -> None:
                 asinh_scale=config.asinh_scale,
             )
 
+    if config.quadratic_pos_features:
+        quad_dim = bundle.spec.space_dim * (bundle.spec.space_dim + 1) // 2
+        bundle.spec.surface_input_dim += quad_dim
+        if bundle.spec.volume_input_dim > 0:
+            bundle.spec.volume_input_dim += quad_dim
+        print(f"[QuadPos] Adding {quad_dim} quadratic position features (space_dim={bundle.spec.space_dim})")
+
     train_loader, val_loaders, test_loaders = build_loaders(config, bundle, num_workers=resolved_num_workers)
     model = build_model(config, bundle).to(device)
     forward_model = torch.compile(model) if config.compile_model and device.type == "cuda" else model
@@ -1694,6 +1723,7 @@ def main() -> None:
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
             volume_loss_weight=config.volume_loss_weight,
+            quadratic_pos_features=config.quadratic_pos_features,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

The DM Transolver currently uses Fourier positional encoding of the raw (x, y, z) coordinates. Fourier features are excellent for capturing periodic/oscillatory patterns but encode **only first-order position information** — they know WHERE a point is but not about the local geometry AROUND it. We hypothesize that adding **second-order (quadratic) position features** — pairwise products x², y², z², xy, xz, yz — will provide the model with implicit curvature information at zero compute overhead.

**Why this matters for surface pressure prediction:** Surface pressure is fundamentally determined by local surface curvature (via the pressure-velocity relationship). Points on flat surfaces, convex surfaces (high pressure), and concave surfaces (low pressure) have systematically different pressure distributions. Quadratic features encode this distinction:
- **x² + y² + z²** = distance² from origin (radial position)
- **xy, xz, yz** = correlation between axes (encodes surface orientation/twist)
- Combined with Fourier features of x, y, z, the model gets both frequency content AND quadratic geometry

This is pure feature engineering — no architecture changes, no new parameters, no throughput overhead. The 6 additional features are concatenated to the existing input features before the input projection MLP.

## Instructions

### Implementation

1. **Add CLI flag:**
   ```python
   parser.add_argument('--quadratic-pos-features', action='store_true', default=False,
                       help='Add x², y², z², xy, xz, yz as input features alongside Fourier encoding')
   ```

2. **Compute quadratic features** (before the input projection):
   ```python
   if args.quadratic_pos_features:
       # coords: [B, N, 3] — the xyz coordinates
       x, y, z = coords[..., 0:1], coords[..., 1:2], coords[..., 2:3]
       quad_features = torch.cat([
           x*x, y*y, z*z,  # squared terms
           x*y, x*z, y*z   # cross terms
       ], dim=-1)  # [B, N, 6]
       # Concatenate to existing features before input projection
       features = torch.cat([features, quad_features], dim=-1)
   ```

3. **Adjust the input projection dimension** to account for 6 extra features. The input projection MLP takes `(existing_dim + 6)` inputs when quadratic features are enabled. Ensure the first linear layer's in_features is updated accordingly.

**That's it.** No architecture changes, no new modules, no loss modifications.

### Trials

**Smoke test first (3 epochs)** — verify shapes, loss finite.

**Trial 1 — Quadratic features, standard config:**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --quadratic-pos-features \
  --wandb_group dm-quadratic-pos
```

**Trial 2 — Quadratic features WITHOUT Fourier (ablation):**
To test whether quadratic features can partially replace Fourier encoding:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --quadratic-pos-features \
  --wandb_group dm-quadratic-pos
```
(Note: this trial omits `--enable-fourier` to test quadratic features in isolation.)

Report `val_primary/surface_rel_l2_pct` for both trials. Target: beat **3.833%**.

## Baseline

Current best DrivAerML metrics (PR #3072):

| Metric | Value | Epoch |
|--------|-------|-------|
| val_primary/surface_rel_l2_pct | **3.833%** | 511 |
| test_primary/surface_rel_l2_pct | **4.685%** | 511 |

- W&B run: `ncl1dh88`
- Config: 4L/512d/8H, AdamW lr=5e-4, T_max=30, gc=0.5, EMA=0.9995, no WD, Fourier

Reproduce:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --grad-clip 0.5 --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995
```