### PR TITLE
URGENT: harness patches for last-ditch benchmark push

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -10,6 +10,7 @@ import json
 import math
 import os
 import random
+import sys
 import time
 from contextlib import nullcontext
 from dataclasses import asdict, dataclass
@@ -30,7 +31,7 @@ from core.features import (
     compute_vortex_panel_velocity,
     compute_wake_deficit_features,
 )
-from core.optim import Lion, Lookahead
+from core.optim import EMA as FixedEMA, Lion, Lookahead
 
 
 class EMAWithWarmup:
@@ -168,6 +169,14 @@ class TrainConfig:
     grad_accum_steps: int = 1
     volume_loss_weight: float = 1.0
     save_checkpoint: bool = False
+    load_checkpoint: str = ""
+    eval_interval: int = 1
+    skip_update_grad_norm: float = 0.0
+    ema_mode: str = "warmup"
+    ema_start_step: int = 50
+    kill_if_best_val_above: str = ""
+    kill_if_no_improvement: str = ""
+    kill_if_grad_nonfinite_steps: int = 0
     seed: int = 0
 
 
@@ -1277,6 +1286,7 @@ def train_one_epoch(
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
     volume_loss_weight: float = 1.0,
+    skip_update_grad_norm: float = 0.0,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1345,18 +1355,32 @@ def train_one_epoch(
         if anp_head is not None:
             all_params += list(anp_head.parameters())
         grad_norm = torch.nn.utils.clip_grad_norm_(all_params, max_norm=grad_clip if grad_clip > 0 else float("inf"))
+        grad_norm_val = float(grad_norm)
         running.setdefault("grad_norm_mean", 0.0)
-        running["grad_norm_mean"] += float(grad_norm)
-        if grad_clip > 0 and float(grad_norm) > grad_clip:
+        running["grad_norm_mean"] += grad_norm_val
+        if grad_clip > 0 and grad_norm_val > grad_clip:
             running.setdefault("grad_clip_events", 0.0)
             running["grad_clip_events"] += 1.0
-        optimizer.step()
+        if not math.isfinite(grad_norm_val):
+            running.setdefault("grad_nonfinite", 0.0)
+            running["grad_nonfinite"] += 1.0
+        skip_step = skip_update_grad_norm > 0 and (not math.isfinite(grad_norm_val) or grad_norm_val > skip_update_grad_norm)
+        if skip_step:
+            optimizer.zero_grad(set_to_none=True)
+            running.setdefault("skipped_updates", 0.0)
+            running["skipped_updates"] += 1.0
+        else:
+            optimizer.step()
         if scheduler is not None:
             scheduler.step()
-        if ema is not None:
+        if ema is not None and not skip_step:
             ema.update(model)
-            running["ema_decay_actual"] = min(ema.decay, (1 + ema.step_counter) / (10 + ema.step_counter))
-        if anp_head is not None and anp_ema is not None:
+        if ema is not None:
+            if isinstance(ema, FixedEMA):
+                running["ema_decay_actual"] = ema.decay if ema.step_counter >= ema.start_step else 0.0
+            else:
+                running["ema_decay_actual"] = min(ema.decay, (1 + ema.step_counter) / (10 + ema.step_counter))
+        if anp_head is not None and anp_ema is not None and not skip_step:
             anp_ema.update(anp_head)
         running["loss"] += accum_loss / micro_count
         micro_batches_total += micro_count
@@ -1638,8 +1662,18 @@ def main() -> None:
         base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
         scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
 
-    ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
-    anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
+    if not config.use_ema:
+        ema = None
+    elif config.ema_mode == "fixed":
+        ema = FixedEMA(model, decay=config.ema_decay, start_step=config.ema_start_step)
+    else:
+        ema = EMAWithWarmup(model, decay=config.ema_decay)
+    if not config.use_ema or anp_head is None:
+        anp_ema = None
+    elif config.ema_mode == "fixed":
+        anp_ema = FixedEMA(anp_head, decay=config.ema_decay, start_step=config.ema_start_step)
+    else:
+        anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay)
     history: list[dict[str, float]] = []
     best_epoch: int | None = None
     best_val_primary_metric_name = primary_metric_key(bundle, phase="val")
@@ -1672,8 +1706,31 @@ def main() -> None:
             tags=[config.dataset, config.model],
         )
 
