### PR TITLE
[codex] Verify assignment PR metadata - give advisor a PR assignment tool that fails if details are missing

### DIFF
--- a/plugins/senpai/scripts/senpai-gh.sh
+++ b/plugins/senpai/scripts/senpai-gh.sh
@@ -80,6 +80,74 @@ close_pr_with_comment() {
     gh_retry gh pr close "$num" --delete-branch
 }
 
+# Create an assignment PR through the one path that verifies student routing.
+#
+# Assignment pickup is label-based: student pods only see work when the PR has
+# the advisor branch label, student:<name>, and status:wip. Raw gh pr create
+# calls can leave behind an unroutable PR if any of that metadata is omitted.
+#
+# On success, this prints the created PR URL after confirming the PR is a draft,
+# targets the requested base/head, and has every required routing label.
+# On failure, it prints the specific missing or mismatched invariant to stderr
+# and returns nonzero so the advisor can fix the assignment before students idle.
+#   create_assignment_pr_from_file <student> <head-branch> <title> <body-file> [base-branch]
+create_assignment_pr_from_file() {
+    local student="$1" head_branch="$2" title="$3" body_file="$4" base_branch="${5:-${ADVISOR_BRANCH:-}}"
+    local pr_url num details
+
+    if [ -z "$student" ] || [ -z "$head_branch" ] || [ -z "$title" ] || [ -z "$body_file" ] || [ -z "$base_branch" ]; then
+        echo "create_assignment_pr_from_file: usage: <student> <head-branch> <title> <body-file> [base-branch]" >&2
+        return 2
+    fi
+    if [ ! -f "$body_file" ]; then
+        echo "create_assignment_pr_from_file: body file not found: $body_file" >&2
+        return 2
+    fi
+
+    pr_url=$(gh_retry gh pr create --draft \
+        --title "$title" \
+        --body-file "$body_file" \
+        --label "$base_branch" \
+        --label "student:$student" \
+        --label "status:wip" \
+        --base "$base_branch" \
+        --head "$head_branch")
+
+    num=$(printf '%s' "$pr_url" | sed -n 's#.*/pull/\([0-9][0-9]*\).*#\1#p')
+    if [ -z "$num" ]; then
+        echo "create_assignment_pr_from_file: could not parse PR number from: $pr_url" >&2
+        return 1
+    fi
+
+    details=$(gh_retry gh pr view "$num" --json number,baseRefName,headRefName,labels,isDraft)
+    python3 - "$student" "$base_branch" "$head_branch" "$details" <<'PY' || return
+import json
+import sys
+
+student, base_branch, head_branch, payload = sys.argv[1:5]
+pr = json.loads(payload)
+labels = {label.get("name", "") for label in pr.get("labels", [])}
+
+errors = []
+if pr.get("baseRefName") != base_branch:
+    errors.append(f"expected base {base_branch}, got {pr.get('baseRefName')}")
+if pr.get("headRefName") != head_branch:
+    errors.append(f"expected head {head_branch}, got {pr.get('headRefName')}")
+if not pr.get("isDraft"):
+    errors.append("expected draft PR")
+for label in (base_branch, f"student:{student}", "status:wip"):
+    if label not in labels:
+        errors.append(f"missing label {label}")
+
+if errors:
+    for error in errors:
+        print(f"create_assignment_pr_from_file: PR #{pr.get('number')} {error}", file=sys.stderr)
+    raise SystemExit(1)
+PY
+
+    printf '%s\n' "$pr_url"
+}
+
 # ---------------------------------------------------------------------------
 # Compound actions — student
 # ---------------------------------------------------------------------------

--- a/plugins/senpai/skills/assign-experiment/SKILL.md
+++ b/plugins/senpai/skills/assign-experiment/SKILL.md
@@ -43,12 +43,11 @@ BRANCH="$0/$1"
 create_assignment_branch "$0" "$1"
 ```
 
-3. **Create the draft PR** with the template below. Replace the placeholders with your actual hypothesis, instructions, and baseline data:
+3. **Write the PR body to a temp file**. Replace the placeholders with your actual hypothesis, instructions, and baseline data:
 
 ```bash
-gh pr create --draft \
-    --title "<Hypothesis title — clear, specific, under 70 chars>" \
-    --body "$(cat <<'PREOF'
+BODY_FILE=$(mktemp)
+cat > "$BODY_FILE" <<'PREOF'
 ## Hypothesis
 <What we think will improve metrics and why. For non-trivial changes,
 include links to papers or code that support the hypothesis.>
