### PR TITLE
Support parallel senpai launches

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,13 +102,18 @@ wandb_project: senpai-v1
 timeout_minutes: 30.0
 max_epochs: 50
 n_students: 4
+student_prefix: ""
+gpus_per_student: 8
+cpu_per_gpu: 15
+memory_gi_per_gpu: 120
+preflight_only: false
 ```
 
 `launch.py` reads this via `simple_parsing` — every field can be overridden on the CLI.
 
 ### Launch credentials
 
-`launch.py` resolves these at launch time, preflights them (including `--dry_run`), and writes them to a per-tag Secret named `senpai-launch-secrets-<tag>`:
+`launch.py` resolves and preflights these for real launches and `--preflight_only`, then writes them to a per-tag Secret named `senpai-launch-secrets-<tag>`:
 
 | Env var | Pod env | Resolution |
 |---|---|---|
@@ -123,7 +128,7 @@ cp example.env .env
 # edit .env and set GITHUB_TOKEN, ANTHROPIC_API_KEY, and EXA_API_KEY
 ```
 
-Notes: `--dry_run` prints redacted Secret values only. Real launches pass the Secret manifest to `kubectl apply` via stdin, but Kubernetes Secrets are still readable to anyone with namespace Secret read access. Delete launch resources when done: `kubectl delete deployments,configmaps,secrets -l research-tag=<tag>`.
+Notes: `--dry_run` renders redacted manifests without resolving or preflighting credentials. Real launches pass the Secret manifest to `kubectl apply` via stdin, but Kubernetes Secrets are still readable to anyone with namespace Secret read access. Delete launch resources when done: `kubectl delete deployments,configmaps,secrets -l research-tag=<tag>`.
 
 GitHub token requirements: use a PAT with `repo` and `read:org`; it must clone `target_repo_url` and push/open PRs there.
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ python k8s/launch.py --tag <research-tag> --advisor --n_students 7 --pvc_mount_p
 python k8s/launch.py --tag <research-tag> --n_students 7 --dry_run
 python k8s/launch.py --tag <research-tag> --advisor --extra_instructions "Only consider optimizer changes."
 
