### PR TITLE
DrivAerML: Grouped Query Attention (GQA) — fewer KV heads for throughput

### DIFF
--- a/target/icml2026/core/architectures/transolver_reference.py
+++ b/target/icml2026/core/architectures/transolver_reference.py
@@ -85,7 +85,7 @@ class UpActDownMlp(nn.Module):
 
 
 class TransolverAttention(nn.Module):
-    def __init__(self, hidden_dim: int, num_heads: int, num_slices: int, dropout: float = 0.0):
+    def __init__(self, hidden_dim: int, num_heads: int, num_slices: int, dropout: float = 0.0, num_kv_heads: int = 0):
         super().__init__()
         if hidden_dim % num_heads != 0:
             raise ValueError("hidden_dim must be divisible by num_heads")
@@ -94,32 +94,66 @@ class TransolverAttention(nn.Module):
         self.dim_head = hidden_dim // num_heads
         self.num_slices = num_slices
         self.dropout = dropout
+        self.num_kv_heads = num_kv_heads if num_kv_heads > 0 else num_heads
+        if num_heads % self.num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.kv_group_size = num_heads // self.num_kv_heads
+        self.use_gqa = self.num_kv_heads < num_heads
 
         self.temperature = nn.Parameter(torch.full((1, num_heads, 1, 1), 0.5))
         self.in_project_x = LinearProjection(hidden_dim, hidden_dim)
-        self.in_project_fx = LinearProjection(hidden_dim, hidden_dim)
         self.in_project_slice = LinearProjection(self.dim_head, num_slices)
-        self.qkv = LinearProjection(self.dim_head, self.dim_head * 3, bias=False)
         self.proj = LinearProjection(hidden_dim, hidden_dim)
         self.proj_dropout = nn.Dropout(dropout)
 
+        if self.use_gqa:
+            kv_hidden = self.num_kv_heads * self.dim_head
+            self.in_project_fx = LinearProjection(hidden_dim, kv_hidden)
+            self.q_proj = LinearProjection(self.dim_head, self.dim_head, bias=False)
+            self.kv_proj = LinearProjection(self.dim_head, self.dim_head * 2, bias=False)
+        else:
+            self.in_project_fx = LinearProjection(hidden_dim, hidden_dim)
+            self.qkv = LinearProjection(self.dim_head, self.dim_head * 3, bias=False)
+
     def create_slices(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> tuple[torch.Tensor, torch.Tensor]:
         batch_size, num_tokens, _ = x.shape
-        fx_mid = self.in_project_fx(x).view(batch_size, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
+        fx_mid = self.in_project_fx(x).view(batch_size, num_tokens, self.num_heads if not self.use_gqa else self.num_kv_heads, self.dim_head).permute(0, 2, 1, 3)
         x_mid = self.in_project_x(x).view(batch_size, num_tokens, self.num_heads, self.dim_head).permute(0, 2, 1, 3)
         slice_logits = self.in_project_slice(x_mid) / self.temperature
         slice_weights = F.softmax(slice_logits, dim=-1)
         if attn_mask is not None:
             mask = attn_mask[:, None, :, None].float()
             slice_weights = slice_weights * mask
-        slice_norm = slice_weights.sum(dim=2, keepdim=False).unsqueeze(-1)
-        slice_tokens = torch.einsum("bhnc,bhns->bhsc", fx_mid, slice_weights) / (slice_norm + 1e-5)
-        return slice_tokens, slice_weights
+        if not self.use_gqa:
+            slice_norm = slice_weights.sum(dim=2, keepdim=False).unsqueeze(-1)
+            slice_tokens = torch.einsum("bhnc,bhns->bhsc", fx_mid, slice_weights) / (slice_norm + 1e-5)
+            return slice_tokens, slice_weights
+        return (x_mid, fx_mid), slice_weights
 
     def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
-        slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask)
-        qkv = self.qkv(slice_tokens)
-        q, k, v = qkv.chunk(3, dim=-1)
+        slices_out, slice_weights = self.create_slices(x, attn_mask=attn_mask)
+
+        if not self.use_gqa:
+            slice_tokens = slices_out
+            qkv = self.qkv(slice_tokens)
+            q, k, v = qkv.chunk(3, dim=-1)
+        else:
+            x_mid, fx_mid = slices_out
+            q_norm = slice_weights.sum(dim=2).unsqueeze(-1)
+            q_slice_tokens = torch.einsum("bhnc,bhns->bhsc", x_mid, slice_weights) / (q_norm + 1e-5)
+            q = self.q_proj(q_slice_tokens)
+
+            kv_slice_weights = slice_weights.view(
+                slice_weights.shape[0], self.num_kv_heads, self.kv_group_size,
+                slice_weights.shape[2], slice_weights.shape[3],
+            ).mean(dim=2)
+            kv_norm = kv_slice_weights.sum(dim=2).unsqueeze(-1)
+            kv_slice_tokens = torch.einsum("bhnc,bhns->bhsc", fx_mid, kv_slice_weights) / (kv_norm + 1e-5)
+            kv = self.kv_proj(kv_slice_tokens)
+            k, v = kv.chunk(2, dim=-1)
+            k = k.repeat_interleave(self.kv_group_size, dim=1)
+            v = v.repeat_interleave(self.kv_group_size, dim=1)
+
         out_slice = F.scaled_dot_product_attention(
             q,
             k,
@@ -139,6 +173,7 @@ class TransformerBlock(nn.Module):
         mlp_expansion_factor: int | float,
         num_slices: int,
         dropout: float = 0.0,
+        num_kv_heads: int = 0,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -148,6 +183,7 @@ class TransformerBlock(nn.Module):
             num_heads=num_heads,
             num_slices=num_slices,
             dropout=dropout,
+            num_kv_heads=num_kv_heads,
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
@@ -167,6 +203,7 @@ class Transformer(nn.Module):
         mlp_expansion_factor: int | float,
         num_slices: int,
         dropout: float = 0.0,
+        num_kv_heads: int = 0,
     ):
         super().__init__()
         self.blocks = nn.ModuleList(
@@ -177,6 +214,7 @@ class Transformer(nn.Module):
                     mlp_expansion_factor=mlp_expansion_factor,
                     num_slices=num_slices,
                     dropout=dropout,
+                    num_kv_heads=num_kv_heads,
                 )
                 for _ in range(depth)
             ]