@@ -64,12 +63,18 @@ include links to papers or code that support the hypothesis.>
 - Baseline W&B run: <run-id> (<wandb-link>)
 - Reproduce command: `cd "$2" && python train.py ...`>
 PREOF
-)" \
-    --label "$ADVISOR_BRANCH" \
-    --label "student:$0" \
-    --label "status:wip" \
-    --base "$ADVISOR_BRANCH" \
-    --head "$BRANCH"
+```
+
+4. **Create and verify the draft PR**:
+
+```bash
+create_assignment_pr_from_file \
+    "$0" \
+    "$BRANCH" \
+    "<Hypothesis title — clear, specific, under 70 chars>" \
+    "$BODY_FILE" \
+    "$ADVISOR_BRANCH"
+rm -f "$BODY_FILE"
 ```
 
 ## Important details
@@ -80,4 +85,5 @@ PREOF
 - **Be specific in instructions.** The student implements exactly what you write. Vague instructions waste GPU time.
 - **Use `--wandb_group`** in instructions when a hypothesis needs multiple iterations (e.g. "try surface weight 5, 10, 20") so related runs are grouped in W&B.
 - **One hypothesis per PR.** Bundling multiple changes makes it impossible to attribute what worked.
-- If the PR body is too long for `gh pr create`, put the core info in the body and add supplementary details as a follow-up comment.
+- **Use `create_assignment_pr_from_file`.** It fails if the PR is not draft, targets the wrong base or head, or is missing `$ADVISOR_BRANCH`, `student:$0`, or `status:wip`.
+- If the PR body is too long, keep the core info in the body file and add supplementary details as a follow-up comment.

--- a/plugins/senpai/skills/senpai-gh/SKILL.md
+++ b/plugins/senpai/skills/senpai-gh/SKILL.md
@@ -45,6 +45,7 @@ GitHub's `gh pr edit --remove-label X --add-label Y` silently strips **all other
 |---|---|
 | `send_pr_back_to_student_with_comment <pr#> <comment>` | Send a PR back to the student with feedback. Comment on the PR, convert back to draft, swap `status:review` → `status:wip`. |
 | `close_pr_with_comment <pr#> <reason>` | Close a dead-end PR with a comment explaining why. Comment with reason, close the PR, delete the remote branch. |
+| `create_assignment_pr_from_file <student> <head-branch> <title> <body-file> [base-branch]` | Create a draft assignment PR, then fail if the required base/head, draft, or routing labels are missing. |
 
 ### Student actions
 


### PR DESCRIPTION
## What changed

Adds a small `create_assignment_pr_from_file` helper for advisor assignment PR creation and routes the `assign-experiment` skill through it.

The workflow now has two explicit steps:

1. The advisor writes the full assignment PR body to a temporary file.
2. The helper creates the draft PR from that file, then reads the PR back and fails if any routing invariant is missing.

The helper verifies:

- the PR is still draft
- the base branch is the advisor branch
- the head branch is the assignment branch
- the advisor branch label is present
- the `student:<name>` label is present
- the `status:wip` label is present

## Why this is useful

This keeps assignment creation simple while making the fragile part fail fast.

Writing the PR body to a file is better than embedding a long heredoc inside a `gh pr create --body "$(...)"` call because the assignment text becomes a concrete artifact before the PR is opened. That makes it easier for the advisor process to generate, inspect, and pass the body without shell quoting surprises, command-substitution edge cases, or body-length weirdness. It also gives us a clean boundary where future checks can be added against the body file before the PR exists.

The metadata verification catches the failure mode that originally stranded students: a PR exists, but the label contract needed by student polling is incomplete. Instead of adding branch-prefix fallback, reconciliation, or warning machinery, this PR preserves the label-based assignment contract and fails immediately when PR creation produces something unroutable.

## Scope

This is intentionally smaller than #2489. It does not add:

- branch-prefix assignment recovery
- advisor-side reconciliation of existing PRs
- student warning plumbing
- ownership inference from branch names

## Validation

- `bash -n plugins/senpai/scripts/senpai-gh.sh`
- `bash -n k8s/entrypoint-advisor.sh`
- `bash -n k8s/entrypoint-student.sh`
- mocked `create_assignment_pr_from_file` success path
- mocked missing-label failure path
- `git diff --check`
