### PR TITLE
Add GH history scope for Senpai launches - avoid agents cheating

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ repo_url: https://github.com/wandb/senpai.git
 repo_branch: main
 target_repo_url: https://github.com/morganmcg1/tandemfoil2.git
 advisor_branch: schmidhuber
+gh_history_scope: branch
 image: ghcr.io/wandb/senpai:latest
 pvc_claim_name: new-pvc
 pvc_mount_path: /mnt/new-pvc
@@ -132,6 +133,10 @@ Notes: `--dry_run` renders redacted manifests without resolving or preflighting 
 
 GitHub token requirements: use a PAT with `repo` and `read:org`; it must clone `target_repo_url` and push/open PRs there.
 
+### GitHub History Scope
+
+`--gh_history_scope branch` is the default: pods clone only the advisor branch while keeping that branch's history. Use `--gh_history_scope repo` to clone the full target repo, or `--gh_history_scope fresh` for a shallow single-branch clone. Use `--extra_instructions` for any agent-facing guidance about what history to use or ignore.
+
 ### Shared cluster secret (`senpai-secrets`)
 
 Every pod also reads `WANDB_API_KEY` from the shared `senpai-secrets` Secret:
@@ -162,6 +167,7 @@ python k8s/launch.py --tag <research-tag> --advisor
 python k8s/launch.py --tag <research-tag> --advisor --n_students 7 --pvc_mount_path "/mnt/pai-amf1-cfd"
 python k8s/launch.py --tag <research-tag> --n_students 7 --dry_run
 python k8s/launch.py --tag <research-tag> --advisor --extra_instructions "Only consider optimizer changes."
+python k8s/launch.py --tag <research-tag> --advisor --gh_history_scope fresh --extra_instructions no-history.md
 
 # Parallel launches: use unique tags, plus --student_prefix when runs share student names
 python k8s/launch.py --tag <tag-a> --advisor --student_prefix a

--- a/k8s/advisor-deployment.yaml
+++ b/k8s/advisor-deployment.yaml
@@ -36,7 +36,7 @@ spec:
         - |
           set -e
           git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-          git clone --branch "$REPO_BRANCH" "$REPO_URL" /workspace/senpai
+          git clone --branch "$REPO_BRANCH" --single-branch --depth 1 --no-tags "$REPO_URL" /workspace/senpai
           cd /workspace/senpai
           bash k8s/entrypoint-advisor.sh
         envFrom:

--- a/k8s/entrypoint-advisor.sh
+++ b/k8s/entrypoint-advisor.sh
@@ -8,6 +8,7 @@ set -e
 set -o pipefail
 
 WORKDIR="/workspace/senpai"
+GH_HISTORY_SCOPE="${GH_HISTORY_SCOPE:-branch}"
 
 echo "=== Senpai Advisor ==="
 echo "Runner repo:  $REPO_URL (branch: $REPO_BRANCH)"
@@ -15,14 +16,33 @@ echo "Target repo:  $TARGET_REPO_URL (branch: $ADVISOR_BRANCH)"
 echo "Problem dir:  $PROBLEM_DIR"
 echo "Tag:          $RESEARCH_TAG"
 echo "Students:     $STUDENT_NAMES"
+echo "GitHub history: $GH_HISTORY_SCOPE"
 
 # Senpai runner repo already cloned by the deployment args block
 cd "$WORKDIR"
+git remote set-url --push origin DISABLED
+
+clone_target_repo() {
+    local depth=()
+    [ "$GH_HISTORY_SCOPE" = "fresh" ] && depth=(--depth 1)
+    case "$GH_HISTORY_SCOPE" in
+        branch|fresh) git clone --branch "$ADVISOR_BRANCH" --single-branch "${depth[@]}" --no-tags "$TARGET_REPO_URL" "$PROBLEM_DIR" ;;
+        repo) git clone "$TARGET_REPO_URL" "$PROBLEM_DIR" ;;
+        *) echo "ERROR: GH_HISTORY_SCOPE must be one of: branch, repo, fresh" >&2; exit 2 ;;
+    esac
+}
 
 # Clone the problem-package repo into $PROBLEM_DIR (bring-your-own-repo —
 # agent commits/PRs live in $TARGET_REPO_URL, not wandb/senpai).
-if [ ! -d "$PROBLEM_DIR/.git" ]; then
-    git clone "$TARGET_REPO_URL" "$PROBLEM_DIR"
+if [ ! -d "$PROBLEM_DIR/.git" ] && ! clone_target_repo; then
+    [ "$GH_HISTORY_SCOPE" = "repo" ] && exit 1
+    depth=()
+    [ "$GH_HISTORY_SCOPE" = "fresh" ] && depth=(--depth 1)
+    git clone --single-branch "${depth[@]}" --no-tags "$TARGET_REPO_URL" "$PROBLEM_DIR"
+    cd "$WORKDIR/$PROBLEM_DIR"
+    git checkout -b "$ADVISOR_BRANCH"
+    git push -u origin "$ADVISOR_BRANCH"
+    cd "$WORKDIR"
 fi
 
 uv pip install --system -e .
