### PR TITLE
DrivAerML: Breakout 3 — domain-normalized volume auxiliary loss

### DIFF
--- a/target/icml2026/core/features.py
+++ b/target/icml2026/core/features.py
@@ -272,21 +272,26 @@ def augment_case_sample(
 
     surface_x = sample.surface_x
     volume_x = sample.volume_x
-    full_x = torch.cat([surface_x, volume_x], dim=0) if volume_x is not None else surface_x
 
-    appended_full: list[torch.Tensor] = []
-    if enable_fourier:
-        full_x = append_fourier_features(full_x, sample.space_dim, fourier_freqs)
-    if enable_cp_panel and sample.dataset_name == "airfrans":
-        appended_full.append(_compute_airfrans_cp_panel(full_x))
-    if enable_wake_deficit and sample.dataset_name.startswith("tandemfoilset"):
-        appended_full.append(_compute_tandem_wake_deficit(full_x, include_angle=enable_wake_angle))
-    if appended_full:
-        full_x = torch.cat([full_x, *appended_full], dim=1)
-
-    num_surface = sample.surface_x.shape[0]
-    surface_x = full_x[:num_surface]
-    volume_x = full_x[num_surface:] if sample.volume_x is not None else None
+    can_concat = volume_x is None or surface_x.shape[-1] == volume_x.shape[-1]
+    if can_concat:
+        full_x = torch.cat([surface_x, volume_x], dim=0) if volume_x is not None else surface_x
+        if enable_fourier:
+            full_x = append_fourier_features(full_x, sample.space_dim, fourier_freqs)
+        appended_full: list[torch.Tensor] = []
+        if enable_cp_panel and sample.dataset_name == "airfrans":
+            appended_full.append(_compute_airfrans_cp_panel(full_x))
+        if enable_wake_deficit and sample.dataset_name.startswith("tandemfoilset"):
+            appended_full.append(_compute_tandem_wake_deficit(full_x, include_angle=enable_wake_angle))
+        if appended_full:
+            full_x = torch.cat([full_x, *appended_full], dim=1)
+        num_surface = sample.surface_x.shape[0]
+        surface_x = full_x[:num_surface]
+        volume_x = full_x[num_surface:] if sample.volume_x is not None else None
+    else:
+        if enable_fourier:
+            surface_x = append_fourier_features(surface_x, sample.space_dim, fourier_freqs)
+            volume_x = append_fourier_features(volume_x, sample.space_dim, fourier_freqs)
     return CaseSample(
         case_id=sample.case_id,
         dataset_name=sample.dataset_name,

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -168,6 +168,7 @@ class TrainConfig:
     grad_clip: float = 0.0
     grad_accum_steps: int = 1
     volume_loss_weight: float = 1.0
+    dm_domain_normalized_volume: bool = False
     save_checkpoint: bool = False
     load_checkpoint: str = ""
     eval_interval: int = 1
@@ -778,6 +779,7 @@ def loss_grouped(
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
     volume_loss_weight: float = 1.0,
+    volume_transform: TargetTransform | None = None,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.surface_x.device)
     metrics: dict[str, float] = {}
@@ -787,7 +789,8 @@ def loss_grouped(
         total = total + surf_loss
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
     if batch.volume_y is not None and outputs["volume_preds"] is not None and batch.volume_mask is not None:
-        target = transform.apply(batch.volume_y)
+        vol_xform = volume_transform if volume_transform is not None else transform
+        target = vol_xform.apply(batch.volume_y)
         vol_loss = F.mse_loss(outputs["volume_preds"][batch.volume_mask], target[batch.volume_mask])
         total = total + vol_loss * volume_loss_weight
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
@@ -819,6 +822,7 @@ def loss_abupt(
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
     volume_loss_weight: float = 1.0,
+    volume_transform: TargetTransform | None = None,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.geometry_position.device)
     metrics: dict[str, float] = {}
@@ -828,7 +832,8 @@ def loss_abupt(
         total = total + surf_loss
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
     if batch.volume_anchor_target is not None and outputs["volume_preds"] is not None:
-        vol_target = transform.apply(batch.volume_anchor_target)
+        vol_xform = volume_transform if volume_transform is not None else transform
+        vol_target = vol_xform.apply(batch.volume_anchor_target)
         vol_loss = F.mse_loss(outputs["volume_preds"], vol_target)
         total = total + vol_loss * volume_loss_weight
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
@@ -869,6 +874,7 @@ def evaluate_grouped(
     *,
     amp_mode: str = "none",
     max_batches: int = 0,
+    volume_transform: TargetTransform | None = None,
 ) -> dict[str, float]:
     model.eval()
     if anp_head is not None:
@@ -1014,7 +1020,8 @@ def evaluate_grouped(
         if batch.surface_y is not None and outputs["surface_preds"] is not None:
             pred_surface = transform.invert(outputs["surface_preds"])
         if batch.volume_y is not None and outputs["volume_preds"] is not None and batch.volume_mask is not None:
-            pred_volume = transform.invert(outputs["volume_preds"])
+            vol_inv = volume_transform if volume_transform is not None else transform
+            pred_volume = vol_inv.invert(outputs["volume_preds"])
 
         if dataset_name == "drivaerml":
             if pred_surface is not None and batch.surface_y is not None:
@@ -1120,6 +1127,7 @@ def evaluate_abupt(
     *,
     amp_mode: str = "none",
     max_batches: int = 0,
+    volume_transform: TargetTransform | None = None,
 ) -> dict[str, float]:
     model.eval()
     dataset_name: str | None = None
@@ -1215,7 +1223,8 @@ def evaluate_abupt(
                 total_surface += float((pred - batch.surface_anchor_target).abs().mean().cpu().item())
                 count_surface += 1
         if batch.volume_anchor_target is not None and outputs["volume_preds"] is not None:
-            pred = transform.invert(outputs["volume_preds"])
+            vol_inv = volume_transform if volume_transform is not None else transform
+            pred = vol_inv.invert(outputs["volume_preds"])
             if dataset_name == "drivaerml":
                 value = _case_masked_rel_l2(
                     pred[0],
@@ -1287,6 +1296,7 @@ def train_one_epoch(
     grad_accum_steps: int = 1,
     volume_loss_weight: float = 1.0,
     skip_update_grad_norm: float = 0.0,
+    volume_transform: TargetTransform | None = None,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1320,7 +1330,7 @@ def train_one_epoch(
                         surface_anchor_position=batch.surface_anchor_position,
                         volume_anchor_position=batch.volume_anchor_position,
                     )
-                    loss, _ = loss_abupt(batch, outputs, transform, volume_loss_weight=volume_loss_weight)
+                    loss, step_metrics = loss_abupt(batch, outputs, transform, volume_loss_weight=volume_loss_weight, volume_transform=volume_transform)
             else:
                 batch = batch.to(device)
                 if isinstance(transform, TandemTargetTransform):
@@ -1333,7 +1343,7 @@ def train_one_epoch(
                             volume_mask=prepared.volume_mask,
                         )
                         outputs = maybe_apply_anp(outputs, prepared, anp_head)
-                        loss, _ = loss_grouped_tandem(prepared, outputs, volume_loss_weight=volume_loss_weight)
+                        loss, step_metrics = loss_grouped_tandem(prepared, outputs, volume_loss_weight=volume_loss_weight)
                 else:
                     with autocast_context(device, amp_mode):
                         outputs = model(
@@ -1342,9 +1352,13 @@ def train_one_epoch(
                             volume_x=batch.volume_x,
                             volume_mask=batch.volume_mask,
                         )
-                        loss, _ = loss_grouped(batch, outputs, transform, volume_loss_weight=volume_loss_weight)
+                        loss, step_metrics = loss_grouped(batch, outputs, transform, volume_loss_weight=volume_loss_weight, volume_transform=volume_transform)
 
             accum_loss += float(loss.detach().cpu().item())
+            for mk, mv in step_metrics.items():
+                if mk != "loss":
+                    running.setdefault(mk, 0.0)
+                    running[mk] += mv
             (loss / grad_accum_steps).backward()
             micro_count += 1
 
@@ -1389,6 +1403,12 @@ def train_one_epoch(
     running["loss"] /= max(steps, 1)
     if "grad_norm_mean" in running:
         running["grad_norm_mean"] /= max(steps, 1)
+    if "surface_loss" in running:
+        running["surface_loss"] /= max(micro_batches_total, 1)
+    if "volume_loss" in running:
+        running["volume_loss"] /= max(micro_batches_total, 1)
+    if "surface_loss" in running and "volume_loss" in running and running["surface_loss"] > 0:
+        running["volume_surface_loss_ratio"] = running["volume_loss"] / running["surface_loss"]
     running["train_steps"] = float(steps)
     running["micro_batches"] = float(micro_batches_total)
     if scheduler is not None:
@@ -1488,6 +1508,7 @@ def evaluate_phase_metrics(
     metric_transform: TargetTransform | None,
     device: torch.device,
     phase: str,
+    volume_transform: TargetTransform | None = None,
 ) -> dict[str, float]:
     metrics: dict[str, float] = {}
     for split_name, loader in loaders.items():
@@ -1500,6 +1521,7 @@ def evaluate_phase_metrics(
                 device,
                 amp_mode=config.amp_mode,
                 max_batches=config.max_eval_batches,
+                volume_transform=volume_transform,
             )
         else:
             split_metrics = evaluate_grouped(
@@ -1510,6 +1532,7 @@ def evaluate_phase_metrics(
                 metric_transform,
                 device,
                 amp_mode=config.amp_mode,
+                volume_transform=volume_transform,
                 max_batches=config.max_eval_batches,
             )
         metrics.update({f"{split_name}/{name}": value for name, value in split_metrics.items()})
@@ -1643,6 +1666,33 @@ def main() -> None:
                 asinh_scale=config.asinh_scale,
             )
 
+    volume_transform: TargetTransform | None = None
+    if config.dm_domain_normalized_volume and config.drivaerml_train_volume_points > 0:
+        train_ds = bundle.train_dataset
+        store = getattr(train_ds, 'store', None)
+        case_ids = getattr(train_ds, 'case_ids', None)
+        if store is not None and case_ids is not None:
+            vol_ys = []
+            for cid in case_ids:
+                case = store.load_case(cid)
+                if case.volume_y is not None:
+                    vy = case.volume_y
+                    if vy.ndim == 2 and vy.shape[0] > 10000:
+                        idx = torch.randperm(vy.shape[0])[:10000]
+                        vy = vy[idx]
+                    vol_ys.append(vy.reshape(-1, vy.shape[-1]))
+            if vol_ys:
+                all_vol = torch.cat(vol_ys, dim=0)
+                volume_y_mean = all_vol.mean(dim=0)
+                volume_y_std = all_vol.std(dim=0).clamp(min=1e-6)
+                volume_transform = TargetTransform(
+                    pressure_index=None,
+                    stats_mean=volume_y_mean,
+                    stats_std=volume_y_std,
+                )
+                print(f"[VolumeNorm] channels={volume_y_mean.shape[0]} "
+                      f"mean={volume_y_mean.tolist()} std={volume_y_std.tolist()}")
+
     train_loader, val_loaders, test_loaders = build_loaders(config, bundle, num_workers=resolved_num_workers)
     model = build_model(config, bundle).to(device)
     forward_model = torch.compile(model) if config.compile_model and device.type == "cuda" else model
@@ -1694,6 +1744,9 @@ def main() -> None:
     if config.wandb_name:
         run_config = asdict(config)
         run_config["effective_batch_size"] = config.batch_size * config.grad_accum_steps
+        if volume_transform is not None and volume_transform.stats_mean is not None:
+            run_config["volume_norm_mean"] = volume_transform.stats_mean.tolist()
+            run_config["volume_norm_std"] = volume_transform.stats_std.tolist()
         run = wandb.init(
             project=os.getenv("WANDB_PROJECT", "senpai-v1"),
             entity=os.getenv("WANDB_ENTITY"),
@@ -1715,6 +1768,7 @@ def main() -> None:
                 bundle=bundle, config=config, forward_model=forward_model,
                 anp_head=anp_head, loaders=loaders, transform=transform,
                 metric_transform=metric_transform, device=device, phase=phase,
+                volume_transform=volume_transform,
             )
             print(json.dumps({f"load_checkpoint_{phase}": metrics}, sort_keys=True), flush=True)
             if run is not None:
@@ -1754,6 +1808,7 @@ def main() -> None:
             grad_accum_steps=config.grad_accum_steps,
             volume_loss_weight=config.volume_loss_weight,
             skip_update_grad_norm=config.skip_update_grad_norm,
+            volume_transform=volume_transform,
         )
 
         grad_nonfinite_count += int(train_metrics.get("grad_nonfinite", 0))
@@ -1777,6 +1832,7 @@ def main() -> None:
                 metric_transform=metric_transform,
                 device=device,
                 phase="val",
+                volume_transform=volume_transform,
             )
 
             current_val = eval_metrics.get(val_primary_key)
@@ -1873,6 +1929,7 @@ def main() -> None:
             bundle=bundle, config=config, forward_model=forward_model,
             anp_head=anp_head, loaders=val_loaders, transform=transform,
             metric_transform=metric_transform, device=device, phase="val",
+            volume_transform=volume_transform,
         )
         current_val = eval_metrics.get(val_primary_key)
         if current_val is not None and current_val < best_val_metric:
@@ -1933,6 +1990,7 @@ def main() -> None:
             metric_transform=metric_transform,
             device=device,
             phase="test",
+            volume_transform=volume_transform,
         )
 
         if ema is not None:
@@ -1961,6 +2019,7 @@ def main() -> None:
                 metric_transform=metric_transform,
                 device=device,
                 phase="test",
+                volume_transform=volume_transform,
             )
             if run is not None:
                 best_checkpoint_metrics: dict[str, float | int | str] = {


### PR DESCRIPTION
## Hypothesis

Previous DrivAerML volume training (PR #3044) failed catastrophically because the volume targets (4 channels: Ux, Uy, Uz, p) were being normalized using the **surface cp stats** (1-channel). The surface normalizer cannot handle 4-channel volume data, causing a ~40,000x loss ratio that destroyed training.

This is not a failed hypothesis — it is a normalization bug. Proper domain-normalized volume auxiliary learning gives the model richer flow-physics supervision (separation, wake, pressure gradients) that should benefit surface pressure prediction. This is the auxiliary representation objective that makes AB-UPT-style methods succeed on DrivAerML.

**Breakout 3 from issue #3283: fix the normalization bug and re-test volume auxiliary learning.**

## Instructions

### Step 1: Add volume target normalization

Add `--dm-domain-normalized-volume` flag. When set, compute **separate** volume statistics (y_mean, y_std per channel) from the training volume data, distinct from the surface cp stats.

In `train.py`, find the section that builds `DatasetBundle` / `TargetTransform`. Add:

```python
# New flag in TrainConfig:
dm_domain_normalized_volume: bool = False  # --dm-domain-normalized-volume
```

After loading training data with volume points enabled, compute volume stats:

```python
if config.dm_domain_normalized_volume and config.drivaerml_train_volume_points > 0:
    # Collect volume targets from training set (sample up to 10k points per case)
    vol_ys = []
    for item in train_dataset:
        if hasattr(item, 'volume_y') and item.volume_y is not None:
            vol_ys.append(item.volume_y.reshape(-1, item.volume_y.shape[-1]))
    if vol_ys:
        all_vol = torch.cat(vol_ys, dim=0)
        volume_y_mean = all_vol.mean(dim=0)  # [4] — Ux, Uy, Uz, p channel means
        volume_y_std = all_vol.std(dim=0).clamp(min=1e-6)  # [4] — per-channel stds
    volume_transform = TargetTransform(
        pressure_index=None,  # no special pressure treatment for volume
        stats_mean=volume_y_mean,
        stats_std=volume_y_std,
    )
```

### Step 2: Apply the correct transform in loss functions

In `loss_grouped` (around line 789), change the volume target normalization to use `volume_transform` if provided:

```python
def loss_grouped(
    batch: GroupedBatch,
    outputs: dict[str, torch.Tensor | None],
    transform: TargetTransform,
    volume_loss_weight: float = 1.0,
    volume_transform: TargetTransform | None = None,  # NEW
) -> tuple[torch.Tensor, dict[str, float]]:
    ...
    if batch.volume_y is not None and outputs["volume_preds"] is not None and batch.volume_mask is not None:
        vol_xform = volume_transform if volume_transform is not None else transform
        target = vol_xform.apply(batch.volume_y)  # use volume-specific stats
        vol_loss = F.mse_loss(outputs["volume_preds"][batch.volume_mask], target[batch.volume_mask])
        total = total + vol_loss * volume_loss_weight
        metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
```

Also pass `volume_transform` through to the training loop call.

### Step 3: Add logging for surface/volume loss balance

Log both `surface_loss` and `volume_loss` to W&B every step. This lets us verify the losses are balanced. If `volume_loss > 10 * surface_loss` at epoch 1, kill immediately.

### Step 4: Smoke test

Before the main trials, run 3 epochs to verify:
1. Volume loss is in a similar range to surface loss (not 1000x larger)
2. grad norms are finite and < 10
3. Model does not NaN

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=3 python train.py \
  --dataset drivaerml \
  --no-surface-only-drivaerml \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-train-volume-points 16000 \
  --drivaerml-eval-surface-points 50000 \
  --drivaerml-eval-volume-points 8000 \
  --dm-domain-normalized-volume \
  --volume-loss-weight 0.1 \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --max-train-batches 50 --max-eval-batches 50 \
  --ema-decay 0.9995 \
  --ema-mode fixed --ema-start-step 50 \
  --no-compile-model
```

Report: surface_loss, volume_loss, ratio at epoch 1. If ratio > 100, STOP and ping advisor.

### Step 5: Main trials

Once smoke test passes, run the full matrix. Use `--wandb_group dm-volume-norm-aux`:

**Trial A — volume_loss_weight=0.1, 16k volume points:**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=600 python train.py \
  --dataset drivaerml \
  --no-surface-only-drivaerml \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-train-volume-points 16000 \
  --drivaerml-eval-surface-points 50000 \
  --drivaerml-eval-volume-points 8000 \
  --dm-domain-normalized-volume \
  --volume-loss-weight 0.1 \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --ema-mode fixed --ema-start-step 50 \
  --no-compile-model \
  --save-checkpoint \
  --skip-update-grad-norm 100 \
  --kill-if-best-val-above 100:8.0 \
  --wandb_group dm-volume-norm-aux \
  --wandb-name "brook/dm-vol-norm-w01-16k"
```

**Trial B — volume_loss_weight=0.03, 16k volume points:**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=600 python train.py \
  --dataset drivaerml \
  --no-surface-only-drivaerml \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-train-volume-points 16000 \
  --drivaerml-eval-surface-points 50000 \
  --drivaerml-eval-volume-points 8000 \
  --dm-domain-normalized-volume \
  --volume-loss-weight 0.03 \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --ema-mode fixed --ema-start-step 50 \
  --no-compile-model \
  --save-checkpoint \
  --skip-update-grad-norm 100 \
  --kill-if-best-val-above 100:8.0 \
  --wandb_group dm-volume-norm-aux \
  --wandb-name "brook/dm-vol-norm-w003-16k"
```

**Trial C — volume_loss_weight=0.3, 8k volume points:**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=600 python train.py \
  --dataset drivaerml \
  --no-surface-only-drivaerml \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-train-volume-points 8000 \
  --drivaerml-eval-surface-points 50000 \
  --drivaerml-eval-volume-points 4000 \
  --dm-domain-normalized-volume \
  --volume-loss-weight 0.3 \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --ema-mode fixed --ema-start-step 50 \
  --no-compile-model \
  --save-checkpoint \
  --skip-update-grad-norm 100 \
  --kill-if-best-val-above 100:8.0 \
  --wandb_group dm-volume-norm-aux \
  --wandb-name "brook/dm-vol-norm-w03-8k"
```

**Kill criteria (all trials):**
- If volume_loss > 50 * surface_loss at epoch 1 → stop, normalization bug not fully fixed
- If best `val_primary/surface_rel_l2_pct` > 8.0% after epoch 100 → kill
- If gradient norm is non-finite for 3+ consecutive steps → kill

**Promote if:** surface val matches or beats surface-only control (~5.5%) by epoch 120, because volume pre-training typically unlocks more gains in later fine-tuning.

### Step 6: Report

Report for all trials:
- `val_primary/surface_rel_l2_pct` at best epoch
- `surface_loss` and `volume_loss` ratio at epoch 1 and epoch 50
- Gradient norm stability (max grad norm over training)
- W&B run IDs

## Baseline

Current best DrivAerML (batch-limited val, full-eval ~4.93%):

| Metric | Value | Epoch |
|--------|-------|-------|
| `val_primary/surface_rel_l2_pct` | **3.833%** | 511 |
| `test_primary/surface_rel_l2_pct` | **4.685%** | 511 |

- W&B run: `ncl1dh88` (eren/dm-ema-9995-gc05)
- Config: 4L/512d/8H, AdamW lr=5e-4, T_max=30, gc=0.5, EMA=0.9995, no WD, Fourier
- **Note:** The batch-limited val (~3.833%) is ~24% optimistic vs full-eval (~4.93%). Full-eval test evidence is ~4.39-4.50%. The goal is to improve the surface prediction floor, not just chase the truncated val number.

Reproduce champion (surface-only):
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --grad-clip 0.5 --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995
```