### PR TITLE
DrivAerML: cosine similarity auxiliary loss (spatial pattern fidelity)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -167,6 +167,7 @@ class TrainConfig:
     grad_clip: float = 0.0
     grad_accum_steps: int = 1
     volume_loss_weight: float = 1.0
+    cosine_sim_weight: float = 0.0
     save_checkpoint: bool = False
     seed: int = 0
 
@@ -1277,6 +1278,7 @@ def train_one_epoch(
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
     volume_loss_weight: float = 1.0,
+    cosine_sim_weight: float = 0.0,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1334,6 +1336,19 @@ def train_one_epoch(
                         )
                         loss, _ = loss_grouped(batch, outputs, transform, volume_loss_weight=volume_loss_weight)
 
+                    if cosine_sim_weight > 0 and batch.surface_y is not None and outputs["surface_preds"] is not None:
+                        pred_masked = outputs["surface_preds"][batch.surface_mask].float()
+                        target_masked = transform.apply(batch.surface_y)[batch.surface_mask].float()
+                        pred_flat = pred_masked.reshape(1, -1)
+                        target_flat = target_masked.reshape(1, -1)
+                        cos_sim = F.cosine_similarity(pred_flat, target_flat, dim=-1)
+                        cosine_loss = (1.0 - cos_sim).mean()
+                        loss = loss + cosine_sim_weight * cosine_loss
+                        running.setdefault("cosine_similarity", 0.0)
+                        running["cosine_similarity"] += float(cos_sim.mean().detach().cpu().item())
+                        running.setdefault("cosine_loss", 0.0)
+                        running["cosine_loss"] += float(cosine_loss.detach().cpu().item())
+
             accum_loss += float(loss.detach().cpu().item())
             (loss / grad_accum_steps).backward()
             micro_count += 1
@@ -1365,6 +1380,10 @@ def train_one_epoch(
     running["loss"] /= max(steps, 1)
     if "grad_norm_mean" in running:
         running["grad_norm_mean"] /= max(steps, 1)
+    if "cosine_similarity" in running:
+        running["cosine_similarity"] /= max(steps, 1)
+    if "cosine_loss" in running:
+        running["cosine_loss"] /= max(steps, 1)
     running["train_steps"] = float(steps)
     running["micro_batches"] = float(micro_batches_total)
     if scheduler is not None:
@@ -1694,6 +1713,7 @@ def main() -> None:
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
             volume_loss_weight=config.volume_loss_weight,
+            cosine_sim_weight=config.cosine_sim_weight,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

MSE alone optimizes per-point magnitude accuracy — it treats each surface point independently. But surface pressure has **spatial structure** (smooth variations, sharp gradients at separation points, pressure recovery patterns) that MSE doesn't explicitly reward. A model could have low MSE but systematically distort the spatial PATTERN of pressure distribution.

**Cosine similarity** between the predicted and target pressure vectors captures the **shape** of the spatial pattern independently of absolute scale:
\`cos_sim = (pred · target) / (||pred|| × ||target||)\`

Adding \`1 - cos_sim\` as an auxiliary loss encourages the model to match the overall spatial pressure distribution pattern, not just minimize per-point squared differences. This:
1. **Scale-invariant** — a prediction that has the right pattern but wrong magnitude still gets cosine credit
2. **Complements MSE** — MSE handles magnitude, cosine handles pattern fidelity
3. **Computationally free** — dot product and norms over 50k points, negligible vs transformer forward pass
4. **Different gradient signal** — MSE gradients scale with error magnitude (small errors → small gradients), while cosine gradients emphasize direction alignment regardless of magnitude. This provides informative gradients even for well-predicted points.

The key insight: if the remaining 3.833% error is systematic spatial bias (same regions consistently wrong), cosine similarity loss directly penalizes pattern distortion, potentially pulling the model toward the correct spatial structure.

## Instructions

### Implementation

1. **Add CLI flag:**
   ```python
   parser.add_argument('--cosine-sim-weight', type=float, default=0.0,
                       help='Weight for cosine similarity auxiliary loss (0=disabled)')
   ```

2. **Compute cosine similarity loss** alongside MSE:
   ```python
   if args.cosine_sim_weight > 0:
       # pred, target: [B, N, C] — B=1, N=50k points, C=output channels
       # Flatten spatial dimensions for per-channel cosine sim
       pred_flat = pred.reshape(pred.shape[0], -1)    # [B, N*C]
       target_flat = target.reshape(target.shape[0], -1)  # [B, N*C]
       
       cos_sim = F.cosine_similarity(pred_flat, target_flat, dim=-1)  # [B]
       cosine_loss = (1 - cos_sim).mean()
       
       total_loss = mse_loss + args.cosine_sim_weight * cosine_loss
   ```

   **Alternative (per-channel):** Compute cosine similarity per output channel separately, then average:
   ```python
   cos_losses = []
   for c in range(pred.shape[-1]):
       cos_sim_c = F.cosine_similarity(pred[..., c], target[..., c], dim=-1)
       cos_losses.append((1 - cos_sim_c).mean())
   cosine_loss = torch.stack(cos_losses).mean()
   ```
   The per-channel version may be better since different output channels (Ux, Uy, p) have different distributions. Try the simpler flat version first, switch to per-channel if results are promising.

3. **Log the cosine similarity** as a metric (not just the loss):
   ```python
   wandb.log({'train/cosine_similarity': cos_sim.mean().item()})
   ```

### Trials

**Smoke test first (3 epochs)** — verify loss finite, cosine similarity in reasonable range (0.5-0.99).

**Trial 1 — weight=0.1 (moderate):**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --cosine-sim-weight 0.1 \
  --wandb_group dm-cosine-sim-loss
```

**Trial 2 — weight=0.5 (strong pattern emphasis):**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --cosine-sim-weight 0.5 \
  --wandb_group dm-cosine-sim-loss
```

Log the cosine similarity metric throughout training — it should increase toward 1.0. If it plateaus early (>0.99 before epoch 100), the pattern is already well-learned and this loss provides diminishing returns. If it's still <0.95 at convergence, the pattern fidelity is a genuine bottleneck.

Report `val_primary/surface_rel_l2_pct` for both trials. Target: beat **3.833%**.

## Baseline

Current best DrivAerML metrics (PR #3072):

| Metric | Value | Epoch |
|--------|-------|-------|
| val_primary/surface_rel_l2_pct | **3.833%** | 511 |
| test_primary/surface_rel_l2_pct | **4.685%** | 511 |

- W&B run: `ncl1dh88`
- Config: 4L/512d/8H, AdamW lr=5e-4, T_max=30, gc=0.5, EMA=0.9995, no WD, Fourier

Reproduce:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --grad-clip 0.5 --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995
```