+# Parallel launches: use unique tags, plus --student_prefix when runs share student names
+python k8s/launch.py --tag <tag-a> --advisor --student_prefix a
+python k8s/launch.py --tag <tag-b> --advisor --student_prefix b
+
 # Stop a launch
 kubectl delete deployments,configmaps,secrets -l research-tag=<research-tag>
 ```

--- a/k8s/advisor-deployment.yaml
+++ b/k8s/advisor-deployment.yaml
@@ -8,7 +8,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: senpai-advisor
+  name: {{ADVISOR_DEPLOYMENT_NAME}}
   labels:
     app: senpai
     role: advisor
@@ -19,6 +19,7 @@ spec:
     matchLabels:
       app: senpai
       role: advisor
+      research-tag: {{RESEARCH_TAG}}
   template:
     metadata:
       labels:
@@ -40,7 +41,7 @@ spec:
           bash k8s/entrypoint-advisor.sh
         envFrom:
         - configMapRef:
-            name: senpai-config-advisor
+            name: {{ADVISOR_CONFIGMAP_NAME}}
         env:
         - name: WANDB_API_KEY
           valueFrom:

--- a/k8s/entrypoint-advisor.sh
+++ b/k8s/entrypoint-advisor.sh
@@ -77,7 +77,7 @@ if [ -n "${EXTRA_INSTRUCTIONS_B64:-}" ]; then
 fi
 
 # Add "$KEY_INFO" (reminder of student names etc) to PROMPT
-KEY_INFO=$'\n\n Key information:\n\n Students: '"$STUDENT_NAMES"' | Tag: '"$RESEARCH_TAG"' | Target repo: '"$GH_REPO"' | Advisor Branch: '"$ADVISOR_BRANCH"' | W&B entity/project: '"$WANDB_ENTITY"'/'"$WANDB_PROJECT"$'\n'
+KEY_INFO=$'\n\n Key information:\n\n Students: '"$STUDENT_NAMES"' | Student GPUs: '"$STUDENT_GPU_COUNT"' | Tag: '"$RESEARCH_TAG"' | Target repo: '"$GH_REPO"' | Advisor Branch: '"$ADVISOR_BRANCH"' | W&B entity/project: '"$WANDB_ENTITY"'/'"$WANDB_PROJECT"$'\n'
 FULL_PROMPT="${PROMPT}"$'\n\n'"${KEY_INFO}"
 
 # Heartbeat prompt for polling
@@ -104,7 +104,7 @@ while true; do
     # Overwrite CLAUDE.md with advisor-specific one — CC's git operations may clobber it with the developer copy.
     # Whitelist vars so envsubst substitutes pod env vars but leaves Claude Code runtime vars
     # like ${CLAUDE_PLUGIN_ROOT} alone (those get expanded by the agent's shell at call time).
-    envsubst '$PROBLEM_DIR $TARGET_REPO_URL $GH_REPO $ADVISOR_BRANCH $RESEARCH_TAG $WANDB_ENTITY $WANDB_PROJECT' \
+    envsubst '$PROBLEM_DIR $TARGET_REPO_URL $GH_REPO $ADVISOR_BRANCH $RESEARCH_TAG $STUDENT_GPU_COUNT $WANDB_ENTITY $WANDB_PROJECT' \
         < "$WORKDIR/system_instructions/CLAUDE-ADVISOR.md" \
         | sed '/^<!--$/,/^-->$/d' \
         > "$WORKDIR/CLAUDE.md"

--- a/k8s/entrypoint-advisor.sh
+++ b/k8s/entrypoint-advisor.sh
@@ -77,7 +77,7 @@ if [ -n "${EXTRA_INSTRUCTIONS_B64:-}" ]; then
 fi
 
 # Add "$KEY_INFO" (reminder of student names etc) to PROMPT
-KEY_INFO=$'\n\n Key information:\n\n Students: '"$STUDENT_NAMES"' | Student GPUs: '"$STUDENT_GPU_COUNT"' | Tag: '"$RESEARCH_TAG"' | Target repo: '"$GH_REPO"' | Advisor Branch: '"$ADVISOR_BRANCH"' | W&B entity/project: '"$WANDB_ENTITY"'/'"$WANDB_PROJECT"$'\n'
+KEY_INFO=$'\n\n Key information:\n\n Students: '"$STUDENT_NAMES"' | GPUs per Student: '"$GPUS_PER_STUDENT"' | Tag: '"$RESEARCH_TAG"' | Target repo: '"$GH_REPO"' | Advisor Branch: '"$ADVISOR_BRANCH"' | W&B entity/project: '"$WANDB_ENTITY"'/'"$WANDB_PROJECT"$'\n'
 FULL_PROMPT="${PROMPT}"$'\n\n'"${KEY_INFO}"
 
 # Heartbeat prompt for polling
@@ -104,7 +104,7 @@ while true; do
     # Overwrite CLAUDE.md with advisor-specific one — CC's git operations may clobber it with the developer copy.
     # Whitelist vars so envsubst substitutes pod env vars but leaves Claude Code runtime vars
     # like ${CLAUDE_PLUGIN_ROOT} alone (those get expanded by the agent's shell at call time).
-    envsubst '$PROBLEM_DIR $TARGET_REPO_URL $GH_REPO $ADVISOR_BRANCH $RESEARCH_TAG $STUDENT_GPU_COUNT $WANDB_ENTITY $WANDB_PROJECT' \
+    envsubst '$PROBLEM_DIR $TARGET_REPO_URL $GH_REPO $ADVISOR_BRANCH $RESEARCH_TAG $GPUS_PER_STUDENT $WANDB_ENTITY $WANDB_PROJECT' \
         < "$WORKDIR/system_instructions/CLAUDE-ADVISOR.md" \
         | sed '/^<!--$/,/^-->$/d' \
         > "$WORKDIR/CLAUDE.md"

--- a/k8s/entrypoint-student.sh
+++ b/k8s/entrypoint-student.sh
@@ -56,7 +56,7 @@ source "$SENPAI_PLUGIN/scripts/senpai-gh.sh"
 TASK_INSTRUCTIONS="$(envsubst < "$WORKDIR/$PROBLEM_DIR/instructions/prompt-student.md" | sed '/^<!--$/,/^-->$/d')"
 PROMPT="${TASK_INSTRUCTIONS}"
 
-KEY_INFO=$'\n\nKey information:\n\nStudent: '"$STUDENT_NAME"' | GPUs: '"$STUDENT_GPU_COUNT"' | Target repo: '"$GH_REPO"' | Advisor Branch: '"$ADVISOR_BRANCH"' | W&B entity/project: '"$WANDB_ENTITY"'/'"$WANDB_PROJECT"$'\n'
+KEY_INFO=$'\n\nKey information:\n\nStudent: '"$STUDENT_NAME"' | GPUs per Student: '"$GPUS_PER_STUDENT"' | Target repo: '"$GH_REPO"' | Advisor Branch: '"$ADVISOR_BRANCH"' | W&B entity/project: '"$WANDB_ENTITY"'/'"$WANDB_PROJECT"$'\n'
 FULL_PROMPT="${PROMPT}"$'\n\n'"${KEY_INFO}"
 
 HEARTBEAT_PROMPT="Continue your student loop using the assigned PRs and GitHub issues listed in the Student research state below. The entrypoint owns assignment polling; do not start persistent GitHub polling monitors. For active training, use sparse wakeups plus training_log_status; do not stream per-epoch logs into Monitor."
@@ -83,7 +83,7 @@ while true; do
     # Overwrite CLAUDE.md with the student role instructions — git checkout/pull clobbers it with the developer copy.
     # Whitelist vars so envsubst substitutes pod env vars but leaves Claude Code runtime vars
     # like ${CLAUDE_PLUGIN_ROOT} alone (those get expanded by the agent's shell at call time).
-    envsubst '$PROBLEM_DIR $TARGET_REPO_URL $GH_REPO $ADVISOR_BRANCH $RESEARCH_TAG $STUDENT_NAME $STUDENT_GPU_COUNT $WANDB_ENTITY $WANDB_PROJECT' \
+    envsubst '$PROBLEM_DIR $TARGET_REPO_URL $GH_REPO $ADVISOR_BRANCH $RESEARCH_TAG $STUDENT_NAME $GPUS_PER_STUDENT $WANDB_ENTITY $WANDB_PROJECT' \
         < "$WORKDIR/system_instructions/CLAUDE-STUDENT.md" \
         | sed '/^<!--$/,/^-->$/d' \
         > "$WORKDIR/CLAUDE.md"

--- a/k8s/entrypoint-student.sh
+++ b/k8s/entrypoint-student.sh
@@ -56,7 +56,7 @@ source "$SENPAI_PLUGIN/scripts/senpai-gh.sh"
 TASK_INSTRUCTIONS="$(envsubst < "$WORKDIR/$PROBLEM_DIR/instructions/prompt-student.md" | sed '/^<!--$/,/^-->$/d')"
 PROMPT="${TASK_INSTRUCTIONS}"
 
-KEY_INFO=$'\n\nKey information:\n\nStudent: '"$STUDENT_NAME"' | Target repo: '"$GH_REPO"' | Advisor Branch: '"$ADVISOR_BRANCH"' | W&B entity/project: '"$WANDB_ENTITY"'/'"$WANDB_PROJECT"$'\n'
+KEY_INFO=$'\n\nKey information:\n\nStudent: '"$STUDENT_NAME"' | GPUs: '"$STUDENT_GPU_COUNT"' | Target repo: '"$GH_REPO"' | Advisor Branch: '"$ADVISOR_BRANCH"' | W&B entity/project: '"$WANDB_ENTITY"'/'"$WANDB_PROJECT"$'\n'
 FULL_PROMPT="${PROMPT}"$'\n\n'"${KEY_INFO}"
 
 HEARTBEAT_PROMPT="Continue your student loop using the assigned PRs and GitHub issues listed in the Student research state below. The entrypoint owns assignment polling; do not start persistent GitHub polling monitors. For active training, use sparse wakeups plus training_log_status; do not stream per-epoch logs into Monitor."
@@ -83,7 +83,7 @@ while true; do
     # Overwrite CLAUDE.md with the student role instructions — git checkout/pull clobbers it with the developer copy.
     # Whitelist vars so envsubst substitutes pod env vars but leaves Claude Code runtime vars
     # like ${CLAUDE_PLUGIN_ROOT} alone (those get expanded by the agent's shell at call time).
-    envsubst '$PROBLEM_DIR $TARGET_REPO_URL $GH_REPO $ADVISOR_BRANCH $RESEARCH_TAG $STUDENT_NAME $WANDB_ENTITY $WANDB_PROJECT' \
+    envsubst '$PROBLEM_DIR $TARGET_REPO_URL $GH_REPO $ADVISOR_BRANCH $RESEARCH_TAG $STUDENT_NAME $STUDENT_GPU_COUNT $WANDB_ENTITY $WANDB_PROJECT' \
         < "$WORKDIR/system_instructions/CLAUDE-STUDENT.md" \
         | sed '/^<!--$/,/^-->$/d' \
         > "$WORKDIR/CLAUDE.md"

--- a/k8s/launch.py
+++ b/k8s/launch.py
@@ -36,7 +36,6 @@ ADVISOR_TEMPLATE = Path(__file__).parent / "advisor-deployment.yaml"
 SENPAI_CONFIG = Path(__file__).parent.parent / "senpai.yaml"
 DOTENV_PATH = Path(__file__).parent.parent / ".env"
 
-
 @dataclass
 class Args:
     """Launch senpai advisor and/or student agents on Kubernetes."""

--- a/k8s/launch.py
+++ b/k8s/launch.py
@@ -35,7 +35,6 @@ STUDENT_TEMPLATE = Path(__file__).parent / "student-deployment.yaml"
 ADVISOR_TEMPLATE = Path(__file__).parent / "advisor-deployment.yaml"
 SENPAI_CONFIG = Path(__file__).parent.parent / "senpai.yaml"
 DOTENV_PATH = Path(__file__).parent.parent / ".env"
-
 @dataclass
 class Args:
     """Launch senpai advisor and/or student agents on Kubernetes."""

--- a/k8s/launch.py
+++ b/k8s/launch.py
@@ -16,6 +16,7 @@ import simple_parsing as sp
 from launch_helpers import (
     existing_student_names,
     expand_student_names,
+    ensure_target_repo_labels,
     kubectl_apply,
     preflight_check_anthropic_api_key,
     preflight_check_exa_api_key,
@@ -26,6 +27,7 @@ from launch_helpers import (
     resolve_anthropic_api_key,
     resolve_exa_api_key,
     resolve_github_token,
+    routing_labels,
     target_repo_slug,
 )
 
@@ -43,6 +45,10 @@ class Args:
     problem_dir: str = "target/"  # active problem directory — entrypoint clones target_repo_url here (from senpai.yaml)
     names: str = ""  # comma-separated student names (e.g. "frieren,fern")
     n_students: int = 4  # number of students to launch (ignored if --names is provided)
+    student_prefix: str = ""  # make assignment labels unique across parallel launches using the same base names
+    gpus_per_student: int = 8  # GPUs requested by each student pod
+    cpu_per_gpu: int = 15  # CPU requested per student GPU
+    memory_gi_per_gpu: int = 120  # memory Gi requested per student GPU
     repo_url: str = "https://github.com/wandb/senpai.git"  # git repo URL (senpai runner)
     repo_branch: str = "main"  # git branch to clone (senpai runner)
     image: str = "ghcr.io/wandb/senpai:latest"  # container image for students
@@ -55,12 +61,17 @@ class Args:
     extra_instructions: str = ""  # extra prompt text for the advisor: a .md file path or a literal string
     timeout_minutes: float = 30.0  # training run wall-clock limit (SENPAI_TIMEOUT_MINUTES)
     max_epochs: int = 50  # maximum training epochs (SENPAI_MAX_EPOCHS)
-    dry_run: bool = False  # print manifests without applying
+    dry_run: bool = False  # render manifests only: do not apply them or validate credentials
+    preflight_only: bool = False  # validate credentials/access only: do not render or apply manifests
 
 
 def render_student(template: str, student_name: str, tag: str, secret_name: str, args: Args) -> str:
+    student_configmap_name = f"senpai-config-student-{tag}-{student_name}"
+    student_deployment_name = f"senpai-{tag}-{student_name}"
+    student_cpu = args.cpu_per_gpu * args.gpus_per_student
+    student_memory_gi = args.memory_gi_per_gpu * args.gpus_per_student
     configmap = render_configmap(
-        name=f"senpai-config-student-{student_name}",
+        name=student_configmap_name,
         labels={"app": "senpai", "role": "student", "research-tag": tag},
         data={
             "REPO_URL": args.repo_url,
@@ -69,6 +80,7 @@ def render_student(template: str, student_name: str, tag: str, secret_name: str,
             "GH_REPO": target_repo_slug(args.target_repo_url),
             "STUDENT_NAME": student_name,
             "RESEARCH_TAG": tag,
+            "GPUS_PER_STUDENT": str(args.gpus_per_student),
             "WANDB_ENTITY": args.wandb_entity,
             "WANDB_PROJECT": args.wandb_project,
             "ADVISOR_BRANCH": args.advisor_branch,
@@ -80,6 +92,8 @@ def render_student(template: str, student_name: str, tag: str, secret_name: str,
         },
     )
     deployment = render_template(template, {
+        "STUDENT_DEPLOYMENT_NAME": student_deployment_name,
+        "STUDENT_CONFIGMAP_NAME": student_configmap_name,
         "STUDENT_NAME": student_name,
         "RESEARCH_TAG": tag,
         "IMAGE": args.image,
@@ -87,11 +101,16 @@ def render_student(template: str, student_name: str, tag: str, secret_name: str,
         "PVC_CLAIM_NAME": args.pvc_claim_name,
         "PVC_MOUNT_PATH": args.pvc_mount_path,
         "LAUNCH_SECRET_NAME": secret_name,
+        "STUDENT_CPU": str(student_cpu),
+        "STUDENT_MEMORY": f"{student_memory_gi}Gi",
+        "GPUS_PER_STUDENT": str(args.gpus_per_student),
     })
     return configmap + "\n---\n" + deployment
 
 
 def render_advisor(template: str, tag: str, student_list: list[str], secret_name: str, args: Args) -> str:
+    advisor_configmap_name = f"senpai-config-advisor-{tag}"
+    advisor_deployment_name = f"senpai-advisor-{tag}"
     data = {
         "REPO_URL": args.repo_url,
         "REPO_BRANCH": args.repo_branch,
@@ -99,6 +118,7 @@ def render_advisor(template: str, tag: str, student_list: list[str], secret_name
         "GH_REPO": target_repo_slug(args.target_repo_url),
         "RESEARCH_TAG": tag,
         "STUDENT_NAMES": ",".join(student_list),
+        "GPUS_PER_STUDENT": str(args.gpus_per_student),
         "WANDB_ENTITY": args.wandb_entity,
         "WANDB_PROJECT": args.wandb_project,
         "ADVISOR_BRANCH": args.advisor_branch,
@@ -110,11 +130,13 @@ def render_advisor(template: str, tag: str, student_list: list[str], secret_name
         content = p.read_text() if p.exists() else args.extra_instructions
         data["EXTRA_INSTRUCTIONS_B64"] = base64.b64encode(content.encode()).decode()
     configmap = render_configmap(
-        name="senpai-config-advisor",
+        name=advisor_configmap_name,
         labels={"app": "senpai", "role": "advisor", "research-tag": tag},
         data=data,
     )
     deployment = render_template(template, {
+        "ADVISOR_DEPLOYMENT_NAME": advisor_deployment_name,
+        "ADVISOR_CONFIGMAP_NAME": advisor_configmap_name,
         "RESEARCH_TAG": tag,
         "PVC_CLAIM_NAME": args.pvc_claim_name,
         "PVC_MOUNT_PATH": args.pvc_mount_path,
@@ -125,19 +147,31 @@ def render_advisor(template: str, tag: str, student_list: list[str], secret_name
 
 def main():
     args = sp.parse(Args, config_path=str(SENPAI_CONFIG))
-    github_token = resolve_github_token(DOTENV_PATH)
-    anthropic_api_key = resolve_anthropic_api_key(DOTENV_PATH)
-    exa_api_key = resolve_exa_api_key(DOTENV_PATH)
+    if min(args.gpus_per_student, args.cpu_per_gpu, args.memory_gi_per_gpu) < 1:
+        sys.exit("ERROR: --gpus_per_student, --cpu_per_gpu, and --memory_gi_per_gpu must all be at least 1")
 
-    preflight_check_target_repo_access(args.target_repo_url, github_token)
-    preflight_check_anthropic_api_key(anthropic_api_key)
-    preflight_check_exa_api_key(exa_api_key)
+    github_token = anthropic_api_key = exa_api_key = ""
+    if not args.dry_run or args.preflight_only:
+        github_token = resolve_github_token(DOTENV_PATH)
+        anthropic_api_key = resolve_anthropic_api_key(DOTENV_PATH)
+        exa_api_key = resolve_exa_api_key(DOTENV_PATH)
+        preflight_check_target_repo_access(args.target_repo_url, github_token)
+        preflight_check_anthropic_api_key(anthropic_api_key)
+        preflight_check_exa_api_key(exa_api_key)
+        if args.preflight_only:
+            print("Preflight OK — credentials and target repo access verified.")
+            return
 
     # Resolve student list
     if args.names:
         student_list = [n.strip() for n in args.names.split(",")]
     else:
         student_list = expand_student_names(args.n_students)
+    if args.student_prefix:
+        student_list = [f"{args.student_prefix}-{name}" for name in student_list]
+
+    if not args.dry_run:
+        ensure_target_repo_labels(args.target_repo_url, github_token, routing_labels(args.advisor_branch, student_list))
 
     student_template = STUDENT_TEMPLATE.read_text()
     advisor_template = ADVISOR_TEMPLATE.read_text()
@@ -191,9 +225,10 @@ def main():
             print("Launched advisor pod")
         print(f"\nMonitor:")
         print(f"  kubectl get deployments -l research-tag={args.tag}")
-        print(f"  kubectl get deployment senpai-advisor")
+        if args.advisor:
+            print(f"  kubectl get deployment senpai-advisor-{args.tag}")
         if student_list:
-            print(f"  kubectl logs -f deployment/senpai-{student_list[0]}")
+            print(f"  kubectl logs -f deployment/senpai-{args.tag}-{student_list[0]}")
         print(f"\nStop:")
         print(f"  kubectl delete deployments,configmaps,secrets -l research-tag={args.tag}")
 

--- a/k8s/launch_helpers.py
+++ b/k8s/launch_helpers.py
@@ -14,6 +14,7 @@ import os
 import subprocess
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 
@@ -33,6 +34,11 @@ STUDENT_NAMES = [
     "himmel", "mugen", "jin",
 ]
 
+LABEL_COLOR_ADVISOR_BRANCH = "0075ca"
+LABEL_COLOR_STATUS_WIP = "fbca04"
+LABEL_COLOR_STATUS_REVIEW = "0e8a16"
+LABEL_COLOR_STUDENT = "f9d0c4"
+
 
 def expand_student_names(n: int, names: list[str] = STUDENT_NAMES) -> list[str]:
     """Return n student names, cycling through `names` with a numeric suffix
@@ -50,14 +56,33 @@ def expand_student_names(n: int, names: list[str] = STUDENT_NAMES) -> list[str]:
     return out
 
 
+def routing_labels(advisor_branch: str, student_names: list[str]) -> dict[str, tuple[str, str]]:
+    """Labels required for advisor/student PR routing."""
+    return {
+        advisor_branch: (LABEL_COLOR_ADVISOR_BRANCH, f"Advisor branch: {advisor_branch}"),
+        "status:wip": (LABEL_COLOR_STATUS_WIP, "Work in progress"),
+        "status:review": (LABEL_COLOR_STATUS_REVIEW, "Ready for advisor review"),
+        **{
+            f"student:{name}": (LABEL_COLOR_STUDENT, f"Assigned to student {name}")
+            for name in student_names
+        },
+    }
+
+
 def existing_student_names(tag: str) -> list[str]:
     result = subprocess.run(
-        ["kubectl", "get", "deployments", "-l", f"app=senpai,role=student,research-tag={tag}", "-o", "name"],
-        capture_output=True,
-        text=True,
-        check=True,
+        [
+            "kubectl",
+            "get",
+            "deployments",
+            "-l",
+            f"app=senpai,role=student,research-tag={tag}",
+            "-o",
+            'jsonpath={range .items[*]}{.metadata.labels.student}{"\\n"}{end}',
+        ],
+        capture_output=True, text=True, check=True,
     )
-    return [line.split("/senpai-", 1)[1] for line in result.stdout.splitlines()]
+    return [line for line in result.stdout.splitlines() if line]
 
 
 def render_template(template: str, replacements: dict[str, str]) -> str:
@@ -292,6 +317,46 @@ def preflight_check_target_repo_access(target_repo_url: str, token: str) -> None
              f"  permissions: {perms}\n"
              f"  Fix: supply a token with write on {slug} via $GITHUB_TOKEN / .env / gh auth, "
              f"or grant '{user}' collaborator write on {slug}.")
+
+
+def ensure_target_repo_labels(target_repo_url: str, token: str, labels: dict[str, tuple[str, str]]) -> None:
+    """Create missing GitHub labels used for Senpai assignment routing."""
+    slug = target_repo_slug(target_repo_url)
+    print(f"Preflight: ensuring routing labels on {slug}")
+
+    def gh_api(path: str, method: str = "GET", data: bytes | None = None) -> dict:
+        req = urllib.request.Request(
+            f"https://api.github.com{path}",
+            data=data,
+            method=method,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "Content-Type": "application/json",
+                "User-Agent": "senpai-launch-preflight",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return json.loads(resp.read() or b"{}")
+
+    for name, (color, description) in labels.items():
+        encoded = urllib.parse.quote(name, safe="")
+        try:
+            gh_api(f"/repos/{slug}/labels/{encoded}")
+            continue
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                payload = json.dumps({
+                    "name": name,
+                    "color": color,
+                    "description": description,
+                }).encode()
+                gh_api(f"/repos/{slug}/labels", method="POST", data=payload)
+                print(f"  created label {name}")
+                continue
+
+            print(f"GitHub label check failed for {name!r}", file=sys.stderr)
+            raise
 
 
 def kubectl_apply(manifest: str, name: str) -> None:

--- a/k8s/student-deployment.yaml
+++ b/k8s/student-deployment.yaml
@@ -70,11 +70,11 @@ spec:
           requests:
             cpu: "{{STUDENT_CPU}}"
             memory: "{{STUDENT_MEMORY}}"
-            nvidia.com/gpu: "{{STUDENT_GPUS}}"
+            nvidia.com/gpu: "{{GPUS_PER_STUDENT}}"
           limits:
             cpu: "{{STUDENT_CPU}}"
             memory: "{{STUDENT_MEMORY}}"
-            nvidia.com/gpu: "{{STUDENT_GPUS}}"
+            nvidia.com/gpu: "{{GPUS_PER_STUDENT}}"
         volumeMounts:
         - name: dshm
           mountPath: /dev/shm

--- a/k8s/student-deployment.yaml
+++ b/k8s/student-deployment.yaml
@@ -8,10 +8,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: senpai-{{STUDENT_NAME}}
+  name: {{STUDENT_DEPLOYMENT_NAME}}
   labels:
     app: senpai
     role: student
+    student: {{STUDENT_NAME}}
     research-tag: {{RESEARCH_TAG}}
 spec:
   replicas: 1
@@ -21,6 +22,7 @@ spec:
     matchLabels:
       app: senpai
       student: {{STUDENT_NAME}}
+      research-tag: {{RESEARCH_TAG}}
   template:
     metadata:
       labels:
@@ -42,7 +44,7 @@ spec:
           bash k8s/entrypoint-student.sh
         envFrom:
         - configMapRef:
-            name: senpai-config-student-{{STUDENT_NAME}}
+            name: {{STUDENT_CONFIGMAP_NAME}}
         env:
         - name: WANDB_API_KEY
           valueFrom:
@@ -66,13 +68,13 @@ spec:
               key: exa-api-key
         resources:
           requests:
-            cpu: "120"
-            memory: "960Gi"
-            nvidia.com/gpu: "8"
+            cpu: "{{STUDENT_CPU}}"
+            memory: "{{STUDENT_MEMORY}}"
+            nvidia.com/gpu: "{{STUDENT_GPUS}}"
           limits:
-            cpu: "120"
-            memory: "960Gi"
-            nvidia.com/gpu: "8"
+            cpu: "{{STUDENT_CPU}}"
+            memory: "{{STUDENT_MEMORY}}"
+            nvidia.com/gpu: "{{STUDENT_GPUS}}"
         volumeMounts:
         - name: dshm
           mountPath: /dev/shm

--- a/plugins/senpai/scripts/senpai-gh.sh
+++ b/plugins/senpai/scripts/senpai-gh.sh
@@ -404,12 +404,16 @@ list_all_prs() {
         --json number,title,state,labels,headRefName,updatedAt,isDraft
 }
 
-# List WIP PRs assigned to a specific student.
+# List WIP PRs assigned to a specific student on the current advisor branch.
 # Returns a JSON array.
-#   student_poll_for_work <student_name>
+#   student_poll_for_work <student_name> [advisor_branch]
 student_poll_for_work() {
-    local name="$1"
-    gh_retry gh pr list --label "student:${name}" --label "status:wip" \
+    local name="$1" branch="${2:-${ADVISOR_BRANCH:-}}"
+    if [ -z "$branch" ]; then
+        echo "student_poll_for_work: missing advisor branch" >&2
+        return 2
+    fi
+    gh_retry gh pr list --label "$branch" --label "student:${name}" --label "status:wip" \
         --limit "$GH_LIST_LIMIT" \
         --json number,title,headRefName,updatedAt,body
 }

--- a/plugins/senpai/skills/poll-for-work/SKILL.md
+++ b/plugins/senpai/skills/poll-for-work/SKILL.md
@@ -19,7 +19,7 @@ Check whether the advisor has assigned you an experiment PR to work on. This is 
 
 Assignments are Github labels, not GitHub assignees:
 
-- A PR is assigned to you only when it has both `student:$0` and `status:wip`.
+- A PR is assigned to you only when it has `$ADVISOR_BRANCH`, `student:$0`, and `status:wip`.
 - Never use `gh pr list --assignee ...`, `--author`, or a hand-written replacement query for assignment polling.
 - Do not use the Claude Code `Monitor` tool for assignment polling. The pod entrypoint owns waiting and re-entry.
 

--- a/plugins/senpai/skills/poll-for-work/SKILL.md
+++ b/plugins/senpai/skills/poll-for-work/SKILL.md
@@ -19,7 +19,7 @@ Check whether the advisor has assigned you an experiment PR to work on. This is 
 
 Assignments are Github labels, not GitHub assignees:
 
-- The current advisor branch is also a routing label. A PR is assigned to you only when it has the current `$ADVISOR_BRANCH` label, `student:$0`, and `status:wip`.
+- The current advisor branch is also a routing label. A PR is assigned to you only when it has the following labels: `$ADVISOR_BRANCH` (current advisor branch), your name label like so: `student:$0`, and this status label: `status:wip`.
 - Never use `gh pr list --assignee ...`, `--author`, or a hand-written replacement query for assignment polling.
 - Do not use the Claude Code `Monitor` tool for assignment polling. The pod entrypoint owns waiting and re-entry.
 

--- a/plugins/senpai/skills/poll-for-work/SKILL.md
+++ b/plugins/senpai/skills/poll-for-work/SKILL.md
@@ -19,7 +19,7 @@ Check whether the advisor has assigned you an experiment PR to work on. This is 
 
 Assignments are Github labels, not GitHub assignees:
 
-- A PR is assigned to you only when it has `$ADVISOR_BRANCH`, `student:$0`, and `status:wip`.
+- The current advisor branch is also a routing label. A PR is assigned to you only when it has the current `$ADVISOR_BRANCH` label, `student:$0`, and `status:wip`.
 - Never use `gh pr list --assignee ...`, `--author`, or a hand-written replacement query for assignment polling.
 - Do not use the Claude Code `Monitor` tool for assignment polling. The pod entrypoint owns waiting and re-entry.
 

--- a/plugins/senpai/skills/senpai-gh/SKILL.md
+++ b/plugins/senpai/skills/senpai-gh/SKILL.md
@@ -65,7 +65,7 @@ The default repo for `gh` is set via the injected `GH_REPO` env var, so no `--re
 | `issue_with_comments <issue#>` | Read one issue and all comments through REST pagination. Returns JSON object. |
 | `list_ready_for_review_prs <branch>` | List PRs with `status:review` on a branch. Returns JSON array. |
 | `list_all_prs <branch>` | List all open PRs on a branch (any status). Returns JSON array. |
