### PR TITLE
DrivAerML: champion recovery seed=777 eval-interval=10 (Bucket A)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1843,6 +1843,24 @@ def main() -> None:
                 kill_output_dir = Path(config.output_dir)
                 kill_output_dir.mkdir(parents=True, exist_ok=True)
                 (kill_output_dir / "KILLED.md").write_text(kill_msg + "\n")
+                if config.save_checkpoint and best_model_state is not None:
+                    best_ckpt_path = kill_output_dir / f"{config.dataset}_{config.model}_best.pt"
+                    ckpt_payload = {
+                        "model_state_dict": best_model_state,
+                        "epoch": best_epoch,
+                        "val_metric": best_val_metric,
+                        "val_primary_metric_name": best_val_primary_metric_name,
+                        "val_primary_metric": best_val_primary_metric,
+                        "config": {k: v for k, v in vars(config).items() if not k.startswith("_")},
+                    }
+                    if best_anp_state is not None:
+                        ckpt_payload["anp_state_dict"] = best_anp_state
+                    if best_ema_shadow is not None:
+                        ckpt_payload["ema_shadow"] = best_ema_shadow
+                    if best_anp_ema_shadow is not None:
+                        ckpt_payload["anp_ema_shadow"] = best_anp_ema_shadow
+                    torch.save(ckpt_payload, best_ckpt_path)
+                    print(f"[SaveCheckpoint] Best model saved to {best_ckpt_path} (epoch={best_epoch}, val={best_val_metric:.6f})")
                 print(kill_msg, file=sys.stderr, flush=True)
                 raise RuntimeError(kill_msg)
 


### PR DESCRIPTION
## Hypothesis

Expanding the DM champion seed ensemble with seed=777. The champion config (EMA=0.9995 + gc=0.5, 4L/512d/8H, AdamW lr=5e-4, T_max=30) achieves 3.833% val / 4.324% full-eval TEST. With 400 training samples, seed variance is meaningful — different random initializations explore different loss basins. Running multiple seeds (we have 0, 7, 13, 42, 456 already in flight) increases the probability of finding a run that breaks below 4.324% TEST and approaches the 3.71% AB-UPT SOTA target.

**CRITICAL BUG NOTE:** Always use `--no-compile-model` with EMA. torch.compile caches parameter tensors — in-place EMA `param.data.copy_()` is NOT visible to the compiled forward pass, causing val metrics to be frozen at initialization values throughout training.

## Instructions

Run the DM champion config with seed=777, 600-min budget, dense eval interval:

```bash
cd target/icml2026 && SENPAI_TIMEOUT_MINUTES=600 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --ema-mode fixed \
  --no-compile-model \
  --save-checkpoint \
  --eval-interval 10 \
  --seed 777 \
  --wandb-group dm-champion-recovery \
  --kill-if-best-val-above 150:8.0 \
  --kill-if-no-improvement 200:0.05
```

**After training completes**, run full-eval on the best checkpoint for authoritative TEST metric:

```bash
cd target/icml2026 && python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --ema-mode fixed \
  --no-compile-model \
  --load-checkpoint <path-to-best-checkpoint> \
  --eval-only
```

## Baseline

- **DM best val:** 3.833% at ep511 (PR #3072, eren, W&B: ncl1dh88)
- **DM best batch-limited TEST:** 4.685%
- **DM authoritative full-eval TEST:** 4.324% (faye run zx5syby1, full-eval on ep517 ckpt from w4ufs8m1)
- **External SOTA target:** <3.71% (AB-UPT)
- **Other seeds in flight:** seed=0 (#3293 norman), seed=7 (#3286 megumi), seed=13 (#3305 faye), seed=42 (#3285 jet), seed=456 (#3310 zenitsu)
- **Champion reproduce:** `cd target/icml2026 && python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --ema-decay 0.9995`

## Expected output

Report in PR comments:
1. Best val `surface_rel_l2_pct` and epoch
2. W&B run ID and group: `dm-champion-recovery`
3. Checkpoint path
4. Full-eval TEST `surface_rel_l2_pct` (from --eval-only run)