### PR TITLE
DrivAerML: coordinate residual branch (bypass MLP for spatial bias)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -169,6 +169,8 @@ class TrainConfig:
     volume_loss_weight: float = 1.0
     save_checkpoint: bool = False
     seed: int = 0
+    bypass_mlp: bool = False
+    bypass_mlp_hidden: int = 128
 
 
 @dataclass
@@ -503,6 +505,40 @@ def cp_panel_prior_index(config: TrainConfig, bundle: DatasetBundle) -> int | No
         base_dim -= 1
         return base_dim
     return None
+
+
+class CoordinateBypassWrapper(torch.nn.Module):
+    """Wraps a Transolver with a parallel point-local bypass MLP (zero-init output)."""
+
+    def __init__(self, base_model: torch.nn.Module, bypass_input_dim: int, output_dim: int, hidden_dim: int = 128):
+        super().__init__()
+        self.base = base_model
+        self.space_dim = base_model.space_dim
+        self.bypass_mlp = torch.nn.Sequential(
+            torch.nn.Linear(bypass_input_dim, hidden_dim),
+            torch.nn.GELU(),
+            torch.nn.Linear(hidden_dim, hidden_dim),
+            torch.nn.GELU(),
+            torch.nn.Linear(hidden_dim, output_dim),
+        )
+        torch.nn.init.zeros_(self.bypass_mlp[-1].weight)
+        torch.nn.init.zeros_(self.bypass_mlp[-1].bias)
+
+    def forward(self, *, surface_x: torch.Tensor, surface_mask: torch.Tensor,
+                volume_x: torch.Tensor | None = None, volume_mask: torch.Tensor | None = None) -> dict:
+        outputs = self.base(surface_x=surface_x, surface_mask=surface_mask,
+                            volume_x=volume_x, volume_mask=volume_mask)
+        bypass_input = surface_x[:, :, self.space_dim:]
+        bypass_correction = self.bypass_mlp(bypass_input)
+        if outputs["surface_preds"] is not None:
+            outputs["surface_preds"] = outputs["surface_preds"] + bypass_correction * surface_mask.unsqueeze(-1)
+        return outputs
+
+    def __getattr__(self, name: str):
+        try:
+            return super().__getattr__(name)
+        except AttributeError:
+            return getattr(self.base, name)
 
 
 def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
@@ -1621,6 +1657,12 @@ def main() -> None:
 
     train_loader, val_loaders, test_loaders = build_loaders(config, bundle, num_workers=resolved_num_workers)
     model = build_model(config, bundle).to(device)
+    if config.bypass_mlp:
+        bypass_input_dim = max(0, bundle.spec.surface_input_dim - bundle.spec.space_dim)
+        bypass_output_dim = bundle.spec.surface_output_dim
+        model = CoordinateBypassWrapper(model, bypass_input_dim, bypass_output_dim, config.bypass_mlp_hidden).to(device)
+        n_bypass = sum(p.numel() for p in model.bypass_mlp.parameters())
+        print(f"[BypassMLP] {bypass_input_dim}→{config.bypass_mlp_hidden}→{bypass_output_dim}, {n_bypass:,} params (zero-init output)")
     forward_model = torch.compile(model) if config.compile_model and device.type == "cuda" else model
     anp_head = None
     if bundle.spec.name == "tandemfoilset" and config.anp_srf:


### PR DESCRIPTION
## Hypothesis

The remaining DrivAerML error (3.833%) is dominated by **systematic spatial bias** — the transformer consistently mispredicts certain spatial regions because attention aggregates over neighborhoods, masking point-local corrections. Every dead-end experiment confirms this: the error is not optimizer noise or depth/width starvation, it is that the model lacks a direct position→correction pathway.

We add a small **parallel bypass MLP** that operates on each point's Fourier-encoded features independently (no cross-point interaction) and whose output is summed with the transformer output. The transformer handles cross-point flow interactions; the bypass MLP captures point-local systematic offsets. This is a ResNet-style shortcut but placed at the input-to-output level, bypassing the attention bottleneck entirely.

Key design choices:
- **Input**: the same Fourier-encoded positional features fed to the transformer (already computed, zero throughput cost)
- **Architecture**: 3-layer MLP (fourier_dim→128→128→output_dim), GELU activation, **zero-initialized final layer** so training starts from the pure transformer baseline
- **No throughput penalty**: tiny MLP runs in parallel with transformer forward pass

If the remaining error is truly spatial-bias-dominated, this bypass should reduce it directly.

## Instructions

All changes go in `target/icml2026/train.py`. Keep the full champion config unchanged — only add the bypass MLP.

**Step 1: Add a bypass MLP to the model class**

In `__init__`, after existing model initialization:

```python
# Bypass MLP: point-local correction from Fourier features
# fourier_dim = the output dimension of the Fourier encoding (check model code)
self.bypass_mlp = nn.Sequential(
    nn.Linear(fourier_dim, 128),
    nn.GELU(),
    nn.Linear(128, 128),
    nn.GELU(),
    nn.Linear(128, output_channels),  # 3 for DrivAerML (Ux, Uy, p)
)
# Zero-init: start from pure transformer baseline
nn.init.zeros_(self.bypass_mlp[-1].weight)
nn.init.zeros_(self.bypass_mlp[-1].bias)
```

**Step 2: Apply in forward pass**

After computing Fourier-encoded features and before/after the transformer:

```python
# x_fourier: [N, fourier_dim] — Fourier-encoded point features
# transformer_out: [N, output_channels] — main transformer predictions
bypass_correction = self.bypass_mlp(x_fourier)  # [N, output_channels]
output = transformer_out + bypass_correction
```

**Step 3: Run two trials with `--wandb_group dm-coord-residual-bypass`**

Trial 1 — 128 hidden units:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --grad-clip 0.5 --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 --ema-decay 0.9995 \
  --wandb_group dm-coord-residual-bypass
```

Trial 2 (run only if Trial 1 shows improvement — wider bypass):
Same config but bypass_mlp uses 256 hidden units.

**Verify epoch time stays within 5% of baseline (~22 sec/epoch).** The bypass MLP is negligible vs 4L/512d, but confirm this upfront before committing to full run.

## Baseline

- **val surface_rel_l2_pct:** 3.833% at epoch 511
- **test surface_rel_l2_pct:** 4.685%
- **W&B run:** ncl1dh88 (eren/dm-ema-9995-gc05)
- **Reproduce:** `cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --ema-decay 0.9995`

## Context

25+ DM experiments have failed. The common failure mode: any modification adding throughput overhead fails due to epoch starvation (#3263 MoE, #3272 quadratic features). This bypass MLP is intentionally tiny (<<1% FLOP overhead) and throughput-neutral. Systematic spatial bias is the identified remaining bottleneck — this is the first experiment to attack it with a dedicated position-dependent correction pathway.