### PR TITLE
AF: separate volume prediction head with extra capacity

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -167,6 +167,8 @@ class TrainConfig:
     grad_clip: float = 0.0
     grad_accum_steps: int = 1
     volume_loss_weight: float = 1.0
+    separate_volume_head: bool = False
+    vol_head_width_mult: int = 2
     save_checkpoint: bool = False
     seed: int = 0
 
@@ -505,6 +507,93 @@ def cp_panel_prior_index(config: TrainConfig, bundle: DatasetBundle) -> int | No
     return None
 
 
+class SeparateHeadTransolver(SenpaiTransolver):
+    """SenpaiTransolver with separate surface/volume output projections.
+
+    Replaces the shared LinearProjection with two MLP heads:
+    - Surface: hidden_dim -> hidden_dim -> surface_output_dim
+    - Volume:  hidden_dim -> hidden_dim*mult -> volume_output_dim (extra capacity)
+    """
+
+    def __init__(self, *, vol_head_width_mult: int = 2, **kwargs):
+        super().__init__(**kwargs)
+        n_h = self.n_hidden
+        self.surface_out_mlp = torch.nn.Sequential(
+            torch.nn.Linear(n_h, n_h),
+            torch.nn.GELU(),
+            torch.nn.Linear(n_h, self.surface_output_dim),
+        )
+        vol_hidden = n_h * vol_head_width_mult
+        self.volume_out_mlp = torch.nn.Sequential(
+            torch.nn.Linear(n_h, vol_hidden),
+            torch.nn.GELU(),
+            torch.nn.Linear(vol_hidden, self.volume_output_dim),
+        )
+        del self.out
+
+    def forward(
+        self,
+        *,
+        surface_x: torch.Tensor,
+        surface_mask: torch.Tensor,
+        volume_x: torch.Tensor | None = None,
+        volume_mask: torch.Tensor | None = None,
+    ) -> dict[str, torch.Tensor | None]:
+        surface_hidden = self._group_hidden(
+            surface_x, self.project_surface_features, self.surface_bias
+        )
+        hidden_parts = [surface_hidden]
+        mask_parts = [surface_mask]
+        has_volume = (
+            volume_x is not None
+            and volume_mask is not None
+            and self.volume_output_dim > 0
+        )
+        if has_volume:
+            vol_hidden = self._group_hidden(
+                volume_x, self.project_volume_features, self.volume_bias
+            )
+            hidden_parts.append(vol_hidden)
+            mask_parts.append(volume_mask)
+
+        hidden = torch.cat(hidden_parts, dim=1) + self.placeholder
+        attn_mask = torch.cat(mask_parts, dim=1)
+        hidden = self.backbone(hidden, attn_mask=attn_mask)
+        normed = self.norm(hidden)
+
+        surface_tokens = surface_x.shape[1]
+        surface_preds = self.surface_out_mlp(normed[:, :surface_tokens])
+        surface_preds = surface_preds * surface_mask.unsqueeze(-1)
+
+        volume_preds = None
+        if has_volume:
+            volume_tokens = volume_x.shape[1]
+            volume_preds = self.volume_out_mlp(
+                normed[:, surface_tokens : surface_tokens + volume_tokens]
+            )
+            if volume_mask is not None:
+                volume_preds = volume_preds * volume_mask.unsqueeze(-1)
+
+        surface_preds = self._apply_pressure_prior_addition(
+            surface_preds, surface_x, self.surface_pressure_prior_idx
+        )
+        if self.surface_head is not None and surface_preds is not None:
+            surface_preds = surface_preds + self.surface_head(
+                hidden[:, :surface_tokens], surface_preds
+            )
+            surface_preds = surface_preds * surface_mask.unsqueeze(-1)
+        volume_preds = self._apply_pressure_prior_addition(
+            volume_preds, volume_x, self.volume_pressure_prior_idx
+        )
+
+        return {
+            "surface_hidden": hidden[:, :surface_tokens],
+            "surface_preds": surface_preds,
+            "volume_hidden": None if not has_volume else hidden[:, surface_tokens:],
+            "volume_preds": volume_preds,
+        }
+
+
 def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
     transolver_kwargs = {
         "n_layers": config.model_layers,
@@ -525,7 +614,7 @@ def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
         )
     if config.model == "senpai_transolver":
         prior_idx = cp_panel_prior_index(config, bundle)