-| `student_poll_for_work <student_name>` | List WIP PRs assigned to a student. Returns JSON array. |
+| `student_poll_for_work <student_name> [branch]` | List branch-scoped WIP PRs assigned to a student. Returns JSON array. |
 | `list_idle_students <names_csv> <branch>` | Print names of students with no `status:wip` PR, one per line. |
 | `pr_body <pr#>` | Read one PR body through REST. Returns JSON. |
 | `pr_issue_comments <pr#>` | Read all PR conversation comments through REST pagination. Returns JSON array. |

--- a/senpai.yaml
+++ b/senpai.yaml
@@ -36,4 +36,6 @@ max_epochs: 50
 n_students: 4
 student_prefix: ""
 gpus_per_student: 8
+cpu_per_gpu: 15
+memory_gi_per_gpu: 120
 preflight_only: false

--- a/senpai.yaml
+++ b/senpai.yaml
@@ -34,3 +34,6 @@ max_epochs: 50
 
 # students
 n_students: 4
+student_prefix: ""
+gpus_per_student: 8
+preflight_only: false

--- a/system_instructions/CLAUDE-ADVISOR.md
+++ b/system_instructions/CLAUDE-ADVISOR.md
@@ -117,7 +117,7 @@ You run inside a pod entrypoint harness: it invokes Claude Code, passes the late
 
    In multi-benchmark targets like `target/icml2026`, the default unit of work
    should be a hypothesis family that is tested across all relevant datasets,
