### PR TITLE
[codex] Add launch-scoped Anthropic and EXA API keys, remove need for CLAUDE_CODE_AUTH_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,49 +110,48 @@ n_students: 4
 
 `launch.py` reads this via `simple_parsing` — every field can be overridden on the CLI.
 
-### GitHub token (per-launch)
+### Launch credentials (per-launch)
 
-`launch.py` resolves your GitHub token at launch time and materialises it as an ephemeral, per-tag k8s Secret (`senpai-github-token-<tag>`) that the pods reference for `GITHUB_TOKEN`. Resolution order:
+`launch.py` resolves your GitHub token and Anthropic API key at launch time and materialises them as an ephemeral, per-tag k8s Secret (`senpai-launch-secrets-<tag>`) that the pods reference for `GITHUB_TOKEN` and `ANTHROPIC_API_KEY`.
+
+GitHub token resolution order:
 
 1. `$GITHUB_TOKEN` in your shell env (shell or [`direnv`](https://direnv.net/) wins).
 2. `.env` at the senpai repo root (`GITHUB_TOKEN=ghp_...`). Not committed; don't paste into a shared file.
 3. `gh auth token` — works out-of-the-box if you're already logged into the `gh` CLI.
 
-If none resolves, `launch.py` exits with instructions. The launch-scoped Secret is labelled with your research tag and is cleaned up by `kubectl delete deployments,configmaps,secrets -l research-tag=<tag>` (see [Running](#running)).
+Anthropic API key resolution order:
 
-The repo ships an `example.env` template — copy it to `.env` and paste your token:
+1. `$ANTHROPIC_API_KEY` in your shell env.
+2. `.env` at the senpai repo root (`ANTHROPIC_API_KEY=sk-ant-...`).
+
+If either credential is missing, `launch.py` exits with instructions. The launch-scoped Secret is labelled with your research tag and is cleaned up by `kubectl delete deployments,configmaps,secrets -l research-tag=<tag>` (see [Running](#running)).
+
+The repo ships an `example.env` template — copy it to `.env` and paste your credentials:
 
 ```bash
 cp example.env .env
-# then edit .env and set GITHUB_TOKEN=ghp_...
+# then edit .env and set GITHUB_TOKEN=ghp_... and ANTHROPIC_API_KEY=sk-ant-...
 ```
 
-`.env` is already gitignored, so the token stays local.
+`.env` is already gitignored, so the credentials stay local.
 
-> **Target-repo permissions.** Prefer a deliberately created classic PAT (`ghp_...`) with `repo` and `read:org`; copied GitHub CLI OAuth tokens (`gho_...`) are easy to launch with stale or insufficient scopes. The token must be able to **clone** `target_repo_url` and **push branches + open/merge PRs** against it. `launch.py` preflights this against the GitHub API before spinning up pods and fails loudly if `permissions.push` is false. Same applies to the `CLAUDE_CODE_OAUTH_TOKEN` user (still in `senpai-secrets`) if you rely on `gh auth status` inside the pod.
+> **Target-repo permissions.** Prefer a deliberately created classic PAT (`ghp_...`) with `repo` and `read:org`; copied GitHub CLI OAuth tokens (`gho_...`) are easy to launch with stale or insufficient scopes. The token must be able to **clone** `target_repo_url` and **push branches + open/merge PRs** against it. `launch.py` preflights this against the GitHub API before spinning up pods and fails loudly if `permissions.push` is false.
 
 ### Shared cluster secrets (`senpai-secrets`)
 
-Every pod also reads three keys from the shared, cluster-wide `senpai-secrets` Secret. Unlike the GitHub token these are not per-launch — set them once on the cluster and every tag reuses them:
+Every pod also reads shared, cluster-wide keys from the `senpai-secrets` Secret. Unlike launch credentials these are not per-launch — set them once on the cluster and every tag reuses them:
 
 | Key in `senpai-secrets` | Used for |
 |---|---|
 | `wandb-api-key` | `WANDB_API_KEY` — all W&B logging from advisor + students |
-| `claude-code-oauth-token` | `CLAUDE_CODE_OAUTH_TOKEN` — Claude Code auth. Prefer this over `ANTHROPIC_API_KEY` (much cheaper) |
 | `exa-api-key` | `EXA_API_KEY` — Exa web search used by the research agent |
 
-If you don't already have a Claude Code OAuth token, generate one interactively:
-
-```bash
-claude setup-token
-```
-
-Then create the secret (the `$(claude setup-token)` inline below works too if you'd rather skip the separate step):
+Create the shared secret:
 
 ```bash
 kubectl create secret generic senpai-secrets \
   --from-literal=wandb-api-key="$WANDB_API_KEY" \
-  --from-literal=claude-code-oauth-token="$(claude setup-token)" \
   --from-literal=exa-api-key="$EXA_API_KEY"
 ```
 
@@ -160,10 +159,10 @@ Rotate a single key without recreating the whole secret:
 
 ```bash
 kubectl patch secret senpai-secrets \
-  --type=merge -p "{\"stringData\":{\"claude-code-oauth-token\":\"$(claude setup-token)\"}}"
+  --type=merge -p "{\"stringData\":{\"exa-api-key\":\"$EXA_API_KEY\"}}"
 ```
 
-`launch.py` does **not** preflight these — if a key is missing, pods will crash-loop on startup. `kubectl get secret senpai-secrets -o jsonpath='{.data}' | jq` confirms all three keys are present.
+`launch.py` does **not** preflight these — if a key is missing, pods will crash-loop on startup. `kubectl get secret senpai-secrets -o jsonpath='{.data}' | jq` confirms the keys are present.
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -10,21 +10,17 @@ Autonomous ML research loop powered by Claude Code agents coordinated through Gi
 
 ## How it works
 
-An **advisor** agent (no GPU) creates hypothesis PRs and assigns them to **student** agents (GPU nodes). Students implement the hypothesis, run experiments, and report results. The advisor reviews: merges winners, iterates on promising ideas, closes dead ends. All coordination happens through GitHub labels and PRs. W&B tracks metrics.
+An **advisor** pod creates experiment PRs and assigns them to **student** GPU pods. Students implement, train, and report; the advisor merges winners and closes dead ends. GitHub labels route work, and W&B tracks metrics.
 
-The repo is **problem-agnostic** — `target/` is empty by default. You bring your own problem-package repo (model, training script, data pipeline, instructions) and the pod entrypoint clones it into `target/` at startup, so the problem-package's repo root lands at `./target/`. `senpai.yaml` sets `target_repo_url:` to the repo to clone.
+`senpai` is **problem-agnostic**. The pod entrypoint clones the configured problem-package repo into `target/`, so agent commits and PRs land in that external repo, not here.
 
-### Current problem
+### Problem packages
 
-TandemFoilSet 3D velocity-field prediction, seeded from the [`tcapelle/kagent`](https://github.com/tcapelle/kagent/tree/main/tandemfoil-competition) competition as a clean Transolver-based implementation. Lives in [`morganmcg1/tandemfoil2`](https://github.com/morganmcg1/tandemfoil2) on branch `kagent_royal_rumble`. The entrypoint clones it into `target/` at pod startup.
-
-### Reference problem packages
-
-Problem packages are self-contained external repos:
-
-- [`morganmcg1/tandemfoil2`](https://github.com/morganmcg1/tandemfoil2) — **ACTIVE**. TandemFoilSet velocity prediction, kagent-seeded. Default branch `kagent_royal_rumble`.
-- [`morganmcg1/icml2026`](https://github.com/morganmcg1/icml2026) — archival. Full ICML 2026 CFD multi-dataset harness (TandemFoil, AirfRANS, DrivAerML, TandemFoil paper).
-- [`morganmcg1/cfd_tandemfoil_v1`](https://github.com/morganmcg1/cfd_tandemfoil_v1) — archival. Original v1 TandemFoil problem package, pre-ICML-2026 sprint.
+| Repo | Status | Notes |
+|---|---|---|
+| [`morganmcg1/tandemfoil2`](https://github.com/morganmcg1/tandemfoil2) | Active | TandemFoilSet velocity prediction, branch `kagent_royal_rumble` |
+| [`morganmcg1/icml2026`](https://github.com/morganmcg1/icml2026) | Archive | ICML 2026 CFD multi-dataset harness |
+| [`morganmcg1/cfd_tandemfoil_v1`](https://github.com/morganmcg1/cfd_tandemfoil_v1) | Archive | Original v1 TandemFoil package |
 
 ![val/loss over time](animated_chart.gif)
 
@@ -66,8 +62,8 @@ graph TD
 ```
 senpai/
 ├── senpai.yaml                    # Project config: problem-package repo/branch + launch defaults
-├── target/                        # Empty by default. Entrypoint clones target_repo_url here at pod startup, so the problem-package repo's root lands at ./target/.
-│   ├── train.py                   #   Training script + model (students modify this)
+├── target/                        # Problem package clone (empty by default)
+│   ├── train.py                   #   Training script + model
 │   ├── program.md                 #   Research context, metrics, constraints
 │   ├── data.py / data/            #   Data pipeline
 │   └── instructions/              #   Task-specific Claude Code prompt templates
@@ -80,24 +76,24 @@ senpai/
 │   ├── launch.py                  #   Deploy advisor + student pods
 │   ├── advisor-deployment.yaml
 │   ├── student-deployment.yaml
-│   ├── entrypoint-advisor.sh      #   Clones target_repo_url into $PROBLEM_DIR; advisor git/PRs scoped to that repo
-│   └── entrypoint-student.sh      #   Clones target_repo_url into $PROBLEM_DIR; student git/PRs scoped to that repo
+│   ├── entrypoint-advisor.sh
+│   └── entrypoint-student.sh
 ├── Dockerfile
 └── .claude/                       # Claude Code skills and agents
 ```
 
-**Important**: the senpai parent repo is problem-agnostic. Agent commits and PRs land in the **problem-package repo** (e.g. `morganmcg1/tandemfoil2`) on its working branch, never in `wandb/senpai`.
+**Important**: agent commits and PRs land in the problem-package repo, never in `wandb/senpai`.
 
 ## Configuration
 
 All project settings live in `senpai.yaml`:
 
 ```yaml
-problem_dir: target/                      # active problem directory — entrypoint clones target_repo_url here
+problem_dir: target/
 repo_url: https://github.com/wandb/senpai.git
 repo_branch: main
-target_repo_url: https://github.com/morganmcg1/tandemfoil2.git   # problem-package repo: agent commits/PRs target this
-advisor_branch: schmidhuber                                      # integration branch inside the problem-package repo (advisor PRs merge here; students branch off it)
+target_repo_url: https://github.com/morganmcg1/tandemfoil2.git
+advisor_branch: schmidhuber
 image: ghcr.io/wandb/senpai:latest
 pvc_claim_name: new-pvc
 pvc_mount_path: /mnt/new-pvc
@@ -110,64 +106,40 @@ n_students: 4
 
 `launch.py` reads this via `simple_parsing` — every field can be overridden on the CLI.
 
-### Launch credentials (per-launch)
+### Launch credentials
 
-`launch.py` resolves your GitHub token, Anthropic API key, and Exa API key at launch time and materialises them as an ephemeral, per-tag k8s Secret (`senpai-launch-secrets-<tag>`) that the pods reference for `GITHUB_TOKEN`, `ANTHROPIC_API_KEY`, and `EXA_API_KEY`.
+`launch.py` resolves these at launch time, preflights them (including `--dry_run`), and writes them to a per-tag Secret named `senpai-launch-secrets-<tag>`:
 
-GitHub token resolution order:
+| Env var | Pod env | Resolution |
+|---|---|---|
+| `GITHUB_TOKEN` | `GITHUB_TOKEN` | shell env -> `.env` -> `gh auth token` |
+| `ANTHROPIC_API_KEY` | `ANTHROPIC_API_KEY` | shell env -> `.env` |
+| `EXA_API_KEY` | `EXA_API_KEY` | shell env -> `.env` |
 
-1. `$GITHUB_TOKEN` in your shell env (shell or [`direnv`](https://direnv.net/) wins).
-2. `.env` at the senpai repo root (`GITHUB_TOKEN=ghp_...`). Not committed; don't paste into a shared file.
-3. `gh auth token` — works out-of-the-box if you're already logged into the `gh` CLI.
-
-Anthropic API key resolution order:
-
-1. `$ANTHROPIC_API_KEY` in your shell env.
-2. `.env` at the senpai repo root (`ANTHROPIC_API_KEY=sk-ant-...`).
-
-Exa API key resolution order:
-
-1. `$EXA_API_KEY` in your shell env.
-2. `.env` at the senpai repo root (`EXA_API_KEY=...`).
-
-If any credential is missing or fails preflight, `launch.py` exits with instructions. This check also runs for `--dry_run`, so dry runs confirm the rendered manifests and credential usability without mutating the cluster. Anthropic preflight uses the auth-only models endpoint; Exa preflight runs one fast, single-result search with no contents and a generic query. The launch-scoped Secret is labelled with your research tag and is cleaned up by `kubectl delete deployments,configmaps,secrets -l research-tag=<tag>` (see [Running](#running)).
-
-The repo ships an `example.env` template — copy it to `.env` and paste your credentials:
+Use `example.env` for local setup:
 
 ```bash
 cp example.env .env
-# then edit .env and set GITHUB_TOKEN=ghp_..., ANTHROPIC_API_KEY=sk-ant-..., and EXA_API_KEY=...
+# edit .env and set GITHUB_TOKEN, ANTHROPIC_API_KEY, and EXA_API_KEY
 ```
 
-`.env` is already gitignored, so the credentials stay local.
+Notes: `--dry_run` prints redacted Secret values only. Real launches pass the Secret manifest to `kubectl apply` via stdin, but Kubernetes Secrets are still readable to anyone with namespace Secret read access. Delete launch resources when done: `kubectl delete deployments,configmaps,secrets -l research-tag=<tag>`.
 
-Security notes: `--dry_run` prints only redacted placeholder Secret values. Real launches pass the Secret manifest to `kubectl apply` over stdin, not as command-line arguments, but Kubernetes Secrets are still readable by anyone with Secret read access in the namespace; use least-privilege per-launch keys where possible and delete the launch resources when the run is over.
-
-> **Target-repo permissions.** Prefer a deliberately created classic PAT (`ghp_...`) with `repo` and `read:org`; copied GitHub CLI OAuth tokens (`gho_...`) are easy to launch with stale or insufficient scopes. The token must be able to **clone** `target_repo_url` and **push branches + open/merge PRs** against it. `launch.py` preflights this against the GitHub API before spinning up pods and fails loudly if `permissions.push` is false.
+GitHub token requirements: use a PAT with `repo` and `read:org`; it must clone `target_repo_url` and push/open PRs there.
 
 ### Shared cluster secret (`senpai-secrets`)
 
-Every pod also reads the shared, cluster-wide W&B key from the `senpai-secrets` Secret. Unlike launch credentials this is not per-launch — set it once on the cluster and every tag reuses it:
-
-| Key in `senpai-secrets` | Used for |
-|---|---|
-| `wandb-api-key` | `WANDB_API_KEY` — all W&B logging from advisor + students |
-
-Create the shared secret:
+Every pod also reads `WANDB_API_KEY` from the shared `senpai-secrets` Secret:
 
 ```bash
-kubectl create secret generic senpai-secrets \
-  --from-literal=wandb-api-key="$WANDB_API_KEY"
+# Create
+kubectl create secret generic senpai-secrets --from-literal=wandb-api-key="$WANDB_API_KEY"
+
+# Rotate
+kubectl patch secret senpai-secrets --type=merge -p "{\"stringData\":{\"wandb-api-key\":\"$WANDB_API_KEY\"}}"
 ```
 
-Rotate a single key without recreating the whole secret:
-
-```bash
-kubectl patch secret senpai-secrets \
-  --type=merge -p "{\"stringData\":{\"wandb-api-key\":\"$WANDB_API_KEY\"}}"
-```
-
-`launch.py` does **not** preflight this — if the key is missing, pods will crash-loop on startup. `kubectl get secret senpai-secrets -o jsonpath='{.data}' | jq` confirms the key is present.
+`launch.py` does not preflight W&B; missing keys crash-loop pods.
 
 ## Running
 
@@ -182,16 +154,11 @@ cd target/ && python train.py --wandb_name "<name>/<description>"
 # Deploy to k8s (reads defaults from senpai.yaml, only --tag is required)
 python k8s/launch.py --tag <research-tag> --advisor
 
-# Override config via CLI
 python k8s/launch.py --tag <research-tag> --advisor --n_students 7 --pvc_mount_path "/mnt/pai-amf1-cfd"
-
-# Dry-run (print manifests, don't apply)
 python k8s/launch.py --tag <research-tag> --n_students 7 --dry_run
-
-# Pass extra instructions to the advisor
 python k8s/launch.py --tag <research-tag> --advisor --extra_instructions "Only consider optimizer changes."
 
-# Stop a launch (tears down deployments, configmaps, and the per-tag token Secret)
+# Stop a launch
 kubectl delete deployments,configmaps,secrets -l research-tag=<research-tag>
 ```
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ n_students: 4
 
 ### Launch credentials (per-launch)
 
-`launch.py` resolves your GitHub token and Anthropic API key at launch time and materialises them as an ephemeral, per-tag k8s Secret (`senpai-launch-secrets-<tag>`) that the pods reference for `GITHUB_TOKEN` and `ANTHROPIC_API_KEY`.
+`launch.py` resolves your GitHub token, Anthropic API key, and Exa API key at launch time and materialises them as an ephemeral, per-tag k8s Secret (`senpai-launch-secrets-<tag>`) that the pods reference for `GITHUB_TOKEN`, `ANTHROPIC_API_KEY`, and `EXA_API_KEY`.
 
 GitHub token resolution order:
 
@@ -125,44 +125,49 @@ Anthropic API key resolution order:
 1. `$ANTHROPIC_API_KEY` in your shell env.
 2. `.env` at the senpai repo root (`ANTHROPIC_API_KEY=sk-ant-...`).
 
-If either credential is missing or fails preflight, `launch.py` exits with instructions. This check also runs for `--dry_run`, so dry runs confirm the rendered manifests and credential usability without mutating the cluster. The launch-scoped Secret is labelled with your research tag and is cleaned up by `kubectl delete deployments,configmaps,secrets -l research-tag=<tag>` (see [Running](#running)).
+Exa API key resolution order:
+
+1. `$EXA_API_KEY` in your shell env.
+2. `.env` at the senpai repo root (`EXA_API_KEY=...`).
+
+If any credential is missing or fails preflight, `launch.py` exits with instructions. This check also runs for `--dry_run`, so dry runs confirm the rendered manifests and credential usability without mutating the cluster. Anthropic preflight uses the auth-only models endpoint; Exa preflight runs one fast, single-result search with no contents and a generic query. The launch-scoped Secret is labelled with your research tag and is cleaned up by `kubectl delete deployments,configmaps,secrets -l research-tag=<tag>` (see [Running](#running)).
 
 The repo ships an `example.env` template — copy it to `.env` and paste your credentials:
 
 ```bash
 cp example.env .env
-# then edit .env and set GITHUB_TOKEN=ghp_... and ANTHROPIC_API_KEY=sk-ant-...
+# then edit .env and set GITHUB_TOKEN=ghp_..., ANTHROPIC_API_KEY=sk-ant-..., and EXA_API_KEY=...
 ```
 
 `.env` is already gitignored, so the credentials stay local.
 
+Security notes: `--dry_run` prints only redacted placeholder Secret values. Real launches pass the Secret manifest to `kubectl apply` over stdin, not as command-line arguments, but Kubernetes Secrets are still readable by anyone with Secret read access in the namespace; use least-privilege per-launch keys where possible and delete the launch resources when the run is over.
+
 > **Target-repo permissions.** Prefer a deliberately created classic PAT (`ghp_...`) with `repo` and `read:org`; copied GitHub CLI OAuth tokens (`gho_...`) are easy to launch with stale or insufficient scopes. The token must be able to **clone** `target_repo_url` and **push branches + open/merge PRs** against it. `launch.py` preflights this against the GitHub API before spinning up pods and fails loudly if `permissions.push` is false.
 
-### Shared cluster secrets (`senpai-secrets`)
+### Shared cluster secret (`senpai-secrets`)
 
-Every pod also reads shared, cluster-wide keys from the `senpai-secrets` Secret. Unlike launch credentials these are not per-launch — set them once on the cluster and every tag reuses them:
+Every pod also reads the shared, cluster-wide W&B key from the `senpai-secrets` Secret. Unlike launch credentials this is not per-launch — set it once on the cluster and every tag reuses it:
 
 | Key in `senpai-secrets` | Used for |
 |---|---|
 | `wandb-api-key` | `WANDB_API_KEY` — all W&B logging from advisor + students |
-| `exa-api-key` | `EXA_API_KEY` — Exa web search used by the research agent |
 
 Create the shared secret:
 
 ```bash
 kubectl create secret generic senpai-secrets \
-  --from-literal=wandb-api-key="$WANDB_API_KEY" \
-  --from-literal=exa-api-key="$EXA_API_KEY"
+  --from-literal=wandb-api-key="$WANDB_API_KEY"
 ```
 
 Rotate a single key without recreating the whole secret:
 
 ```bash
 kubectl patch secret senpai-secrets \
-  --type=merge -p "{\"stringData\":{\"exa-api-key\":\"$EXA_API_KEY\"}}"
+  --type=merge -p "{\"stringData\":{\"wandb-api-key\":\"$WANDB_API_KEY\"}}"
 ```
 
-`launch.py` does **not** preflight these — if a key is missing, pods will crash-loop on startup. `kubectl get secret senpai-secrets -o jsonpath='{.data}' | jq` confirms the keys are present.
+`launch.py` does **not** preflight this — if the key is missing, pods will crash-loop on startup. `kubectl get secret senpai-secrets -o jsonpath='{.data}' | jq` confirms the key is present.
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Anthropic API key resolution order:
 1. `$ANTHROPIC_API_KEY` in your shell env.
 2. `.env` at the senpai repo root (`ANTHROPIC_API_KEY=sk-ant-...`).
 
-If either credential is missing, `launch.py` exits with instructions. The launch-scoped Secret is labelled with your research tag and is cleaned up by `kubectl delete deployments,configmaps,secrets -l research-tag=<tag>` (see [Running](#running)).
+If either credential is missing or fails preflight, `launch.py` exits with instructions. This check also runs for `--dry_run`, so dry runs confirm the rendered manifests and credential usability without mutating the cluster. The launch-scoped Secret is labelled with your research tag and is cleaned up by `kubectl delete deployments,configmaps,secrets -l research-tag=<tag>` (see [Running](#running)).
 
 The repo ships an `example.env` template — copy it to `.env` and paste your credentials:
 

--- a/example.env
+++ b/example.env
@@ -12,6 +12,10 @@
 #   1. $ANTHROPIC_API_KEY in your shell env
 #   2. .env at the senpai repo root (this file, after you rename it)
 #
+# `k8s/launch.py` reads EXA_API_KEY in this order:
+#   1. $EXA_API_KEY in your shell env
+#   2. .env at the senpai repo root (this file, after you rename it)
+#
 # Prefer a deliberately created classic PAT (`ghp_...`) for launch, not a
 # copied GitHub CLI OAuth token (`gho_...`). Required scopes for private org
 # repos: repo + read:org. The token also needs clone + push + PR-open on the
@@ -19,3 +23,4 @@
 
 GITHUB_TOKEN=
 ANTHROPIC_API_KEY=
+EXA_API_KEY=

--- a/example.env
+++ b/example.env
@@ -1,12 +1,16 @@
-# Copy this file to `.env` at the senpai repo root and fill in your token:
+# Copy this file to `.env` at the senpai repo root and fill in your credentials:
 #   cp example.env .env
 #
-# `.env` is gitignored — never commit your token.
+# `.env` is gitignored — never commit your credentials.
 #
 # `k8s/launch.py` reads GITHUB_TOKEN in this order:
 #   1. $GITHUB_TOKEN in your shell env
 #   2. .env at the senpai repo root (this file, after you rename it)
 #   3. `gh auth token`
+#
+# `k8s/launch.py` reads ANTHROPIC_API_KEY in this order:
+#   1. $ANTHROPIC_API_KEY in your shell env
+#   2. .env at the senpai repo root (this file, after you rename it)
 #
 # Prefer a deliberately created classic PAT (`ghp_...`) for launch, not a
 # copied GitHub CLI OAuth token (`gho_...`). Required scopes for private org
@@ -14,3 +18,4 @@
 # `target_repo_url` you launch against.
 
 GITHUB_TOKEN=
+ANTHROPIC_API_KEY=

--- a/k8s/advisor-deployment.yaml
+++ b/k8s/advisor-deployment.yaml
@@ -60,7 +60,7 @@ spec:
         - name: EXA_API_KEY
           valueFrom:
             secretKeyRef:
-              name: senpai-secrets
+              name: {{LAUNCH_SECRET_NAME}}
               key: exa-api-key
         resources:
           requests:

--- a/k8s/advisor-deployment.yaml
+++ b/k8s/advisor-deployment.yaml
@@ -50,18 +50,18 @@ spec:
         - name: GITHUB_TOKEN
           valueFrom:
             secretKeyRef:
-              name: {{GITHUB_TOKEN_SECRET_NAME}}
+              name: {{LAUNCH_SECRET_NAME}}
               key: github-token
+        - name: ANTHROPIC_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{LAUNCH_SECRET_NAME}}
+              key: anthropic-api-key
         - name: EXA_API_KEY
           valueFrom:
             secretKeyRef:
               name: senpai-secrets
               key: exa-api-key
-        - name: CLAUDE_CODE_OAUTH_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: senpai-secrets
-              key: claude-code-oauth-token
         resources:
           requests:
             cpu: "4"

--- a/k8s/launch.py
+++ b/k8s/launch.py
@@ -18,11 +18,13 @@ from launch_helpers import (
     expand_student_names,
     kubectl_apply,
     preflight_check_anthropic_api_key,
+    preflight_check_exa_api_key,
     preflight_check_target_repo_access,
     render_configmap,
     render_launch_secret,
     render_template,
     resolve_anthropic_api_key,
+    resolve_exa_api_key,
     resolve_github_token,
     target_repo_slug,
 )
@@ -125,9 +127,11 @@ def main():
     args = sp.parse(Args, config_path=str(SENPAI_CONFIG))
     github_token = resolve_github_token(DOTENV_PATH)
     anthropic_api_key = resolve_anthropic_api_key(DOTENV_PATH)
+    exa_api_key = resolve_exa_api_key(DOTENV_PATH)
 
     preflight_check_target_repo_access(args.target_repo_url, github_token)
     preflight_check_anthropic_api_key(anthropic_api_key)
+    preflight_check_exa_api_key(exa_api_key)
 
     # Resolve student list
     if args.names:
@@ -142,10 +146,20 @@ def main():
     # --- Apply per-launch token secret first (pods reference it on startup) ---
     if args.dry_run:
         print(f"--- Secret: {secret_name} ---")
-        print(render_launch_secret(args.tag, "<REDACTED_GITHUB_TOKEN>", "<REDACTED_ANTHROPIC_API_KEY>"))
+        print(
+            render_launch_secret(
+                args.tag,
+                "<REDACTED_GITHUB_TOKEN>",
+                "<REDACTED_ANTHROPIC_API_KEY>",
+                "<REDACTED_EXA_API_KEY>",
+            )
+        )
         print()
     else:
-        kubectl_apply(render_launch_secret(args.tag, github_token, anthropic_api_key), f"secret {secret_name}")
+        kubectl_apply(
+            render_launch_secret(args.tag, github_token, anthropic_api_key, exa_api_key),
+            f"secret {secret_name}",
+        )
 
     # --- Deploy students ---
     for name in student_list:

--- a/k8s/launch.py
+++ b/k8s/launch.py
@@ -19,8 +19,9 @@ from launch_helpers import (
     kubectl_apply,
     preflight_check_target_repo_access,
     render_configmap,
+    render_launch_secret,
     render_template,
-    render_token_secret,
+    resolve_anthropic_api_key,
     resolve_github_token,
     target_repo_slug,
 )
@@ -82,7 +83,7 @@ def render_student(template: str, student_name: str, tag: str, secret_name: str,
         "ADVISOR_BRANCH": args.advisor_branch,
         "PVC_CLAIM_NAME": args.pvc_claim_name,
         "PVC_MOUNT_PATH": args.pvc_mount_path,
-        "GITHUB_TOKEN_SECRET_NAME": secret_name,
+        "LAUNCH_SECRET_NAME": secret_name,
     })
     return configmap + "\n---\n" + deployment
 
@@ -114,17 +115,18 @@ def render_advisor(template: str, tag: str, student_list: list[str], secret_name
         "RESEARCH_TAG": tag,
         "PVC_CLAIM_NAME": args.pvc_claim_name,
         "PVC_MOUNT_PATH": args.pvc_mount_path,
-        "GITHUB_TOKEN_SECRET_NAME": secret_name,
+        "LAUNCH_SECRET_NAME": secret_name,
     })
     return configmap + "\n---\n" + deployment
 
 
 def main():
     args = sp.parse(Args, config_path=str(SENPAI_CONFIG))
-    token = resolve_github_token(DOTENV_PATH)
+    github_token = resolve_github_token(DOTENV_PATH)
+    anthropic_api_key = resolve_anthropic_api_key(DOTENV_PATH)
 
     if not args.dry_run:
-        preflight_check_target_repo_access(args.target_repo_url, token)
+        preflight_check_target_repo_access(args.target_repo_url, github_token)
 
     # Resolve student list
     if args.names:
@@ -134,15 +136,15 @@ def main():
 
     student_template = STUDENT_TEMPLATE.read_text()
     advisor_template = ADVISOR_TEMPLATE.read_text()
-    secret_name = f"senpai-github-token-{args.tag}"
+    secret_name = f"senpai-launch-secrets-{args.tag}"
 
     # --- Apply per-launch token secret first (pods reference it on startup) ---
     if args.dry_run:
         print(f"--- Secret: {secret_name} ---")
-        print(render_token_secret(args.tag, "<REDACTED>"))
+        print(render_launch_secret(args.tag, "<REDACTED_GITHUB_TOKEN>", "<REDACTED_ANTHROPIC_API_KEY>"))
         print()
     else:
-        kubectl_apply(render_token_secret(args.tag, token), f"secret {secret_name}")
+        kubectl_apply(render_launch_secret(args.tag, github_token, anthropic_api_key), f"secret {secret_name}")
 
     # --- Deploy students ---
     for name in student_list:

--- a/k8s/launch.py
+++ b/k8s/launch.py
@@ -17,6 +17,7 @@ from launch_helpers import (
     existing_student_names,
     expand_student_names,
     kubectl_apply,
+    preflight_check_anthropic_api_key,
     preflight_check_target_repo_access,
     render_configmap,
     render_launch_secret,
@@ -125,8 +126,8 @@ def main():
     github_token = resolve_github_token(DOTENV_PATH)
     anthropic_api_key = resolve_anthropic_api_key(DOTENV_PATH)
 
-    if not args.dry_run:
-        preflight_check_target_repo_access(args.target_repo_url, github_token)
+    preflight_check_target_repo_access(args.target_repo_url, github_token)
+    preflight_check_anthropic_api_key(anthropic_api_key)
 
     # Resolve student list
     if args.names:

--- a/k8s/launch_helpers.py
+++ b/k8s/launch_helpers.py
@@ -146,6 +146,36 @@ def render_launch_secret(tag: str, github_token: str, anthropic_api_key: str) ->
     )
 
 
+def preflight_check_anthropic_api_key(api_key: str) -> None:
+    """Verify the supplied Anthropic API key can authenticate to the API."""
+    print("Preflight: checking Anthropic API key", flush=True)
+    req = urllib.request.Request(
+        "https://api.anthropic.com/v1/models",
+        headers={
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+            "User-Agent": "senpai-launch-preflight",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        hint = ""
+        if e.code == 401:
+            hint = (
+                "\n  Your Anthropic API key is invalid or expired.\n"
+                "  Fix: create a fresh key and put it in .env as ANTHROPIC_API_KEY=<key>."
+            )
+        sys.exit(
+            f"ERROR: Anthropic API {e.code} for /v1/models: "
+            f"{e.read().decode(errors='replace')}{hint}"
+        )
+    except urllib.error.URLError as e:
+        sys.exit(f"ERROR: could not reach Anthropic API: {e.reason}")
+    print("  OK — Anthropic API key authenticated")
+
+
 def _oauth_scopes(header_value: str | None) -> set[str]:
     return {scope.strip() for scope in (header_value or "").split(",") if scope.strip()}
 

--- a/k8s/launch_helpers.py
+++ b/k8s/launch_helpers.py
@@ -114,20 +114,35 @@ def resolve_github_token(dotenv_path: Path) -> str:
              "at the senpai repo root, or run `gh auth login`.")
 
 
-def render_token_secret(tag: str, token: str) -> str:
-    """Per-launch k8s Secret holding only the github-token key."""
-    enc = base64.b64encode(token.encode()).decode()
+def resolve_anthropic_api_key(dotenv_path: Path) -> str:
+    """Resolve the Anthropic API key: $ANTHROPIC_API_KEY → .env → hard error."""
+    # Treat empty $ANTHROPIC_API_KEY as unset so .env fallback still kicks in.
+    if not os.environ.get("ANTHROPIC_API_KEY", "").strip():
+        os.environ.pop("ANTHROPIC_API_KEY", None)
+    _load_dotenv(dotenv_path)
+    key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
+    if key:
+        return key
+    sys.exit("ERROR: no Anthropic API key. Set $ANTHROPIC_API_KEY in your shell "
+             "or add ANTHROPIC_API_KEY=<key> to .env at the senpai repo root.")
+
+
+def render_launch_secret(tag: str, github_token: str, anthropic_api_key: str) -> str:
+    """Per-launch k8s Secret holding API credentials used by advisor/student pods."""
+    github_enc = base64.b64encode(github_token.encode()).decode()
+    anthropic_enc = base64.b64encode(anthropic_api_key.encode()).decode()
     return (
         "apiVersion: v1\n"
         "kind: Secret\n"
         "metadata:\n"
-        f"  name: senpai-github-token-{tag}\n"
+        f"  name: senpai-launch-secrets-{tag}\n"
         "  labels:\n"
         "    app: senpai\n"
         f"    research-tag: {tag}\n"
         "type: Opaque\n"
         "data:\n"
-        f"  github-token: {enc}\n"
+        f"  github-token: {github_enc}\n"
+        f"  anthropic-api-key: {anthropic_enc}\n"
     )
 
 

--- a/k8s/launch_helpers.py
+++ b/k8s/launch_helpers.py
@@ -53,7 +53,9 @@ def expand_student_names(n: int, names: list[str] = STUDENT_NAMES) -> list[str]:
 def existing_student_names(tag: str) -> list[str]:
     result = subprocess.run(
         ["kubectl", "get", "deployments", "-l", f"app=senpai,role=student,research-tag={tag}", "-o", "name"],
-        capture_output=True, text=True, check=True,
+        capture_output=True,
+        text=True,
+        check=True,
     )
     return [line.split("/senpai-", 1)[1] for line in result.stdout.splitlines()]
 
@@ -82,30 +84,52 @@ def target_repo_slug(url: str) -> str:
     return url.split("github.com", 1)[-1].lstrip(":/").removesuffix(".git")
 
 
-def _load_dotenv(path: Path) -> None:
-    """Read KEY=VAL lines from path into os.environ (doesn't override existing)."""
+LAUNCH_CREDENTIAL_ENV_NAMES = ("GITHUB_TOKEN", "ANTHROPIC_API_KEY", "EXA_API_KEY")
+
+
+def _dotenv_values(path: Path) -> dict[str, str]:
+    """Read KEY=VAL lines from path."""
+    values = {}
     if not path.exists():
-        return
+        return values
     for line in path.read_text().splitlines():
         line = line.strip()
         if not line or line.startswith("#") or "=" not in line:
             continue
         k, v = line.split("=", 1)
         v = v.strip().strip('"').strip("'")
-        os.environ.setdefault(k.strip(), v)
+        values[k.strip()] = v
+    return values
+
+
+def _subprocess_env_without_launch_credentials() -> dict[str, str]:
+    return {k: v for k, v in os.environ.items() if k not in LAUNCH_CREDENTIAL_ENV_NAMES}
+
+
+def resolve_required_secret(dotenv_path: Path, env_name: str, label: str) -> str:
+    """Resolve a required secret from the shell env, then .env."""
+    value = os.environ.get(env_name, "").strip()
+    if not value:
+        value = _dotenv_values(dotenv_path).get(env_name, "").strip()
+    if value:
+        return value
+    sys.exit(f"ERROR: no {label}. Set ${env_name} in your shell or add {env_name}=<key> to .env.")
 
 
 def resolve_github_token(dotenv_path: Path) -> str:
     """Resolve the GitHub token: $GITHUB_TOKEN → .env → `gh auth token` → hard error."""
-    # Treat empty $GITHUB_TOKEN as unset so .env fallback still kicks in.
-    if not os.environ.get("GITHUB_TOKEN", "").strip():
-        os.environ.pop("GITHUB_TOKEN", None)
-    _load_dotenv(dotenv_path)
     tok = os.environ.get("GITHUB_TOKEN", "").strip()
+    if not tok:
+        tok = _dotenv_values(dotenv_path).get("GITHUB_TOKEN", "").strip()
     if tok:
         return tok
     try:
-        res = subprocess.run(["gh", "auth", "token"], capture_output=True, text=True)
+        res = subprocess.run(
+            ["gh", "auth", "token"],
+            capture_output=True,
+            text=True,
+            env=_subprocess_env_without_launch_credentials(),
+        )
         if res.returncode == 0 and res.stdout.strip():
             return res.stdout.strip()
     except FileNotFoundError:
@@ -116,21 +140,24 @@ def resolve_github_token(dotenv_path: Path) -> str:
 
 def resolve_anthropic_api_key(dotenv_path: Path) -> str:
     """Resolve the Anthropic API key: $ANTHROPIC_API_KEY → .env → hard error."""
-    # Treat empty $ANTHROPIC_API_KEY as unset so .env fallback still kicks in.
-    if not os.environ.get("ANTHROPIC_API_KEY", "").strip():
-        os.environ.pop("ANTHROPIC_API_KEY", None)
-    _load_dotenv(dotenv_path)
-    key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
-    if key:
-        return key
-    sys.exit("ERROR: no Anthropic API key. Set $ANTHROPIC_API_KEY in your shell "
-             "or add ANTHROPIC_API_KEY=<key> to .env at the senpai repo root.")
+    return resolve_required_secret(dotenv_path, "ANTHROPIC_API_KEY", "Anthropic API key")
 
 
-def render_launch_secret(tag: str, github_token: str, anthropic_api_key: str) -> str:
+def resolve_exa_api_key(dotenv_path: Path) -> str:
+    """Resolve the Exa API key: $EXA_API_KEY → .env → hard error."""
+    return resolve_required_secret(dotenv_path, "EXA_API_KEY", "Exa API key")
+
+
+def render_launch_secret(
+    tag: str,
+    github_token: str,
+    anthropic_api_key: str,
+    exa_api_key: str,
+) -> str:
     """Per-launch k8s Secret holding API credentials used by advisor/student pods."""
     github_enc = base64.b64encode(github_token.encode()).decode()
     anthropic_enc = base64.b64encode(anthropic_api_key.encode()).decode()
+    exa_enc = base64.b64encode(exa_api_key.encode()).decode()
     return (
         "apiVersion: v1\n"
         "kind: Secret\n"
@@ -143,12 +170,46 @@ def render_launch_secret(tag: str, github_token: str, anthropic_api_key: str) ->
         "data:\n"
         f"  github-token: {github_enc}\n"
         f"  anthropic-api-key: {anthropic_enc}\n"
+        f"  exa-api-key: {exa_enc}\n"
     )
+
+
+def _api_error_summary(error: urllib.error.HTTPError, *secrets: str) -> str:
+    body = error.read().decode(errors="replace").strip()
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError:
+        summary = body
+    else:
+        err = payload.get("error", payload)
+        if isinstance(err, dict):
+            parts = [str(err[k]) for k in ("type", "tag", "message") if err.get(k)]
+            summary = ": ".join(parts) if parts else json.dumps(err, sort_keys=True)
+        else:
+            summary = str(err)
+        request_id = payload.get("request_id") or payload.get("requestId")
+        if request_id:
+            summary = f"{summary} (request id: {request_id})"
+    for secret in secrets:
+        if secret:
+            summary = summary.replace(secret, "<redacted>")
+    return (summary or "<empty response>")[:1000]
+
+
+def _preflight_http(name: str, req: urllib.request.Request, secret: str, timeout: int) -> None:
+    print(f"Preflight: checking {name}", flush=True)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        sys.exit(f"ERROR: {name} failed: HTTP {e.code}: {_api_error_summary(e, secret)}")
+    except urllib.error.URLError as e:
+        sys.exit(f"ERROR: {name} failed: {e.reason}")
+    print(f"  OK — {name} authenticated")
 
 
 def preflight_check_anthropic_api_key(api_key: str) -> None:
     """Verify the supplied Anthropic API key can authenticate to the API."""
-    print("Preflight: checking Anthropic API key", flush=True)
     req = urllib.request.Request(
         "https://api.anthropic.com/v1/models",
         headers={
@@ -157,23 +218,27 @@ def preflight_check_anthropic_api_key(api_key: str) -> None:
             "User-Agent": "senpai-launch-preflight",
         },
     )
-    try:
-        with urllib.request.urlopen(req, timeout=10) as resp:
-            json.loads(resp.read())
-    except urllib.error.HTTPError as e:
-        hint = ""
-        if e.code == 401:
-            hint = (
-                "\n  Your Anthropic API key is invalid or expired.\n"
-                "  Fix: create a fresh key and put it in .env as ANTHROPIC_API_KEY=<key>."
-            )
-        sys.exit(
-            f"ERROR: Anthropic API {e.code} for /v1/models: "
-            f"{e.read().decode(errors='replace')}{hint}"
-        )
-    except urllib.error.URLError as e:
-        sys.exit(f"ERROR: could not reach Anthropic API: {e.reason}")
-    print("  OK — Anthropic API key authenticated")
+    _preflight_http("Anthropic API key", req, api_key, timeout=10)
+
+
+def preflight_check_exa_api_key(api_key: str) -> None:
+    """Verify the supplied Exa API key can authenticate and run a minimal search."""
+    payload = json.dumps({
+        "query": "api credential preflight",
+        "type": "fast",
+        "numResults": 1,
+    }).encode()
+    req = urllib.request.Request(
+        "https://api.exa.ai/search",
+        data=payload,
+        headers={
+            "x-api-key": api_key,
+            "Content-Type": "application/json",
+            "User-Agent": "senpai-launch-preflight",
+        },
+        method="POST",
+    )
+    _preflight_http("Exa API key", req, api_key, timeout=15)
 
 
 def _oauth_scopes(header_value: str | None) -> set[str]:
@@ -209,7 +274,7 @@ def preflight_check_target_repo_access(target_repo_url: str, token: str) -> None
                 )
             sys.exit(
                 f"ERROR: GitHub API {e.code} for {path}: "
-                f"{e.read().decode(errors='replace')}{hint}"
+                f"{_api_error_summary(e, token)}{hint}"
             )
 
     perms = gh_api(f"/repos/{slug}").get("permissions", {})

--- a/k8s/secrets.yaml.template
+++ b/k8s/secrets.yaml.template
@@ -4,8 +4,7 @@
 #
 # Create the secret:
 #   kubectl create secret generic senpai-secrets \
-#     --from-literal=wandb-api-key=YOUR_KEY \
-#     --from-literal=exa-api-key=YOUR_KEY
+#     --from-literal=wandb-api-key=YOUR_KEY
 
 apiVersion: v1
 kind: Secret
@@ -14,4 +13,3 @@ metadata:
 type: Opaque
 stringData:
   wandb-api-key: "REPLACE_ME"
-  exa-api-key: "REPLACE_ME"

--- a/k8s/secrets.yaml.template
+++ b/k8s/secrets.yaml.template
@@ -5,6 +5,7 @@
 # Create the secret:
 #   kubectl create secret generic senpai-secrets \
 #     --from-literal=wandb-api-key=YOUR_KEY \
+#     --from-literal=exa-api-key=YOUR_KEY
 
 apiVersion: v1
 kind: Secret
@@ -13,3 +14,4 @@ metadata:
 type: Opaque
 stringData:
   wandb-api-key: "REPLACE_ME"
+  exa-api-key: "REPLACE_ME"

--- a/k8s/student-deployment.yaml
+++ b/k8s/student-deployment.yaml
@@ -52,18 +52,18 @@ spec:
         - name: GITHUB_TOKEN
           valueFrom:
             secretKeyRef:
-              name: {{GITHUB_TOKEN_SECRET_NAME}}
+              name: {{LAUNCH_SECRET_NAME}}
               key: github-token
+        - name: ANTHROPIC_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{LAUNCH_SECRET_NAME}}
+              key: anthropic-api-key
         - name: EXA_API_KEY
           valueFrom:
             secretKeyRef:
               name: senpai-secrets
               key: exa-api-key
-        - name: CLAUDE_CODE_OAUTH_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: senpai-secrets
-              key: claude-code-oauth-token
         resources:
           requests:
             cpu: "120"

--- a/k8s/student-deployment.yaml
+++ b/k8s/student-deployment.yaml
@@ -62,7 +62,7 @@ spec:
         - name: EXA_API_KEY
           valueFrom:
             secretKeyRef:
-              name: senpai-secrets
+              name: {{LAUNCH_SECRET_NAME}}
               key: exa-api-key
         resources:
           requests:


### PR DESCRIPTION
Date: 2026-04-27

## Summary

Launches now use a per-tag Kubernetes Secret for `GITHUB_TOKEN`, `ANTHROPIC_API_KEY`, and `EXA_API_KEY`, with credential preflight during both real launches and `--dry_run`.

## Changes

- Resolve GitHub, Anthropic, and Exa credentials from shell env / `.env` at launch time.
- Render `senpai-launch-secrets-<tag>` with `github-token`, `anthropic-api-key`, and `exa-api-key`.
- Wire advisor and student pods to read all launch credentials from that per-tag Secret.
- Remove Claude OAuth and shared Exa secret requirements from manifests/docs.
- Keep shared `senpai-secrets` focused on W&B.
- Shorten README launch/setup docs.

## Security notes

- `--dry_run` prints redacted Secret values only.
- Real launches send Secret manifests to `kubectl apply` over stdin, not command-line args.
- Provider error messages are summarized and redacted before printing.
- Kubernetes Secrets still require namespace RBAC discipline and launch cleanup.

## Validation

- `.venv/bin/python -m compileall k8s/launch.py k8s/launch_helpers.py`
- `git diff --check`
- Fake Anthropic/Exa keys fail with concise sanitized 401 messages.
- `.env` credential resolution does not mutate `os.environ`.