+    if config.load_checkpoint:
+        ckpt = torch.load(config.load_checkpoint, map_location=device, weights_only=True)
+        state = ckpt.get("model_state_dict", ckpt)
+        model.load_state_dict(state, strict=False)
+        print(f"[LoadCheckpoint] Loaded from {config.load_checkpoint}")
+        for phase, loaders in [("val", val_loaders), ("test", test_loaders)]:
+            if not loaders:
+                continue
+            metrics = evaluate_phase_metrics(
+                bundle=bundle, config=config, forward_model=forward_model,
+                anp_head=anp_head, loaders=loaders, transform=transform,
+                metric_transform=metric_transform, device=device, phase=phase,
+            )
+            print(json.dumps({f"load_checkpoint_{phase}": metrics}, sort_keys=True), flush=True)
+            if run is not None:
+                wandb.log(metrics)
+                run.summary.update(metrics)
+        if run is not None:
+            wandb.finish()
+        return
+
     start_time = time.monotonic()
     timeout_seconds = None if not timeout_env else float(timeout_env) * 60.0
+    grad_nonfinite_count = 0
+    last_eval_epoch = 0
 
     for epoch in range(1, config.epochs + 1):
         if timeout_seconds is not None and epoch > 1 and (time.monotonic() - start_time) >= timeout_seconds:
@@ -1694,53 +1751,109 @@ def main() -> None:
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
             volume_loss_weight=config.volume_loss_weight,
+            skip_update_grad_norm=config.skip_update_grad_norm,
         )
 
-        if ema is not None:
-            ema.store(model)
-            ema.copy_to(model)
-        if anp_head is not None and anp_ema is not None:
-            anp_ema.store(anp_head)
-            anp_ema.copy_to(anp_head)
+        grad_nonfinite_count += int(train_metrics.get("grad_nonfinite", 0))
 
-        eval_metrics = evaluate_phase_metrics(
-            bundle=bundle,
-            config=config,
-            forward_model=forward_model,
-            anp_head=anp_head,
-            loaders=val_loaders,
-            transform=transform,
-            metric_transform=metric_transform,
-            device=device,
-            phase="val",
-        )
-
-        current_primary_metric = eval_metrics.get(best_val_primary_metric_name)
-        if current_primary_metric is not None and (
-            best_val_primary_metric is None or current_primary_metric < best_val_primary_metric
-        ):
-            best_epoch = epoch
-            best_val_primary_metric = current_primary_metric
-            best_val_metrics = dict(eval_metrics)
-            best_model_state = snapshot_module_state(model)
-            best_anp_state = snapshot_module_state(anp_head)
-
-        current_val = eval_metrics.get(val_primary_key)
-        if current_val is not None and current_val < best_val_metric:
-            best_val_metric = current_val
-            best_epoch = epoch
-            best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
-            if anp_head is not None:
-                best_anp_state = {k: v.cpu().clone() for k, v in anp_head.state_dict().items()}
+        should_eval = (epoch == 1 or epoch % config.eval_interval == 0 or epoch == config.epochs)
+        if should_eval:
             if ema is not None:
-                best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
-            if anp_ema is not None:
-                best_anp_ema_shadow = {k: v.cpu().clone() for k, v in anp_ema.shadow.items()}
+                ema.store(model)
+                ema.copy_to(model)
+            if anp_head is not None and anp_ema is not None:
+                anp_ema.store(anp_head)
+                anp_ema.copy_to(anp_head)
 
