### PR TITLE
DrivAerML: champion recovery seed=0 no-compile (ncl1dh88 replica)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -168,6 +168,8 @@ class TrainConfig:
     grad_accum_steps: int = 1
     volume_loss_weight: float = 1.0
     save_checkpoint: bool = False
+    load_checkpoint: str = ""
+    eval_only: bool = False
     seed: int = 0
 
 
@@ -1621,6 +1623,12 @@ def main() -> None:
 
     train_loader, val_loaders, test_loaders = build_loaders(config, bundle, num_workers=resolved_num_workers)
     model = build_model(config, bundle).to(device)
+
+    if config.load_checkpoint:
+        ckpt = torch.load(config.load_checkpoint, map_location=device, weights_only=True)
+        model.load_state_dict(ckpt)
+        print(f"Loaded checkpoint from {config.load_checkpoint}", flush=True)
+
     forward_model = torch.compile(model) if config.compile_model and device.type == "cuda" else model
     anp_head = None
     if bundle.spec.name == "tandemfoilset" and config.anp_srf:
@@ -1628,6 +1636,40 @@ def main() -> None:
             hidden_dim=getattr(model, "n_hidden", 192),
             output_dim=bundle.spec.surface_output_dim,
         ).to(device)
+
+    if config.eval_only:
+        if not test_loaders:
+            print("No test loaders available for eval-only mode", flush=True)
+            return
+        model.eval()
+        with torch.no_grad():
+            test_metrics = evaluate_phase_metrics(
+                bundle=bundle,
+                config=config,
+                forward_model=forward_model,
+                anp_head=anp_head,
+                loaders=test_loaders,
+                transform=transform,
+                metric_transform=metric_transform,
+                device=device,
+                phase="test",
+            )
+        run = None
+        if config.wandb_name:
+            run_config = asdict(config)
+            run = wandb.init(
+                project=os.getenv("WANDB_PROJECT", "senpai-v1"),
+                entity=os.getenv("WANDB_ENTITY"),
+                name=config.wandb_name,
+                group=config.wandb_group or None,
+                config=run_config,
+                tags=[config.dataset, config.model, "eval-only"],
+            )
+            wandb.log(test_metrics, step=0)
+            run.summary.update(test_metrics)
+            run.finish()
+        print(json.dumps({"eval_only_test_metrics": test_metrics}, sort_keys=True), flush=True)
+        return
 
     params = list(model.parameters())
     if anp_head is not None:


### PR DESCRIPTION
## Hypothesis
Exact replica of ncl1dh88 with --no-compile-model and SENPAI_TIMEOUT_MINUTES=600. The original run used torch.compile which can introduce non-determinism and instability. This is the most direct champion reproduction — if it reaches or beats 3.833% val, we have a stable foundation for further improvements.

## Bucket
A — Champion Recovery / Reproducibility

## Command
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=600 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --ema-decay 0.9995 --no-compile-model --wandb_group dm-champion-recovery
```

## Kill Condition
If best truncated val still above 8% after epoch 120, kill.

## Baseline
- **val surface_rel_l2_pct:** 3.833% at epoch 511
- **test surface_rel_l2_pct:** 4.685%
- **W&B run:** ncl1dh88 (eren/dm-ema-9995-gc05)
- **Full-eval test evidence:** ~4.39-4.50% (see issue #3283)
- **Target:** <3.71% (AB-UPT benchmark)

## Expected outcome
With seed=0 (same as original), this should most closely reproduce ncl1dh88. If val drops below 3.833%, that indicates torch.compile was hurting stability. If it matches, we have a clean no-compile baseline for all further experiments.