-   not a one-off single-benchmark tweak. Use the student's 8 GPUs to cover a
+   not a one-off single-benchmark tweak. Use the student's $STUDENT_GPU_COUNT GPUs to cover a
    small matrix across datasets and nearby variants unless a single-dataset
    frontier closure or best-checkpoint recovery run is clearly the highest-value
    use of that slot.

--- a/system_instructions/CLAUDE-ADVISOR.md
+++ b/system_instructions/CLAUDE-ADVISOR.md
@@ -117,7 +117,7 @@ You run inside a pod entrypoint harness: it invokes Claude Code, passes the late
 
    In multi-benchmark targets like `target/icml2026`, the default unit of work
    should be a hypothesis family that is tested across all relevant datasets,
-   not a one-off single-benchmark tweak. Use the student's $STUDENT_GPU_COUNT GPUs to cover a
+   not a one-off single-benchmark tweak. Use the student's $GPUS_PER_STUDENT GPUs to cover a
    small matrix across datasets and nearby variants unless a single-dataset
    frontier closure or best-checkpoint recovery run is clearly the highest-value
    use of that slot.

--- a/system_instructions/CLAUDE-STUDENT.md
+++ b/system_instructions/CLAUDE-STUDENT.md
@@ -92,7 +92,7 @@ swap_gh_pr_label <pr#> "status:wip" "status:review"
      pr_all_comments <number>
      ```
      If the advisor has left new instructions (e.g. to try a different variant, abort the current direction, or adjust parameters), follow them instead of proceeding with the original plan.
-   - If the PR is intentionally cross-dataset, use your $STUDENT_GPU_COUNT GPUs to cover the
+   - If the PR is intentionally cross-dataset, use your $GPUS_PER_STUDENT GPUs to cover the
      requested dataset matrix and keep the reported results grouped by dataset
      so transfer or non-transfer is obvious.
 

--- a/system_instructions/CLAUDE-STUDENT.md
+++ b/system_instructions/CLAUDE-STUDENT.md
@@ -43,7 +43,7 @@ swap_gh_pr_label <pr#> "status:wip" "status:review"
 
 1. **Poll for work**
    The pod entrypoint polls before invoking you. The `## Student research state` block in your prompt is the source of truth for the current assignment.