-        if ema is not None:
-            ema.restore(model)
-        if anp_head is not None and anp_ema is not None:
-            anp_ema.restore(anp_head)
+            eval_metrics = evaluate_phase_metrics(
+                bundle=bundle,
+                config=config,
+                forward_model=forward_model,
+                anp_head=anp_head,
+                loaders=val_loaders,
+                transform=transform,
+                metric_transform=metric_transform,
+                device=device,
+                phase="val",
+            )
+
+            current_primary_metric = eval_metrics.get(best_val_primary_metric_name)
+            if current_primary_metric is not None and (
+                best_val_primary_metric is None or current_primary_metric < best_val_primary_metric
+            ):
+                best_epoch = epoch
+                best_val_primary_metric = current_primary_metric
+                best_val_metrics = dict(eval_metrics)
+                best_model_state = snapshot_module_state(model)
+                best_anp_state = snapshot_module_state(anp_head)
+
+            current_val = eval_metrics.get(val_primary_key)
+            if current_val is not None and current_val < best_val_metric:
+                best_val_metric = current_val
+                best_epoch = epoch
+                best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
+                if anp_head is not None:
+                    best_anp_state = {k: v.cpu().clone() for k, v in anp_head.state_dict().items()}
+                if ema is not None:
+                    best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
+                if anp_ema is not None:
+                    best_anp_ema_shadow = {k: v.cpu().clone() for k, v in anp_ema.shadow.items()}
+
+            kill_reason = None
+            if config.kill_if_best_val_above and best_val_metric is not None:
+                gate_epoch_str, gate_threshold_str = config.kill_if_best_val_above.split(":")
+                gate_epoch, gate_threshold = int(gate_epoch_str), float(gate_threshold_str)
+                if epoch >= gate_epoch and best_val_metric > gate_threshold:
+                    kill_reason = (
+                        f"best_val {best_val_metric:.4f} exceeded kill gate {gate_threshold} "
+                        f"after epoch {gate_epoch}"
+                    )
+            if kill_reason is None and config.kill_if_no_improvement and best_epoch is not None:
+                patience_str, min_delta_str = config.kill_if_no_improvement.split(":")
+                patience, min_delta = int(patience_str), float(min_delta_str)
+                if epoch - best_epoch >= patience:
+                    kill_reason = (
+                        f"no improvement for {epoch - best_epoch} epochs "
+                        f"(patience={patience}, min_delta={min_delta})"
+                    )
+            if kill_reason is None and config.kill_if_grad_nonfinite_steps > 0:
+                if grad_nonfinite_count >= config.kill_if_grad_nonfinite_steps:
+                    kill_reason = (
+                        f"grad nonfinite for {grad_nonfinite_count} cumulative steps "
+                        f"(threshold={config.kill_if_grad_nonfinite_steps})"
+                    )
+
+            if ema is not None:
+                ema.restore(model)
+            if anp_head is not None and anp_ema is not None:
+                anp_ema.restore(anp_head)
+
+            if kill_reason is not None:
+                wandb_info = f"group={config.wandb_group or 'none'} name={config.wandb_name or 'none'}"
+                kill_msg = (
+                    f"EXPERIMENT_KILLED: dataset={config.dataset} {wandb_info} "
+                    f"epoch={epoch} best_val={best_val_metric:.4f} "
+                    f"best_epoch={best_epoch} reason={kill_reason}"
+                )
+                epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
+                epoch_metrics["best_val_metric"] = best_val_metric
+                epoch_metrics["best_epoch"] = float(best_epoch)
+                epoch_metrics["kill_reason"] = kill_reason
+                history.append(epoch_metrics)
+                if run is not None:
+                    wandb.log(epoch_metrics, step=epoch)
+                    run.summary["kill_reason"] = kill_reason
+                    run.summary["kill_epoch"] = epoch
+                    run.finish()
+                kill_output_dir = Path(config.output_dir)
+                kill_output_dir.mkdir(parents=True, exist_ok=True)
+                (kill_output_dir / "KILLED.md").write_text(kill_msg + "\n")
+                print(kill_msg, file=sys.stderr, flush=True)
+                raise RuntimeError(kill_msg)
+
+            last_eval_epoch = epoch
+        else:
+            eval_metrics = {}
 
         epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
         epoch_metrics["best_val_metric"] = best_val_metric
@@ -1752,6 +1865,50 @@ def main() -> None:
             run.summary["best_epoch"] = best_epoch
             run.summary["best_val_metric"] = best_val_metric
         print(json.dumps(epoch_metrics, sort_keys=True), flush=True)
