### PR TITLE
AF: volume→surface cross-attention for volume closure

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -167,6 +167,8 @@ class TrainConfig:
     grad_clip: float = 0.0
     grad_accum_steps: int = 1
     volume_loss_weight: float = 1.0
+    vol_cross_attn: bool = False
+    vol_cross_attn_heads: int = 4
     save_checkpoint: bool = False
     seed: int = 0
 
@@ -505,6 +507,88 @@ def cp_panel_prior_index(config: TrainConfig, bundle: DatasetBundle) -> int | No
     return None
 
 
+class VolumeSurfaceCrossAttention(torch.nn.Module):
+    """Cross-attention where volume points attend to surface point representations."""
+
+    def __init__(self, hidden_dim: int, num_heads: int = 4):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = hidden_dim // num_heads
+        self.hidden_dim = hidden_dim
+        self.norm_q = torch.nn.LayerNorm(hidden_dim)
+        self.norm_kv = torch.nn.LayerNorm(hidden_dim)
+        self.q_proj = torch.nn.Linear(hidden_dim, hidden_dim)
+        self.k_proj = torch.nn.Linear(hidden_dim, hidden_dim)
+        self.v_proj = torch.nn.Linear(hidden_dim, hidden_dim)
+        self.out_proj = torch.nn.Linear(hidden_dim, hidden_dim)
+        torch.nn.init.zeros_(self.out_proj.weight)
+        torch.nn.init.zeros_(self.out_proj.bias)
+
+    def forward(
+        self,
+        volume_features: torch.Tensor,
+        surface_features: torch.Tensor,
+        volume_mask: torch.Tensor,
+        surface_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        B = volume_features.shape[0]
+        H, D = self.num_heads, self.head_dim
+        output = torch.zeros_like(volume_features)
+        vol_normed = self.norm_q(volume_features)
+        surf_normed = self.norm_kv(surface_features)
+        for b in range(B):
+            vol_idx = volume_mask[b].bool()
+            surf_idx = surface_mask[b].bool()
+            if not vol_idx.any() or not surf_idx.any():
+                continue
+            vol = vol_normed[b, vol_idx]
+            surf = surf_normed[b, surf_idx]
+            n_vol, n_surf = vol.shape[0], surf.shape[0]
+            q = self.q_proj(vol).view(n_vol, H, D).transpose(0, 1).unsqueeze(0)
+            k = self.k_proj(surf).view(n_surf, H, D).transpose(0, 1).unsqueeze(0)
+            v = self.v_proj(surf).view(n_surf, H, D).transpose(0, 1).unsqueeze(0)
+            attn_out = F.scaled_dot_product_attention(q, k, v)
+            attn_out = attn_out.squeeze(0).transpose(0, 1).contiguous().view(n_vol, self.hidden_dim)
+            output[b, vol_idx] = self.out_proj(attn_out).to(output.dtype)
+        return volume_features + output
+
+
+class VolumeCrossAttentionWrapper(torch.nn.Module):
+    """Wraps a base model and adds volume→surface cross-attention post-processing."""
+
+    def __init__(self, base_model: torch.nn.Module, hidden_dim: int, num_heads: int = 4):
+        super().__init__()
+        self.base = base_model
+        self.vol_surf_cross_attn = VolumeSurfaceCrossAttention(hidden_dim, num_heads)
+        vol_out_dim = base_model.volume_output_dim
+        self.vol_correction = torch.nn.Linear(hidden_dim, vol_out_dim)
+        torch.nn.init.zeros_(self.vol_correction.weight)
+        torch.nn.init.zeros_(self.vol_correction.bias)
+
+    def forward(
+        self,
+        *,
+        surface_x: torch.Tensor,
+        surface_mask: torch.Tensor,
+        volume_x: torch.Tensor | None = None,
+        volume_mask: torch.Tensor | None = None,
+    ) -> dict[str, torch.Tensor | None]:
+        outputs = self.base(
+            surface_x=surface_x,
+            surface_mask=surface_mask,
+            volume_x=volume_x,
+            volume_mask=volume_mask,
+        )
+        vol_hidden = outputs.get("volume_hidden")
+        surf_hidden = outputs.get("surface_hidden")
+        if vol_hidden is not None and surf_hidden is not None and volume_mask is not None:
+            enriched = self.vol_surf_cross_attn(vol_hidden, surf_hidden, volume_mask, surface_mask)
+            correction = self.vol_correction(enriched) * volume_mask.unsqueeze(-1)
+            outputs = dict(outputs)
+            outputs["volume_preds"] = outputs["volume_preds"] + correction
+        return outputs
+
+
 def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
     transolver_kwargs = {
         "n_layers": config.model_layers,
@@ -514,8 +598,9 @@ def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
         "mlp_ratio": config.model_mlp_ratio,
         "slice_num": config.model_slices,
     }
+    model: torch.nn.Module
     if config.model == "reference_transolver":
-        return ReferenceTransolver(
+        model = ReferenceTransolver(
             space_dim=bundle.spec.space_dim,
             surface_input_dim=bundle.spec.surface_input_dim,
             surface_output_dim=bundle.spec.surface_output_dim,
@@ -523,9 +608,9 @@ def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
             volume_output_dim=bundle.spec.volume_output_dim,
             **transolver_kwargs,
         )
-    if config.model == "senpai_transolver":
+    elif config.model == "senpai_transolver":
         prior_idx = cp_panel_prior_index(config, bundle)
-        return SenpaiTransolver(
+        model = SenpaiTransolver(
             space_dim=bundle.spec.space_dim,
             surface_input_dim=bundle.spec.surface_input_dim,
             surface_output_dim=bundle.spec.surface_output_dim,
@@ -539,13 +624,19 @@ def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
             volume_pressure_prior_idx=prior_idx,
             **transolver_kwargs,
         )
-    if config.model == "reference_abupt":
-        return ABUPTReference(
+    elif config.model == "reference_abupt":
+        model = ABUPTReference(
             space_dim=bundle.spec.space_dim,
             surface_output_dim=bundle.spec.surface_output_dim,
             volume_output_dim=bundle.spec.volume_output_dim,
         )
-    raise ValueError(f"Unknown model: {config.model}")
+    else:
+        raise ValueError(f"Unknown model: {config.model}")
+    if config.vol_cross_attn and bundle.spec.volume_output_dim > 0:
+        model = VolumeCrossAttentionWrapper(
+            model, hidden_dim=config.model_hidden_dim, num_heads=config.vol_cross_attn_heads,
+        )
+    return model
 
 
 def build_optimizer(params, config: TrainConfig):


### PR DESCRIPTION
## Hypothesis

Volume prediction is harder because volume points are spatially distant from the geometry surface where aerodynamic information originates. The current model treats surface and volume points identically through the same transformer trunk — volume points must implicitly learn to leverage surface information via self-attention. But in a 2-layer transformer with mixed surface+volume tokens, this implicit path may be too weak.

We add an explicit **cross-attention layer** after the transformer trunk where **volume points attend to surface point representations**. This gives volume predictions direct access to surface-level aerodynamic information — physically motivated because volume flow fields in incompressible flow are determined by surface boundary conditions (potential flow theory).

Surface points bypass the cross-attention and go directly to the output MLP (their predictions are already strong). Only volume points benefit from the enriched representation.

## Instructions

All changes in `target/icml2026/train.py`. Champion architecture and hyperparameters unchanged — only add the cross-attention post-processing.

**Step 1: Add cross-attention module to the model**

```python
class VolumeSurfaceCrossAttention(nn.Module):
    def __init__(self, hidden_dim, num_heads=4):
        super().__init__()
        self.cross_attn = nn.MultiheadAttention(
            embed_dim=hidden_dim,
            num_heads=num_heads,
            batch_first=True,
        )
        self.norm = nn.LayerNorm(hidden_dim)

    def forward(self, volume_features, surface_features):
        # volume_features: [N_vol, hidden_dim] — queries
        # surface_features: [N_surf, hidden_dim] — keys/values
        # Add batch dimension for nn.MultiheadAttention
        vol = volume_features.unsqueeze(0)   # [1, N_vol, D]
        surf = surface_features.unsqueeze(0)  # [1, N_surf, D]
        attn_out, _ = self.cross_attn(vol, surf, surf)  # [1, N_vol, D]
        # Residual connection + LayerNorm
        out = self.norm(volume_features + attn_out.squeeze(0))
        return out  # [N_vol, hidden_dim]
```

**Step 2: Integrate after transformer trunk**

In `__init__`:
```python
self.vol_surf_cross_attn = VolumeSurfaceCrossAttention(
    hidden_dim=256, num_heads=4
)
```

In `forward()`, after the transformer trunk produces features for all points:
```python
# all_features: [N_total, hidden_dim] from transformer trunk
# Separate surface and volume features (check how existing code tracks point types)
surface_features = all_features[surface_mask]  # [N_surf, D]
volume_features = all_features[volume_mask]    # [N_vol, D]

# Enrich volume with surface context
volume_features = self.vol_surf_cross_attn(volume_features, surface_features)

# Recombine for output MLP (or apply separate heads)
all_features[volume_mask] = volume_features
output = self.output_mlp(all_features)
```

Check how the data pipeline separates surface/volume points — look at how `vol_loss` vs `surface_loss` are computed.

**Step 3: Run with `--wandb_group af-vol-cross-attention`**

```bash
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 --cosine-t-max 50 \
  --grad-clip 1.0 --weight-decay 1e-2 --enable-fourier \
  --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 --ema-decay 0.999 --vol-loss-weight 10.0 \
  --wandb_group af-vol-cross-attention
```

**Report:** both surface_mse and vol_mse at best checkpoint, epoch counts, throughput (the cross-attention is one extra attention layer on volume points only — expect modest overhead, should still complete 600+ epochs).

## Baseline

- **val surface_mse:** 0.000296 at epoch 704
- **val vol_mse:** 0.002039 at epoch 743
- **W&B run:** PR #3135, EMA=0.999 + vol-weight=10x champion
- **Reproduce:** `cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --ema-decay 0.999 --vol-loss-weight 10.0`

## Success criteria

- **Primary:** vol_mse < 0.002039 without surface_mse regression above 0.000320
- **Stretch:** vol_mse < 0.0017 (SpiderSolver benchmark target)
- Surface is a hard constraint — even large vol gains are rejected if surface regresses significantly