@@ -33,10 +53,13 @@ git config user.name "senpai-advisor"
 git config user.email "senpai-advisor@senpai"
 
 # --- Create or checkout advisor branch ---
-git fetch origin
+if [ "$GH_HISTORY_SCOPE" != "repo" ]; then
+    git remote set-branches origin "$ADVISOR_BRANCH"
+    git config remote.origin.tagOpt --no-tags
+fi
 if git rev-parse --verify "origin/$ADVISOR_BRANCH" >/dev/null 2>&1; then
     git checkout "$ADVISOR_BRANCH"
-    git pull origin "$ADVISOR_BRANCH"
+    git pull --ff-only origin "$ADVISOR_BRANCH"
 else
     git checkout -b "$ADVISOR_BRANCH"
     git push -u origin "$ADVISOR_BRANCH"

--- a/k8s/entrypoint-student.sh
+++ b/k8s/entrypoint-student.sh
@@ -8,21 +8,32 @@ set -e
 set -o pipefail
 
 WORKDIR="/workspace/senpai"
+GH_HISTORY_SCOPE="${GH_HISTORY_SCOPE:-branch}"
 
 echo "=== Senpai Student: $STUDENT_NAME ==="
 echo "Runner repo:  $REPO_URL (branch: $REPO_BRANCH)"
 echo "Target repo:  $TARGET_REPO_URL (branch: $ADVISOR_BRANCH)"
 echo "Problem dir:  $PROBLEM_DIR"
+echo "GitHub history: $GH_HISTORY_SCOPE"
 echo "GPUs:         $(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | wc -l) x $(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | head -1)"
 
 # Senpai runner repo already cloned by the deployment args block
 cd "$WORKDIR"
+git remote set-url --push origin DISABLED
+
+clone_target_repo() {
+    local depth=()
+    [ "$GH_HISTORY_SCOPE" = "fresh" ] && depth=(--depth 1)
+    case "$GH_HISTORY_SCOPE" in
+        branch|fresh) git clone --branch "$ADVISOR_BRANCH" --single-branch "${depth[@]}" --no-tags "$TARGET_REPO_URL" "$PROBLEM_DIR" ;;
+        repo) git clone "$TARGET_REPO_URL" "$PROBLEM_DIR" ;;
+        *) echo "ERROR: GH_HISTORY_SCOPE must be one of: branch, repo, fresh" >&2; exit 2 ;;
+    esac
+}
 
 # Clone the problem-package repo into $PROBLEM_DIR (bring-your-own-repo —
 # agent commits/PRs live in $TARGET_REPO_URL, not wandb/senpai).
-if [ ! -d "$PROBLEM_DIR/.git" ]; then
-    git clone "$TARGET_REPO_URL" "$PROBLEM_DIR"
-fi
+[ -d "$PROBLEM_DIR/.git" ] || clone_target_repo
 
 uv pip install --system -e .
 
@@ -30,6 +41,10 @@ uv pip install --system -e .
 cd "$WORKDIR/$PROBLEM_DIR"
 git config user.name "senpai-$STUDENT_NAME"
 git config user.email "senpai-$STUDENT_NAME@senpai"
+if [ "$GH_HISTORY_SCOPE" != "repo" ]; then
+    git remote set-branches origin "$ADVISOR_BRANCH"
+    git config remote.origin.tagOpt --no-tags
+fi
 
 # --- Start Hivemind (streams CC session logs to hivemind.wandb.tools) ---
 mkdir -p ~/.claude/projects
@@ -78,7 +93,7 @@ while true; do
     # Return to latest advisor branch so student starts from the current baseline
     cd "$WORKDIR/$PROBLEM_DIR"
     git checkout "$ADVISOR_BRANCH" 2>/dev/null || true
-    git pull origin "$ADVISOR_BRANCH" 2>/dev/null || true
+    git pull --ff-only origin "$ADVISOR_BRANCH" 2>/dev/null || true
 
     # Overwrite CLAUDE.md with the student role instructions — git checkout/pull clobbers it with the developer copy.
     # Whitelist vars so envsubst substitutes pod env vars but leaves Claude Code runtime vars

--- a/k8s/launch.py
+++ b/k8s/launch.py
@@ -53,6 +53,7 @@ class Args:
     wandb_entity: str = "wandb-applied-ai-team"  # W&B entity (team or username)
     wandb_project: str = "senpai-v1"  # W&B project name
     advisor_branch: str = "schmidhuber"  # branch the advisor works on inside the problem-package repo (students PR into it; created from the problem-package default branch if missing)
+    gh_history_scope: str = "branch"  # branch=normal track memory, fresh=clean ablation, repo=whole-repo memory
     pvc_claim_name: str = "new-pvc"  # PVC name mounted into pods
     pvc_mount_path: str = "/mnt/new-pvc"  # mount path for the dataset PVC inside the containers
     advisor: bool = False  # also deploy the advisor pod (default: students only)