+
+    if config.eval_interval > 1 and history and last_eval_epoch < int(history[-1]["epoch"]):
+        final_trained_epoch = int(history[-1]["epoch"])
+        if ema is not None:
+            ema.store(model)
+            ema.copy_to(model)
+        if anp_head is not None and anp_ema is not None:
+            anp_ema.store(anp_head)
+            anp_ema.copy_to(anp_head)
+        eval_metrics = evaluate_phase_metrics(
+            bundle=bundle, config=config, forward_model=forward_model,
+            anp_head=anp_head, loaders=val_loaders, transform=transform,
+            metric_transform=metric_transform, device=device, phase="val",
+        )
+        current_primary_metric = eval_metrics.get(best_val_primary_metric_name)
+        if current_primary_metric is not None and (
+            best_val_primary_metric is None or current_primary_metric < best_val_primary_metric
+        ):
+            best_epoch = final_trained_epoch
+            best_val_primary_metric = current_primary_metric
+            best_val_metrics = dict(eval_metrics)
+            best_model_state = snapshot_module_state(model)
+            best_anp_state = snapshot_module_state(anp_head)
+        current_val = eval_metrics.get(val_primary_key)
+        if current_val is not None and current_val < best_val_metric:
+            best_val_metric = current_val
+            best_epoch = final_trained_epoch
+            best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
+            if anp_head is not None:
+                best_anp_state = {k: v.cpu().clone() for k, v in anp_head.state_dict().items()}
+            if ema is not None:
+                best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
+            if anp_ema is not None:
+                best_anp_ema_shadow = {k: v.cpu().clone() for k, v in anp_ema.shadow.items()}
+        if ema is not None:
+            ema.restore(model)
+        if anp_head is not None and anp_ema is not None:
+            anp_ema.restore(anp_head)
+        final_eval_log = {"epoch": float(final_trained_epoch), **eval_metrics,
+                          "best_val_metric": best_val_metric, "best_epoch": float(best_epoch)}
+        history[-1].update(eval_metrics)
+        if run is not None:
+            wandb.log(final_eval_log, step=final_trained_epoch)
+        print(json.dumps({"final_epoch_eval": final_eval_log}, sort_keys=True), flush=True)
 
     if best_epoch is not None:
         print(
@@ -1867,15 +2024,36 @@ def main() -> None:
             torch.save(terminal_model_state, output_dir / f"{config.dataset}_{config.model}.pt")
         else:
             torch.save(model.state_dict(), output_dir / f"{config.dataset}_{config.model}.pt")
+        best_ckpt_path = output_dir / f"{config.dataset}_{config.model}_best.pt"
         if best_model_state is not None:
-            torch.save(best_model_state, output_dir / f"{config.dataset}_{config.model}_best.pt")
+            ckpt_payload = {
+                "model_state_dict": best_model_state,
+                "epoch": best_epoch,
+                "val_metric": best_val_metric,
+                "val_primary_metric_name": best_val_primary_metric_name,
+                "val_primary_metric": best_val_primary_metric,
+                "config": {k: v for k, v in vars(config).items() if not k.startswith("_")},
+            }
+            if best_anp_state is not None:
+                ckpt_payload["anp_state_dict"] = best_anp_state
+            if best_ema_shadow is not None:
+                ckpt_payload["ema_shadow"] = best_ema_shadow
+            if best_anp_ema_shadow is not None:
+                ckpt_payload["anp_ema_shadow"] = best_anp_ema_shadow
+            torch.save(ckpt_payload, best_ckpt_path)
+            print(f"[SaveCheckpoint] Best model saved to {best_ckpt_path} (epoch={best_epoch}, val={best_val_metric:.6f})")
+            if run is not None:
+                artifact = wandb.Artifact(
+                    f"best-checkpoint-{config.dataset}", type="model",
+                    metadata={"epoch": best_epoch, "val_metric": best_val_metric},
+                )
+                artifact.add_file(str(best_ckpt_path))
+                run.log_artifact(artifact)
         if anp_head is not None:
             if terminal_anp_state is not None:
                 torch.save(terminal_anp_state, output_dir / f"{config.dataset}_{config.model}_anp.pt")
             else:
                 torch.save(anp_head.state_dict(), output_dir / f"{config.dataset}_{config.model}_anp.pt")
-            if best_anp_state is not None:
-                torch.save(best_anp_state, output_dir / f"{config.dataset}_{config.model}_anp_best.pt")
     if run is not None:
         run.finish()
 

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1677,17 +1677,14 @@ def main() -> None:
     history: list[dict[str, float]] = []
     best_epoch: int | None = None
     best_val_primary_metric_name = primary_metric_key(bundle, phase="val")
-    best_val_primary_metric: float | None = None
-    best_val_metrics: dict[str, float] = {}
-    best_model_state: dict[str, torch.Tensor] | None = None
-    best_anp_state: dict[str, torch.Tensor] | None = None
-
     if bundle.spec.name == "tandemfoilset":
         val_primary_key = "val_primary/surface_pressure_mae"
     else:
         val_primary_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
-    best_epoch = 0
+    best_val_primary_metric: float | None = None
+    best_val_metrics: dict[str, float] = {}
+    best_epoch: int = 0
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
     best_ema_shadow: dict[str, torch.Tensor] | None = None
@@ -1731,6 +1728,11 @@ def main() -> None:
     timeout_seconds = None if not timeout_env else float(timeout_env) * 60.0
     grad_nonfinite_count = 0
     last_eval_epoch = 0
+    kill_patience, kill_min_delta = 0, 0.0
+    kill_ref_metric, kill_ref_epoch = float("inf"), 0
+    if config.kill_if_no_improvement:
+        _p, _d = config.kill_if_no_improvement.split(":")
+        kill_patience, kill_min_delta = int(_p), float(_d)
 
     for epoch in range(1, config.epochs + 1):
         if timeout_seconds is not None and epoch > 1 and (time.monotonic() - start_time) >= timeout_seconds:
@@ -1777,27 +1779,22 @@ def main() -> None:
                 phase="val",
             )
 