-   - PR assignments are label-based: assigned work has `$ADVISOR_BRANCH`, `student:<your-name>`, and `status:wip`.
+   - PR assignments are label-based: assigned work has the following labels: `$ADVISOR_BRANCH`, `student:<your-name>`, and `status:wip`.
    - GitHub assignees are not used for assignment. Never use `gh pr list --assignee ...` to find your work.
    - Do not create persistent GitHub polling monitors. If no PRs or issues are listed, exit; the entrypoint will sleep and re-invoke you when work appears.
    - If you need to manually re-check during a live session, invoke the `senpai:poll-for-work` skill with args `<your-name>` or run `student_poll_for_work "<your-name>"` after sourcing `senpai-gh.sh`.
@@ -92,10 +92,6 @@ swap_gh_pr_label <pr#> "status:wip" "status:review"
      pr_all_comments <number>
      ```
      If the advisor has left new instructions (e.g. to try a different variant, abort the current direction, or adjust parameters), follow them instead of proceeding with the original plan.
-   - If the PR is intentionally cross-dataset, use your $GPUS_PER_STUDENT GPUs to cover the
-     requested dataset matrix and keep the reported results grouped by dataset
-     so transfer or non-transfer is obvious.
-
 5. **Report results**
    Add a new PR comment with a Results section (template in `$PROBLEM_DIR/program.md`):
    - Start your comment with:

--- a/system_instructions/CLAUDE-STUDENT.md
+++ b/system_instructions/CLAUDE-STUDENT.md
@@ -43,7 +43,7 @@ swap_gh_pr_label <pr#> "status:wip" "status:review"
 
 1. **Poll for work**
    The pod entrypoint polls before invoking you. The `## Student research state` block in your prompt is the source of truth for the current assignment.