-        return SenpaiTransolver(
+        senpai_kwargs = dict(
             space_dim=bundle.spec.space_dim,
             surface_input_dim=bundle.spec.surface_input_dim,
             surface_output_dim=bundle.spec.surface_output_dim,
@@ -539,6 +628,12 @@ def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
             volume_pressure_prior_idx=prior_idx,
             **transolver_kwargs,
         )
+        if config.separate_volume_head:
+            return SeparateHeadTransolver(
+                vol_head_width_mult=config.vol_head_width_mult,
+                **senpai_kwargs,
+            )
+        return SenpaiTransolver(**senpai_kwargs)
     if config.model == "reference_abupt":
         return ABUPTReference(
             space_dim=bundle.spec.space_dim,
@@ -1663,6 +1758,8 @@ def main() -> None:
     if config.wandb_name:
         run_config = asdict(config)
         run_config["effective_batch_size"] = config.batch_size * config.grad_accum_steps
+        run_config["model_params"] = sum(p.numel() for p in model.parameters())
+        run_config["model_trainable_params"] = sum(p.numel() for p in model.parameters() if p.requires_grad)
         run = wandb.init(
             project=os.getenv("WANDB_PROJECT", "senpai-v1"),
             entity=os.getenv("WANDB_ENTITY"),


### PR DESCRIPTION
## Hypothesis

The current model uses a **shared output MLP** for all points — surface and volume predictions come from the same final layer. But vol_mse (0.002039) is ~7x higher than surface_mse (0.000296), suggesting the shared output bottleneck under-allocates capacity to volume.

We replace the single shared output MLP with **two separate heads**:
- **Surface head**: standard capacity (matches current output MLP — 256→256→out_channels)
- **Volume head**: double-width (256→512→out_channels, ~2x parameters in the output layer)

The transformer trunk is unchanged (shared — still benefits from joint surface+volume representation learning). Only the final output projection is split. This gives volume predictions a dedicated pathway with more parameters to model the more complex interior flow field.

Why this makes physical sense: surface aerodynamics is largely a boundary condition problem (the geometry defines most of the solution). Volume aerodynamics requires modeling wake formation, separation bubbles, and 3D vortical structures — a fundamentally richer prediction problem. The same output capacity used for surface should not suffice for volume.

## Instructions

All changes in `target/icml2026/train.py`. Champion config unchanged — only split the output MLP.

**Step 1: Find the current output MLP in the model class**

Locate the output projection layer (likely `self.output_mlp` or `self.head` or similar — it maps from `hidden_dim` to `output_channels`).

**Step 2: Replace with two separate heads**

In `__init__`, replace the single output MLP with:

```python
# Surface head: standard capacity
self.surface_head = nn.Sequential(
    nn.Linear(hidden_dim, hidden_dim),
    nn.GELU(),
    nn.Linear(hidden_dim, output_channels),
)
# Volume head: double width for extra capacity
self.volume_head = nn.Sequential(
    nn.Linear(hidden_dim, hidden_dim * 2),
    nn.GELU(),
    nn.Linear(hidden_dim * 2, output_channels),
)
```

**Step 3: Route by point type in forward pass**

The data pipeline already separates surface/volume points. In `forward()`, after the transformer trunk:

```python
# transformer_features: [N, hidden_dim] — all points (surface + volume mixed)
# surface_mask: boolean tensor [N] — True for surface points
# volume_mask: boolean tensor [N] — True for volume points

output = torch.zeros(N, output_channels, device=x.device)
output[surface_mask] = self.surface_head(transformer_features[surface_mask])
output[volume_mask] = self.volume_head(transformer_features[volume_mask])
```

Check how the data pipeline provides point type membership — look for how `vol_loss` vs `surface_loss` are computed to find where the split happens.

**Step 4: Run with `--wandb_group af-separate-vol-head`**

```bash
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 --cosine-t-max 50 \
  --grad-clip 1.0 --weight-decay 1e-2 --enable-fourier \
  --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 --ema-decay 0.999 --vol-loss-weight 10.0 \
  --wandb_group af-separate-vol-head
```

Report both `val_primary/surface_mse` and `val_primary/vol_mse` at best checkpoint, and the epoch at which each is achieved.

## Baseline

- **val surface_mse:** 0.000296 at epoch 704
- **val vol_mse:** 0.002039 at epoch 743
- **W&B run:** (PR #3135, EMA=0.999 + vol-weight=10x champion)
- **Reproduce:** `cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --ema-decay 0.999 --vol-loss-weight 10.0`

## Success criteria

- **Primary target:** vol_mse < 0.002039 without surface_mse regression above 0.000296
- **Volume closure goal:** vol_mse < 0.0017 (SpiderSolver benchmark target — currently 1.20x gap)
- Surface must not regress more than 5% (hard constraint per human directive)