-            current_primary_metric = eval_metrics.get(best_val_primary_metric_name)
-            if current_primary_metric is not None and (
-                best_val_primary_metric is None or current_primary_metric < best_val_primary_metric
-            ):
-                best_epoch = epoch
-                best_val_primary_metric = current_primary_metric
-                best_val_metrics = dict(eval_metrics)
-                best_model_state = snapshot_module_state(model)
-                best_anp_state = snapshot_module_state(anp_head)
-
             current_val = eval_metrics.get(val_primary_key)
             if current_val is not None and current_val < best_val_metric:
                 best_val_metric = current_val
+                best_val_primary_metric = current_val
+                best_val_metrics = dict(eval_metrics)
                 best_epoch = epoch
                 best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
-                if anp_head is not None:
-                    best_anp_state = {k: v.cpu().clone() for k, v in anp_head.state_dict().items()}
+                best_anp_state = snapshot_module_state(anp_head)
                 if ema is not None:
                     best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
                 if anp_ema is not None:
                     best_anp_ema_shadow = {k: v.cpu().clone() for k, v in anp_ema.shadow.items()}
+
+            if current_val is not None and current_val < kill_ref_metric - kill_min_delta:
+                kill_ref_metric = current_val
+                kill_ref_epoch = epoch
 
             kill_reason = None
             if config.kill_if_best_val_above and best_val_metric is not None:
@@ -1808,13 +1805,11 @@ def main() -> None:
                         f"best_val {best_val_metric:.4f} exceeded kill gate {gate_threshold} "
                         f"after epoch {gate_epoch}"
                     )
-            if kill_reason is None and config.kill_if_no_improvement and best_epoch is not None:
-                patience_str, min_delta_str = config.kill_if_no_improvement.split(":")
-                patience, min_delta = int(patience_str), float(min_delta_str)
-                if epoch - best_epoch >= patience:
+            if kill_reason is None and config.kill_if_no_improvement:
+                if epoch - kill_ref_epoch >= kill_patience:
                     kill_reason = (
-                        f"no improvement for {epoch - best_epoch} epochs "
-                        f"(patience={patience}, min_delta={min_delta})"
+                        f"no significant improvement (>{kill_min_delta}) for "
+                        f"{epoch - kill_ref_epoch} epochs (patience={kill_patience})"
                     )
             if kill_reason is None and config.kill_if_grad_nonfinite_steps > 0:
                 if grad_nonfinite_count >= config.kill_if_grad_nonfinite_steps:
@@ -1879,22 +1874,14 @@ def main() -> None:
             anp_head=anp_head, loaders=val_loaders, transform=transform,
             metric_transform=metric_transform, device=device, phase="val",
         )
-        current_primary_metric = eval_metrics.get(best_val_primary_metric_name)
-        if current_primary_metric is not None and (
-            best_val_primary_metric is None or current_primary_metric < best_val_primary_metric
-        ):
-            best_epoch = final_trained_epoch
-            best_val_primary_metric = current_primary_metric
-            best_val_metrics = dict(eval_metrics)
-            best_model_state = snapshot_module_state(model)
-            best_anp_state = snapshot_module_state(anp_head)
         current_val = eval_metrics.get(val_primary_key)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
+            best_val_primary_metric = current_val
+            best_val_metrics = dict(eval_metrics)
             best_epoch = final_trained_epoch
             best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
-            if anp_head is not None:
-                best_anp_state = {k: v.cpu().clone() for k, v in anp_head.state_dict().items()}
+            best_anp_state = snapshot_module_state(anp_head)
             if ema is not None:
                 best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
             if anp_ema is not None:


### PR DESCRIPTION
## Priority: CRITICAL — implement before all other work

Per issue #3283, these harness patches must land ASAP to enable the final benchmark push. All changes in `target/icml2026/train.py`.