-   - PR assignments are label-based: assigned work has both `student:<your-name>` and `status:wip`.
+   - PR assignments are label-based: assigned work has `$ADVISOR_BRANCH`, `student:<your-name>`, and `status:wip`.
    - GitHub assignees are not used for assignment. Never use `gh pr list --assignee ...` to find your work.
    - Do not create persistent GitHub polling monitors. If no PRs or issues are listed, exit; the entrypoint will sleep and re-invoke you when work appears.
    - If you need to manually re-check during a live session, invoke the `senpai:poll-for-work` skill with args `<your-name>` or run `student_poll_for_work "<your-name>"` after sourcing `senpai-gh.sh`.
@@ -92,7 +92,7 @@ swap_gh_pr_label <pr#> "status:wip" "status:review"
      pr_all_comments <number>
      ```
      If the advisor has left new instructions (e.g. to try a different variant, abort the current direction, or adjust parameters), follow them instead of proceeding with the original plan.
-   - If the PR is intentionally cross-dataset, use your 8 GPUs to cover the
+   - If the PR is intentionally cross-dataset, use your $STUDENT_GPU_COUNT GPUs to cover the
      requested dataset matrix and keep the reported results grouped by dataset
      so transfer or non-transfer is obvious.
 


### PR DESCRIPTION
## Summary
- tag-scope advisor/student Kubernetes resources so multiple launches can coexist in one namespace
- add `--student_prefix`, `--gpus_per_student`, `--cpu_per_gpu`, `--memory_gi_per_gpu`, and `--preflight_only` launcher options
- keep `--dry_run` offline/redacted while `--preflight_only` validates GitHub/Anthropic/Exa credentials without rendering or applying manifests
- branch-scope student work polling, create missing routing labels at launch time, and document parallel launch basics in the README

## Validation
- `uv run python k8s/launch.py --tag charlie-r1 --repo_branch icml-appendix-charlie --advisor_branch icml-appendix-charlie-r1 --student_prefix charlie1 --n_students 2 --gpus_per_student 1 --target_repo_url https://github.com/morganmcg1/TandemFoilSet-Balanced.git --advisor --dry_run`
- `uv run python k8s/launch.py --tag default-gpu-check --target_repo_url https://github.com/morganmcg1/TandemFoilSet-Balanced.git --n_students 1 --dry_run`
- `uv run python k8s/launch.py --tag bad --target_repo_url https://github.com/morganmcg1/TandemFoilSet-Balanced.git --gpus_per_student 0 --dry_run`
- `kubectl apply --dry-run=client -f /tmp/mainpr-clean-charlie.yaml`
- `uv run python k8s/launch.py --help | sed -n '30,75p'`
- `uv run python -m compileall k8s/launch.py k8s/launch_helpers.py`
- `bash -n k8s/entrypoint-advisor.sh k8s/entrypoint-student.sh plugins/senpai/scripts/senpai-gh.sh`
- `git diff --check`

## Preflight note
- `--preflight_only` reached GitHub and Anthropic successfully using the local repo-root `.env`, then failed on the local Exa key with `HTTP 401: Invalid API key`; this is a local credential issue, not a manifest/rendering issue.
