### PR TITLE
[codex] Rename status check skill

### DIFF
--- a/.agents/skills/senpai-status-check/SKILL.md
+++ b/.agents/skills/senpai-status-check/SKILL.md
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-PackageName: skills
 
-name: experiment-status-check
+name: senpai-status-check
 description: >
   Produce a fresh status report for the senpai ML experiment fleet. Use when the
   user asks for an experiment status, final status, PR/W&B/pod health check,

--- a/.claude/skills/senpai-status-check/SKILL.md
+++ b/.claude/skills/senpai-status-check/SKILL.md
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-PackageName: skills
 
-name: experiment-status-check
+name: senpai-status-check
 description: >
   Produce a fresh status report for the senpai ML experiment fleet. Use when the
   user asks for an experiment status, final status, PR/W&B/pod health check,


### PR DESCRIPTION
## Summary

Renames the experiment status skill to `senpai-status-check` in both skill locations:

- `.agents/skills/senpai-status-check/SKILL.md`
- `.claude/skills/senpai-status-check/SKILL.md`

Also updates the `name:` frontmatter in both files. The old `experiment-status-check` references are removed.

## Validation

- `rg -n "experiment-status-check|senpai-status-check" .agents .claude README.md system_instructions plugins`
- `diff -u .agents/skills/senpai-status-check/SKILL.md .claude/skills/senpai-status-check/SKILL.md`
- `git diff --check origin/main..HEAD`