## Patch 1: --load-checkpoint eval-only path

Add CLI flag:
```
--load-checkpoint <path>
```

Behavior:
- Load model state dict from the checkpoint file
- Load ANP state if present
- Run val and test evaluation passes
- Exit without any training
- Respect absence of `--max-eval-batches` for full paper-facing metrics
- Print results to stdout and log to W&B

This is the shortest path to full-eval of existing best checkpoints without retraining.

## Patch 2: --eval-interval N

Add CLI flag:
```
--eval-interval N  (default: 1, meaning every epoch as current behavior)
```

Behavior:
- Train every epoch as normal
- Only run validation/test eval on epoch 1 and every N epochs
- ALWAYS evaluate at the final epoch
- Save best checkpoint only on evaluated epochs
- For DrivAerML, use `--eval-interval 5` or `--eval-interval 10` with `--max-eval-batches 200` for fast steering, then full-eval finalists

## Patch 3: --ema-mode fixed|warmup with --ema-start-step

Add CLI flags:
```
--ema-mode fixed    (use core.optim.EMA with fixed decay from start)
--ema-mode warmup   (use current EMAWithWarmup behavior — this is the default)
--ema-start-step 50 (step at which to initialize EMA, only for fixed mode)
```

Context: The best DrivAerML run (ncl1dh88, 3.833%) came from the older fixed-decay EMA path. The current codebase uses EMAWithWarmup, and reruns on the newer path appear weaker or less stable. We need to restore the fixed-EMA option.

Implementation: reuse `core.optim.EMA` for fixed mode. Default to `warmup` for backward compatibility.

## Patch 4: --skip-update-grad-norm threshold

Add CLI flag:
```
--skip-update-grad-norm <threshold>  (e.g., 50, 100, 300)
```

Behavior:
- After loss.backward(), compute pre-clipping gradient norm
- If grad norm is non-finite OR above the threshold:
  - Zero all gradients
  - Skip optimizer.step()
  - Skip EMA update
  - Log `skipped_updates += 1` to W&B
  - Let the LR scheduler step normally (or test both variants)
- Otherwise proceed normally

This directly targets the known DrivAerML failure mode: rare catastrophic gradient spikes around late training (faye saw ep417, champion survived to ep517 but others crash earlier).

## Patch 5: --save-checkpoint (mandatory on all final-wave runs)

Add CLI flag:
```
--save-checkpoint  (saves best checkpoint based on val metric)
```

Behavior:
- After each eval pass, if current val metric improves on best, save model state dict to `drivaerml_senpai_transolver_best.pt` (or dataset-appropriate name)
- Also save to W&B artifacts for later retrieval
- Include epoch number, val metric, and config in the checkpoint

## Patch 6: Kill gates

Add CLI flags:
```
--kill-if-best-val-above EPOCH:THRESHOLD
--kill-if-metric-above METRIC:EPOCH:THRESHOLD
--kill-if-nonfinite-metric
--kill-if-grad-nonfinite-steps N
--kill-if-no-improvement EPOCHS:MIN_DELTA
```

Behavior:
- Evaluate gates immediately after each validation pass
- Use dataset primary metric, lower-is-better
- Before exiting: log kill reason to W&B summary, write `KILLED.md` in output dir, print to stderr
- Exit by raising `RuntimeError` with message starting `EXPERIMENT_KILLED:`
- Message must include: dataset, W&B run/group/name, epoch, current metric, best metric, threshold, reason

Example:
```
EXPERIMENT_KILLED: dataset=drivaerml group=dm-last-ditch epoch=104 best_val_primary/surface_rel_l2_pct=6.03 exceeded kill gate 5.50 after epoch 100. Advisor action: close PR and reassign.
```

## Implementation order

Implement in this order (each is independently useful):
1. `--save-checkpoint` (simplest, enables everything else)
2. `--load-checkpoint` (enables full-eval of existing checkpoints)
3. `--eval-interval` (enables fast training with periodic eval)
4. `--skip-update-grad-norm` (enables stable long training)
5. `--ema-mode` (enables champion recovery)
6. Kill gates (enables automatic experiment triage)

After implementing each patch, commit incrementally so we can merge partial progress if needed.

## Baseline

This is infrastructure — no metric comparison needed. Submit for review as soon as patches 1-5 are working. Kill gates (patch 6) can follow in a separate commit if time is tight.

## W&B group: dm-harness-patches