### PR TITLE
DrivAerML: gradient-spike-safe champion gc=0.25

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1292,6 +1292,7 @@ def train_one_epoch(
     if anp_head is not None:
         anp_head.train()
     running = {"loss": 0.0}
+    grad_norms_list: list[float] = []
     steps = 0
     micro_batches_total = 0
     batches = loader if max_batches <= 0 else itertools.islice(loader, max_batches)
@@ -1358,6 +1359,8 @@ def train_one_epoch(
         grad_norm_val = float(grad_norm)
         running.setdefault("grad_norm_mean", 0.0)
         running["grad_norm_mean"] += grad_norm_val
+        if math.isfinite(grad_norm_val):
+            grad_norms_list.append(grad_norm_val)
         if grad_clip > 0 and grad_norm_val > grad_clip:
             running.setdefault("grad_clip_events", 0.0)
             running["grad_clip_events"] += 1.0
@@ -1389,6 +1392,11 @@ def train_one_epoch(
     running["loss"] /= max(steps, 1)
     if "grad_norm_mean" in running:
         running["grad_norm_mean"] /= max(steps, 1)
+    if grad_norms_list:
+        grad_norms_sorted = sorted(grad_norms_list)
+        running["grad_norm_max"] = grad_norms_sorted[-1]
+        p99_idx = min(int(len(grad_norms_sorted) * 0.99), len(grad_norms_sorted) - 1)
+        running["grad_norm_p99"] = grad_norms_sorted[p99_idx]
     running["train_steps"] = float(steps)
     running["micro_batches"] = float(micro_batches_total)
     if scheduler is not None:


### PR DESCRIPTION
## Hypothesis
Tighter gradient clipping (gc=0.25 vs champion gc=0.5) to suppress the gradient spikes that appear to cause late-training collapses. The champion run (ncl1dh88) shows occasional gradient spikes — halving the clip threshold should allow the model to train deeper into the schedule without catastrophic updates.

If --skip-update-grad-norm is available from #3284, also add --skip-update-grad-norm 100 to skip the weight update on any step where the raw grad norm exceeds 100.

## Bucket
D — Gradient Safety

## Command
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=600 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.25 --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --ema-decay 0.9995 --no-compile-model --wandb_group dm-gradient-safe
```

## Kill Condition
If val is clearly worse than 3.833% by epoch 200 with no sign of catching up, kill.

## Baseline
- **val surface_rel_l2_pct:** 3.833% at epoch 511
- **test surface_rel_l2_pct:** 4.685%
- **W&B run:** ncl1dh88 (eren/dm-ema-9995-gc05)
- **Full-eval test evidence:** ~4.39-4.50% (see issue #3283)
- **Target:** <3.71% (AB-UPT benchmark)

## Expected outcome
If gradient spikes are the primary instability source, gc=0.25 should allow the model to reach lower val loss at late epochs. Report gradient norm statistics (mean, max, p99) alongside val metrics.