@@ -205,6 +243,7 @@ class ReferenceTransolver(nn.Module):
         n_head: int = 3,
         mlp_ratio: int = 4,
         slice_num: int = 96,
+        n_kv_head: int = 0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -233,6 +272,7 @@ class ReferenceTransolver(nn.Module):
             mlp_expansion_factor=mlp_ratio,
             num_slices=slice_num,
             dropout=dropout,
+            num_kv_heads=n_kv_head,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.out = LinearProjection(n_hidden, surface_output_dim + volume_output_dim)

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -169,6 +169,7 @@ class TrainConfig:
     volume_loss_weight: float = 1.0
     save_checkpoint: bool = False
     seed: int = 0
+    num_kv_heads: int = 0
 
 
 @dataclass
@@ -513,6 +514,7 @@ def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
         "n_head": config.model_heads,
         "mlp_ratio": config.model_mlp_ratio,
         "slice_num": config.model_slices,
+        "n_kv_head": config.num_kv_heads,
     }
     if config.model == "reference_transolver":
         return ReferenceTransolver(
@@ -1678,6 +1680,7 @@ def main() -> None:
     for epoch in range(1, config.epochs + 1):
         if timeout_seconds is not None and epoch > 1 and (time.monotonic() - start_time) >= timeout_seconds:
             break
+        epoch_start = time.monotonic()
         train_metrics = train_one_epoch(
             model=forward_model,
             anp_head=anp_head,
@@ -1742,7 +1745,10 @@ def main() -> None:
         if anp_head is not None and anp_ema is not None:
             anp_ema.restore(anp_head)
 
+        epoch_elapsed = time.monotonic() - epoch_start
         epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
+        epoch_metrics["epoch_time_sec"] = epoch_elapsed
+        epoch_metrics["epoch_time_min"] = epoch_elapsed / 60.0
         epoch_metrics["best_val_metric"] = best_val_metric
         epoch_metrics["best_epoch"] = float(best_epoch)
         history.append(epoch_metrics)


### PR DESCRIPTION
## Hypothesis

The MoE experiment (#3263) demonstrated that **throughput is the primary constraint** on DM — any modification that slows per-epoch time below baseline gets epoch-starved and loses. The flip side: any modification that IMPROVES throughput gets more epochs within the timeout and may find deeper optima.

**Grouped Query Attention (GQA)** (Ainslie et al., 2023; used in LLaMA 2/3, Mistral, Gemma) reduces the number of Key-Value heads while keeping all Query heads. With 8 Q heads and 2 KV groups, each KV head is shared across 4 Q heads. This reduces the KV projection parameters by 4x and the KV computation by 4x, while maintaining the full Q-head expressivity for attention pattern computation.

For DM with 50k surface point tokens at bs=1:
- Standard MHA: 8 Q heads × 64d, 8 K heads × 64d, 8 V heads × 64d → 3 × 512 → 512 projections
- GQA (2 KV groups): 8 Q heads × 64d, 2 K heads × 64d, 2 V heads × 64d → Q: 512→512, K: 512→128, V: 512→128

This saves ~25% of the attention parameter budget and reduces memory bandwidth for the KV cache. At 50k tokens, the KV computation is a significant fraction of total FLOPS. If GQA provides even 10-15% throughput improvement, that translates to ~50-75 more epochs within the timeout — potentially enough to push past 3.833%.

**Key insight from the head count sweep:** 8H is the optimal head count. GQA tests whether the VALUE of all 8 heads matters (it might) or whether 8 QUERY patterns are sufficient even with shared KV projections (the GQA hypothesis).

## Instructions

### Implementation

1. **Add CLI flag:**
   ```python
   parser.add_argument('--num-kv-heads', type=int, default=0,
                       help='Number of KV heads for GQA (0=same as model-heads, standard MHA)')
   ```

2. **Modify the self-attention module** to support GQA:
   ```python
   num_q_heads = args.model_heads  # 8
   num_kv_heads = args.num_kv_heads if args.num_kv_heads > 0 else num_q_heads
   head_dim = hidden_dim // num_q_heads  # 64
   
   # Q projection: full heads
   self.q_proj = nn.Linear(hidden_dim, num_q_heads * head_dim)
   # K, V projections: fewer heads
   self.k_proj = nn.Linear(hidden_dim, num_kv_heads * head_dim)
   self.v_proj = nn.Linear(hidden_dim, num_kv_heads * head_dim)
   self.o_proj = nn.Linear(num_q_heads * head_dim, hidden_dim)
   ```

3. **In the attention forward pass**, repeat KV heads to match Q heads:
   ```python
   # After projecting Q, K, V:
   # Q: [B, N, num_q_heads, head_dim]
   # K: [B, N, num_kv_heads, head_dim]
   # V: [B, N, num_kv_heads, head_dim]
   
   if num_kv_heads < num_q_heads:
       repeat_factor = num_q_heads // num_kv_heads
       K = K.repeat_interleave(repeat_factor, dim=2)  # [B, N, num_q_heads, head_dim]
       V = V.repeat_interleave(repeat_factor, dim=2)
   
   # Then compute attention normally with Q, K, V all having num_q_heads
   ```

   **Alternative (more efficient):** Use `torch.nn.functional.scaled_dot_product_attention` with GQA-aware reshaping, which avoids the explicit repeat.

### Trials

**Smoke test first (3 epochs)** — verify shapes, attention output matches expected dims, loss finite. Also measure per-epoch time vs baseline.

**Trial 1 — 2 KV heads (4:1 Q/KV ratio):**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --num-kv-heads 2 \
  --wandb_group dm-gqa
```

**Trial 2 — 4 KV heads (2:1 Q/KV ratio, milder):**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --num-kv-heads 4 \
  --wandb_group dm-gqa
```

**Critical:** Report per-epoch time (min/epoch) for both trials alongside the standard metrics. The throughput improvement IS the hypothesis — if GQA doesn't speed things up measurably, the experiment is moot.

Report `val_primary/surface_rel_l2_pct` for both trials. Target: beat **3.833%**.

## Baseline

Current best DrivAerML metrics (PR #3072):

| Metric | Value | Epoch |
|--------|-------|-------|
| val_primary/surface_rel_l2_pct | **3.833%** | 511 |
| test_primary/surface_rel_l2_pct | **4.685%** | 511 |

- W&B run: `ncl1dh88`
- Config: 4L/512d/8H, AdamW lr=5e-4, T_max=30, gc=0.5, EMA=0.9995, no WD, Fourier

Reproduce:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --grad-clip 0.5 --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995
```