### PR TITLE
DrivAerML: Breakout 2 — metric-aware MSE+raw-rel-L2 loss

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -178,6 +178,8 @@ class TrainConfig:
     kill_if_no_improvement: str = ""
     kill_if_grad_nonfinite_steps: int = 0
     seed: int = 0
+    dm_loss: str = "mse"
+    dm_rel_l2_weight: float = 0.05
 
 
 @dataclass
@@ -778,6 +780,8 @@ def loss_grouped(
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
     volume_loss_weight: float = 1.0,
+    dm_loss: str = "mse",
+    dm_rel_l2_weight: float = 0.05,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.surface_x.device)
     metrics: dict[str, float] = {}
@@ -786,6 +790,21 @@ def loss_grouped(
         surf_loss = F.mse_loss(outputs["surface_preds"][batch.surface_mask], target[batch.surface_mask])
         total = total + surf_loss
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
+        if dm_loss == "mse_plus_raw_rel_l2":
+            raw_pred = transform.invert(outputs["surface_preds"])
+            raw_target = batch.surface_y
+            mask = batch.surface_mask
+            B = raw_pred.shape[0]
+            rel_l2_sum = raw_pred.new_zeros(())
+            for b in range(B):
+                m = mask[b]
+                err = (raw_pred[b][m] - raw_target[b][m]).pow(2).sum()
+                ref = raw_target[b][m].pow(2).sum().clamp(min=1e-8)
+                rel_l2_sum = rel_l2_sum + (err / ref).sqrt()
+            raw_rel_l2 = rel_l2_sum / max(B, 1)
+            total = total + dm_rel_l2_weight * raw_rel_l2
+            metrics["raw_rel_l2_loss"] = float(raw_rel_l2.detach().cpu().item())
+            metrics["rel_l2_contribution"] = float((dm_rel_l2_weight * raw_rel_l2).detach().cpu().item())
     if batch.volume_y is not None and outputs["volume_preds"] is not None and batch.volume_mask is not None:
         target = transform.apply(batch.volume_y)
         vol_loss = F.mse_loss(outputs["volume_preds"][batch.volume_mask], target[batch.volume_mask])
@@ -1287,6 +1306,8 @@ def train_one_epoch(
     grad_accum_steps: int = 1,
     volume_loss_weight: float = 1.0,
     skip_update_grad_norm: float = 0.0,
+    dm_loss: str = "mse",
+    dm_rel_l2_weight: float = 0.05,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1342,7 +1363,11 @@ def train_one_epoch(
                             volume_x=batch.volume_x,
                             volume_mask=batch.volume_mask,
                         )
-                        loss, _ = loss_grouped(batch, outputs, transform, volume_loss_weight=volume_loss_weight)
+                        loss, loss_metrics = loss_grouped(batch, outputs, transform, volume_loss_weight=volume_loss_weight, dm_loss=dm_loss, dm_rel_l2_weight=dm_rel_l2_weight)
+                        for k in ("raw_rel_l2_loss", "rel_l2_contribution"):
+                            if k in loss_metrics:
+                                running.setdefault(k, 0.0)
+                                running[k] += loss_metrics[k]
 
             accum_loss += float(loss.detach().cpu().item())
             (loss / grad_accum_steps).backward()
@@ -1389,6 +1414,9 @@ def train_one_epoch(
     running["loss"] /= max(steps, 1)
     if "grad_norm_mean" in running:
         running["grad_norm_mean"] /= max(steps, 1)
+    for k in ("raw_rel_l2_loss", "rel_l2_contribution"):
+        if k in running:
+            running[k] /= max(steps, 1)
     running["train_steps"] = float(steps)
     running["micro_batches"] = float(micro_batches_total)
     if scheduler is not None:
@@ -1754,6 +1782,8 @@ def main() -> None:
             grad_accum_steps=config.grad_accum_steps,
             volume_loss_weight=config.volume_loss_weight,
             skip_update_grad_norm=config.skip_update_grad_norm,
+            dm_loss=config.dm_loss,
+            dm_rel_l2_weight=config.dm_rel_l2_weight,
         )
 
         grad_nonfinite_count += int(train_metrics.get("grad_nonfinite", 0))


### PR DESCRIPTION
## Hypothesis

The DrivAerML paper metric (`surface_rel_l2_pct`) is per-case relative L2 on **raw (unnormalized) cp**. But training optimizes MSE on **z-normalized cp**. This creates a metric mismatch: the loss landscape the optimizer sees does not match the metric we report. Cases with large absolute cp values (high-speed regions, strong pressure gradients) are weighted differently in the loss vs the metric.

**Breakout 2 from #3283:** Add a differentiable raw-relative-L2 auxiliary loss term alongside the existing MSE. The MSE provides stable base gradients; the rel-L2 term nudges optimization toward the actual evaluation metric. This is NOT pure relative-L2 training (which collapsed in PR #3074) — the MSE term anchors training stability.

## Instructions

### Step 1: Add CLI flags

```python
# In TrainConfig:
dm_loss: str = 'mse'  # choices: 'mse', 'mse_plus_raw_rel_l2'
dm_rel_l2_weight: float = 0.05
```

### Step 2: Add differentiable raw-rel-L2 to `loss_grouped`

In `loss_grouped` (around line 776), after computing the normal surface MSE loss, add the auxiliary term when `dm_loss == 'mse_plus_raw_rel_l2'`:

```python
def loss_grouped(
    batch, outputs, transform,
    volume_loss_weight=1.0,
    volume_transform=None,
    dm_loss='mse',          # NEW
    dm_rel_l2_weight=0.05,  # NEW
):
    # ... existing MSE computation ...
    target = transform.apply(batch.surface_y)
    surf_loss = F.mse_loss(outputs["surface_preds"][batch.surface_mask], target[batch.surface_mask])
    total = surf_loss
    metrics["surface_loss"] = float(surf_loss.detach().cpu().item())

    # NEW: add raw-relative-L2 auxiliary term for DrivAerML
    if dm_loss == 'mse_plus_raw_rel_l2':
        # Invert predictions to raw space (transform.invert already exists at line 235)
        raw_pred = transform.invert(outputs["surface_preds"])  # [B, N, C]
        raw_target = batch.surface_y  # already raw
        mask = batch.surface_mask  # [B, N]

        # Per-case relative L2 (batch_size=1 for DM, but handle general case)
        B = raw_pred.shape[0]
        rel_l2_sum = raw_pred.new_zeros(())
        for b in range(B):
            m = mask[b]  # [N]
            err = (raw_pred[b][m] - raw_target[b][m]).pow(2).sum()
            ref = raw_target[b][m].pow(2).sum().clamp(min=1e-8)  # clamp denom, do NOT detach
            rel_l2_sum = rel_l2_sum + (err / ref).sqrt()
        raw_rel_l2 = rel_l2_sum / max(B, 1)

        total = total + dm_rel_l2_weight * raw_rel_l2
        metrics["raw_rel_l2_loss"] = float(raw_rel_l2.detach().cpu().item())
        metrics["rel_l2_contribution"] = float((dm_rel_l2_weight * raw_rel_l2).detach().cpu().item())

    # ... rest of function (volume loss etc.) ...
```

**Critical:** Do NOT detach `raw_pred` — the gradients must flow through the auxiliary term back to the model. Clamp the denominator `ref` to `min=1e-8` to prevent division-by-zero but keep it differentiable.

### Step 3: Thread the new args through the training loop

Pass `dm_loss` and `dm_rel_l2_weight` from `TrainConfig` through to `loss_grouped` in the training step (around line 1345).

### Step 4: Smoke test (3 epochs)

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=3 python train.py \
  --dataset drivaerml \
  --dm-loss mse_plus_raw_rel_l2 --dm-rel-l2-weight 0.05 \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 \
  --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 50 --max-eval-batches 50 \
  --ema-decay 0.9995 --ema-mode fixed --ema-start-step 50 \
  --no-compile-model
```

Verify: surface_loss, raw_rel_l2_loss, and total loss are all finite. Check that `raw_rel_l2_loss` is in a reasonable range (0.5–5.0 at epoch 1).

### Step 5: Main trials

Run 3 trials in parallel on 3 GPUs with `--wandb_group dm-metric-aware`:

**Trial A — rel_l2_weight=0.02 (gentle nudge):**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=0 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=600 python train.py \
  --dataset drivaerml \
  --dm-loss mse_plus_raw_rel_l2 --dm-rel-l2-weight 0.02 \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 \
  --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 --ema-mode fixed --ema-start-step 50 \
  --no-compile-model --save-checkpoint \
  --skip-update-grad-norm 100 \
  --kill-if-no-improvement 200:0.05 \
  --wandb-group dm-metric-aware --wandb-name "canute/dm-mse-rel-l2-w002" --agent canute
```

**Trial B — rel_l2_weight=0.05 (moderate):**
Same as Trial A but `--dm-rel-l2-weight 0.05` and wandb-name `"canute/dm-mse-rel-l2-w005"`

**Trial C — rel_l2_weight=0.1 (stronger metric alignment):**
Same as Trial A but `--dm-rel-l2-weight 0.1` and wandb-name `"canute/dm-mse-rel-l2-w01"`

**Kill criteria:**
- Kill if `raw_rel_l2_loss` is NaN or Inf at any point
- Kill if gradient norm is non-finite for 3+ consecutive steps
- Kill if no improvement in val_primary/surface_rel_l2_pct for 200 epochs (min_delta=0.05)

### Step 6: Report

For each trial, report:
- `val_primary/surface_rel_l2_pct` at best epoch and every 100 epochs
- `raw_rel_l2_loss` at epoch 1, 50, 100 — to confirm the auxiliary term is active and decreasing
- `surface_loss` (MSE component) — to confirm it's not disrupted by the auxiliary
- Gradient norm stability (max observed)
- W&B run IDs

## Baseline

Current best DrivAerML (batch-limited val, full-eval ~4.93%):

| Metric | Value | Epoch |
|--------|-------|-------|
| `val_primary/surface_rel_l2_pct` | **3.833%** | 511 |
| `test_primary/surface_rel_l2_pct` | **4.685%** | 511 |

- W&B run: `ncl1dh88` (eren/dm-ema-9995-gc05)
- Config: 4L/512d/8H, AdamW lr=5e-4, T_max=30, gc=0.5, EMA=0.9995, no WD, Fourier
- **Note:** batch-limited val (~3.833%) is ~24% optimistic vs full-eval (~4.93%). Full-eval test evidence: ~4.39-4.50%.
- **Prior failure:** PR #3074 tried pure relative-L2 in z-normalized target space — it collapsed. This experiment uses raw-space rel-L2 as an auxiliary term alongside MSE, which is fundamentally different.