### PR TITLE
DrivAerML: ReLU² activation in FFN (Primer-style squared ReLU)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -33,6 +33,37 @@ from core.features import (
 from core.optim import Lion, Lookahead
 
 
+class ReLUSquared(torch.nn.Module):
+    """Squared ReLU activation from Primer (So et al., 2021): relu(x)^2.
+
+    Produces sparser activations than GELU: zero for all negative inputs and
+    quadratically suppressed for small positive inputs.
+    """
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.relu(x).square()
+
+
+def apply_ffn_activation(model: torch.nn.Module, activation: str) -> None:
+    """Replace UpActDownMlp.act in all transformer FFN layers with the chosen activation.
+
+    Only patches the transformer backbone FFN blocks (UpActDownMlp); leaves
+    ZeroInitSurfaceRefinementHead and MLP bias modules untouched.
+    """
+    if activation == "gelu":
+        return
+    from core.architectures.transolver_reference import UpActDownMlp
+
+    if activation == "relu_squared":
+        act_module: torch.nn.Module = ReLUSquared()
+    else:
+        raise ValueError(f"Unknown ffn_activation: {activation!r}. Expected 'gelu' or 'relu_squared'.")
+
+    for module in model.modules():
+        if isinstance(module, UpActDownMlp):
+            module.act = act_module
+
+
 class EMAWithWarmup:
     """EMA with timm-style adaptive decay warmup: min(target, (1+step)/(10+step))."""
 
@@ -169,6 +200,7 @@ class TrainConfig:
     volume_loss_weight: float = 1.0
     save_checkpoint: bool = False
     seed: int = 0
+    ffn_activation: str = "gelu"
 
 
 @dataclass
@@ -1621,6 +1653,7 @@ def main() -> None:
 
     train_loader, val_loaders, test_loaders = build_loaders(config, bundle, num_workers=resolved_num_workers)
     model = build_model(config, bundle).to(device)
+    apply_ffn_activation(model, config.ffn_activation)
     forward_model = torch.compile(model) if config.compile_model and device.type == "cuda" else model
     anp_head = None
     if bundle.spec.name == "tandemfoilset" and config.anp_srf:


### PR DESCRIPTION
## Hypothesis

The DM transformer uses GELU activation in its FFN layers. ReLU² (squared ReLU: `relu(x)²`) was identified in the Primer architecture search (So et al., 2021, "Primer: Searching for Efficient Transformers for Language Modeling") as consistently outperforming GELU across transformer scales. ReLU² produces **sparser activations** than GELU — zero for all negative inputs AND quadratically suppressed for small positive inputs. Sparser activations create more feature-selective representations, which could help the model develop specialized spatial features for different aerodynamic regions rather than diffuse representations across all regions.

This directly targets the systematic spatial bias problem: if the model's FFN activations are too dense/uniform, it conflates spatially distinct regions with similar average features. Sparser activations force sharper feature discrimination.

**Zero throughput penalty** — ReLU² is computationally simpler than GELU (one relu + one multiply vs. the GELU approximation). If anything, it should be marginally faster.

Reference: So et al. (2021), "Primer: Searching for Efficient Transformers for Language Modeling" — found ReLU² in automated architecture search, validated across multiple scales.

## Instructions

All changes in `target/icml2026/train.py`. Champion config unchanged — only modify the FFN activation function.

**Step 1: Define ReLU² activation**

```python
def relu_squared(x):
    return torch.relu(x).square()
```

or equivalently:

```python
def relu_squared(x):
    return F.relu(x) ** 2
```

**Step 2: Replace GELU with ReLU² in the FFN layers**

Find where the FFN (feed-forward network) activation is defined in the transformer layers. It will be something like `nn.GELU()` or `F.gelu(x)`. Replace with the ReLU² function defined above.

Only change the FFN activation inside the transformer layers. Leave any other activations (e.g., in the output MLP, in the Fourier encoding) unchanged.

**Step 3: Run with `--wandb_group dm-relu-squared`**

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --grad-clip 0.5 --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 --ema-decay 0.9995 \
  --wandb_group dm-relu-squared
```

**Verify:** (1) epoch time ≤ baseline (~22s/epoch), (2) training doesn't diverge in first 30 epochs, (3) report best val surface_rel_l2_pct and the epoch at which it occurs.

## Baseline

- **val surface_rel_l2_pct:** 3.833% at epoch 511
- **test surface_rel_l2_pct:** 4.685%
- **W&B run:** ncl1dh88 (eren/dm-ema-9995-gc05)
- **Config:** 4L/512d/8H, AdamW lr=5e-4, T_max=30, EMA=0.9995, gc=0.5, Fourier
- **Reproduce:** `cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --ema-decay 0.9995`