@@ -82,6 +83,7 @@ def render_student(template: str, student_name: str, tag: str, secret_name: str,
             "WANDB_ENTITY": args.wandb_entity,
             "WANDB_PROJECT": args.wandb_project,
             "ADVISOR_BRANCH": args.advisor_branch,
+            "GH_HISTORY_SCOPE": args.gh_history_scope,
             "WANDB_MODE": "online",
             "SENPAI_TIMEOUT_MINUTES": str(args.timeout_minutes),
             "SENPAI_MAX_EPOCHS": str(args.max_epochs),
@@ -120,6 +122,7 @@ def render_advisor(template: str, tag: str, student_list: list[str], secret_name
         "WANDB_ENTITY": args.wandb_entity,
         "WANDB_PROJECT": args.wandb_project,
         "ADVISOR_BRANCH": args.advisor_branch,
+        "GH_HISTORY_SCOPE": args.gh_history_scope,
         "PROBLEM_DIR": args.problem_dir,
         "PVC_MOUNT_PATH": args.pvc_mount_path,
     }
@@ -147,6 +150,8 @@ def main():
     args = sp.parse(Args, config_path=str(SENPAI_CONFIG))
     if min(args.gpus_per_student, args.cpu_per_gpu, args.memory_gi_per_gpu) < 1:
         sys.exit("ERROR: --gpus_per_student, --cpu_per_gpu, and --memory_gi_per_gpu must all be at least 1")
+    if args.gh_history_scope not in {"branch", "repo", "fresh"}:
+        sys.exit("ERROR: --gh_history_scope must be one of: branch, repo, fresh")
 
     github_token = anthropic_api_key = exa_api_key = ""
     if not args.dry_run or args.preflight_only:

--- a/k8s/student-deployment.yaml
+++ b/k8s/student-deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - |
           set -e
           git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-          git clone --branch "$REPO_BRANCH" "$REPO_URL" /workspace/senpai
+          git clone --branch "$REPO_BRANCH" --single-branch --depth 1 --no-tags "$REPO_URL" /workspace/senpai
           cd /workspace/senpai
           bash k8s/entrypoint-student.sh
         envFrom:

--- a/senpai.yaml
+++ b/senpai.yaml
@@ -27,6 +27,7 @@ wandb_project: senpai-v1
 
 # advisor — the integration branch inside the problem-package repo that advisor PRs merge into
 advisor_branch: schmidhuber
+gh_history_scope: branch
 
 # training limits
 timeout_minutes: 30.0

--- a/system_instructions/CLAUDE-ADVISOR.md
+++ b/system_instructions/CLAUDE-ADVISOR.md
@@ -134,7 +134,7 @@ You run inside a pod entrypoint harness: it invokes Claude Code, passes the late
 
         - It can find every experiment that has been run or is currently running by invoking the `list-experiments` skill
 
-        - Every PR in our repo is an experiment idea and result 
+        - Every PR in our repo is an experiment idea and result
         
         - Some PRs might contain multiple trials related to the same idea.
 

--- a/system_instructions/CLAUDE-STUDENT.md
+++ b/system_instructions/CLAUDE-STUDENT.md
@@ -57,8 +57,9 @@ swap_gh_pr_label <pr#> "status:wip" "status:review"
      ```
    - Check out the branch:
      ```bash
-     git fetch origin
-     git checkout <branch>
+     branch=$(gh pr view <number> --json headRefName --jq .headRefName)
+     git fetch --depth 1 origin "$branch"
+     git checkout -B "$branch" FETCH_HEAD
      ```
    - Note: PRs target the advisor's branch (specified in your prompt), not `main`.
 


### PR DESCRIPTION
During ablations, the agents were able to see and search too much repo history, this, plus additional instructions passed to the agent during `launch.py` will hopefully reduce the chances of learning more than wanted from past experiments during ablations. Its flexible as sometimes you do want to learn from the past.

## Summary
- add `--gh_history_scope` with `branch` (default), `repo`, and `fresh` modes
- wire `GH_HISTORY_SCOPE` into advisor and student ConfigMaps
- clone the runner repo as shallow single-branch in advisor/student deployments
- disable pushes back to the runner repo inside advisor/student pods
- clone the target repo according to `GH_HISTORY_SCOPE`:
  - `branch`: single advisor branch clone with branch history
  - `fresh`: shallow single advisor branch clone
  - `repo`: full target repo clone
- keep agent-facing history policy out of default `CLAUDE-*` instructions and skills; use `--extra_instructions` for run-specific guidance
- update the student pickup instructions to fetch only the assigned PR head before checkout
- document `gh_history_scope` in `senpai.yaml` and README

## Verification
- `bash -n k8s/entrypoint-advisor.sh k8s/entrypoint-student.sh`
- `git diff --check`
- dry-run rendered `--gh_history_scope branch`, `--gh_history_scope fresh`, and `--gh_history_scope repo` manifests and confirmed `GH_HISTORY_SCOPE` reaches advisor/student ConfigMaps
- invalid `--gh_history_scope nope` fails before manifest rendering
