### PR TITLE
Harden isolated experiment launches

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ repo_branch: main
 target_repo_url: https://github.com/morganmcg1/tandemfoil2.git
 advisor_branch: schmidhuber
 gh_history_scope: branch
+human_issues: true
 image: ghcr.io/wandb/senpai:latest
 pvc_claim_name: new-pvc
 pvc_mount_path: /mnt/new-pvc
@@ -136,6 +137,12 @@ GitHub token requirements: use a PAT with `repo` and `read:org`; it must clone `
 ### GitHub History Scope
 
 `--gh_history_scope branch` is the default: pods clone only the advisor branch while keeping that branch's history. Use `--gh_history_scope repo` to clone the full target repo, or `--gh_history_scope fresh` for a shallow single-branch clone. Use `--extra_instructions` for any agent-facing guidance about what history to use or ignore.
+
+### Research Modes
+
+- **Isolated ablation:** use a unique `--tag`, unique `--advisor_branch`, `--gh_history_scope fresh`, `--student_prefix`, and `--nohuman_issues`. Agents see only the routed branch/PR stream unless explicitly told otherwise.
+- **Normal branch memory:** use `--gh_history_scope branch` with human issues enabled. Agents keep continuity on the active advisor branch while routine PR/issue polling stays scoped to the target repo.
+- **Deliberate exploration:** use `--gh_history_scope repo` or targeted `--extra_instructions` that ask the advisor/researcher-agent to inspect other branches, PRs, issues, W&B runs, or repos. Senpai helpers stay scoped to `GH_REPO`, but explicit `gh --repo owner/repo ...` reads are available when credentials allow.
 
 ### Shared cluster secret (`senpai-secrets`)
 

--- a/k8s/advisor-deployment.yaml
+++ b/k8s/advisor-deployment.yaml
@@ -35,9 +35,10 @@ spec:
         args:
         - |
           set -e
-          git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-          git clone --branch "$REPO_BRANCH" --single-branch --depth 1 --no-tags "$REPO_URL" /workspace/senpai
+          repo_auth_url="$(printf '%s' "$REPO_URL" | sed "s#https://github.com/#https://${GITHUB_TOKEN}@github.com/#")"
+          git clone --branch "$REPO_BRANCH" --single-branch --depth 1 --no-tags "$repo_auth_url" /workspace/senpai
           cd /workspace/senpai
+          git remote set-url origin "$REPO_URL"
           bash k8s/entrypoint-advisor.sh
         envFrom:
         - configMapRef:

--- a/k8s/entrypoint-advisor.sh
+++ b/k8s/entrypoint-advisor.sh
@@ -9,6 +9,8 @@ set -o pipefail
 
 WORKDIR="/workspace/senpai"
 GH_HISTORY_SCOPE="${GH_HISTORY_SCOPE:-branch}"
+export TARGET_WORKDIR="$WORKDIR/$PROBLEM_DIR"
+GIT_CREDENTIAL_FILE="$WORKDIR/.git-credentials"
 
 echo "=== Senpai Advisor ==="
 echo "Runner repo:  $REPO_URL (branch: $REPO_BRANCH)"
@@ -21,6 +23,34 @@ echo "GitHub history: $GH_HISTORY_SCOPE"
 # Senpai runner repo already cloned by the deployment args block
 cd "$WORKDIR"
 git remote set-url --push origin DISABLED
+git config remote.origin.pushurl DISABLED
+git config --unset-all url."https://${GITHUB_TOKEN}@github.com/".insteadOf 2>/dev/null || true
+export SENPAI_REAL_GIT="$(command -v git)"
+mkdir -p .git/hooks
+cat > .git/hooks/pre-push <<'EOF'
+#!/bin/sh
+echo "ERROR: refusing to push from the senpai runner repo; use the cloned target repo instead." >&2
+exit 1
+EOF
+chmod +x .git/hooks/pre-push
+mkdir -p "$WORKDIR/git-guard-bin"
+cat > "$WORKDIR/git-guard-bin/git" <<'EOF'
+#!/bin/sh
+real_git="${SENPAI_REAL_GIT:-/usr/bin/git}"
+if [ "$1" = "push" ]; then
+    top="$("$real_git" rev-parse --show-toplevel 2>/dev/null || true)"
+    if [ -n "${TARGET_WORKDIR:-}" ] && [ "$top" != "${TARGET_WORKDIR%/}" ]; then
+        echo "ERROR: refusing git push outside target repo; cwd=$(pwd), top=${top:-none}, target=$TARGET_WORKDIR" >&2
+        exit 2
+    fi
+fi
+exec "$real_git" "$@"
+EOF
+chmod +x "$WORKDIR/git-guard-bin/git"
+export PATH="$WORKDIR/git-guard-bin:$PATH"
+printf 'https://x-access-token:%s@github.com\n' "$GITHUB_TOKEN" > "$GIT_CREDENTIAL_FILE"
+chmod 600 "$GIT_CREDENTIAL_FILE"
+git config --global credential.helper "store --file=$GIT_CREDENTIAL_FILE"
 
 clone_target_repo() {
     local depth=()
@@ -44,6 +74,7 @@ if [ ! -d "$PROBLEM_DIR/.git" ] && ! clone_target_repo; then
     git push -u origin "$ADVISOR_BRANCH"
     cd "$WORKDIR"
 fi
+git config --global --unset-all credential.helper 2>/dev/null || true
 
 uv pip install --system -e .
 
@@ -51,6 +82,8 @@ uv pip install --system -e .
 cd "$WORKDIR/$PROBLEM_DIR"
 git config user.name "senpai-advisor"
 git config user.email "senpai-advisor@senpai"
+gh repo set-default "$GH_REPO"
+git config credential.helper "store --file=$GIT_CREDENTIAL_FILE"
 
 # --- Create or checkout advisor branch ---
 if [ "$GH_HISTORY_SCOPE" != "repo" ]; then
@@ -70,16 +103,22 @@ LOGDIR="$WORKDIR/advisor_logs"
 mkdir -p "$LOGDIR"
 
 # --- Start Hivemind logging service (streams CC session logs to hivemind.wandb.tools) ---
-mkdir -p ~/.claude/projects
-uvx --from wandb-hivemind hivemind run &
-echo "=== Hivemind started (PID=$!) ==="
+if [ "${SENPAI_ENABLE_AGENT_TRACING:-true}" = "true" ]; then
+    mkdir -p ~/.claude/projects
+    uvx --from wandb-hivemind hivemind run &
+    echo "=== Hivemind started (PID=$!) ==="
+else
+    echo "=== Hivemind disabled ==="
+fi
 
 # --- Load CC run command helper function ---
 source "$WORKDIR/k8s/run-senpai-claude.sh"
 
 # --- Register Weave CC plugin (tools already baked into Docker image) ---
 export PATH="$HOME/.claude/bin:$PATH"
-source "$WORKDIR/k8s/install-weave-cc-plugin.sh"
+if [ "${SENPAI_ENABLE_AGENT_TRACING:-true}" = "true" ]; then
+    source "$WORKDIR/k8s/install-weave-cc-plugin.sh"
+fi
 
 # --- Register Senpai CC plugin (skills + tools for common git tasks; CC uses --plugin-dir SENPAI_PLUGIN for tools) ---
 SENPAI_PLUGIN="$WORKDIR/plugins/senpai"
@@ -100,7 +139,12 @@ if [ -n "${EXTRA_INSTRUCTIONS_B64:-}" ]; then
 fi
 
 # Add "$KEY_INFO" (reminder of student names etc) to PROMPT
-KEY_INFO=$'\n\n Key information:\n\n Students: '"$STUDENT_NAMES"' | GPUs per Student: '"$GPUS_PER_STUDENT"' | Tag: '"$RESEARCH_TAG"' | Target repo: '"$GH_REPO"' | Advisor Branch: '"$ADVISOR_BRANCH"' | W&B entity/project: '"$WANDB_ENTITY"'/'"$WANDB_PROJECT"$'\n'
+if [ "${WANDB_MODE:-online}" = "disabled" ]; then
+    LOGGING_INFO="Experiment logging: local JSONL metrics only"
+else
+    LOGGING_INFO="W&B entity/project: ${WANDB_ENTITY}/${WANDB_PROJECT}"
+fi
+KEY_INFO=$'\n\n Key information:\n\n Students: '"$STUDENT_NAMES"' | GPUs per Student: '"$GPUS_PER_STUDENT"' | Tag: '"$RESEARCH_TAG"' | Target repo: '"$GH_REPO"' | Advisor Branch: '"$ADVISOR_BRANCH"' | '"$LOGGING_INFO"$'\n'
 FULL_PROMPT="${PROMPT}"$'\n\n'"${KEY_INFO}"
 
 # Heartbeat prompt for polling
@@ -137,11 +181,11 @@ while true; do
     [ -f "$LAST_CHECK_FILE" ] && SINCE=$(cat "$LAST_CHECK_FILE")
 
     # --- Check research state before invoking CC ---
-    REVIEW_JSON=$(list_ready_for_review_prs "$ADVISOR_BRANCH" "$SINCE")
+    REVIEW_JSON=$(list_ready_for_review_prs "$ADVISOR_BRANCH" "$SINCE" || printf '[]')
     REVIEW_COUNT=$(printf '%s' "$REVIEW_JSON" | json_len)
-    ISSUE_JSON=$(check_gh_issues "$ADVISOR_BRANCH" "$SINCE")
+    ISSUE_JSON=$(check_gh_issues "$ADVISOR_BRANCH" "$SINCE" || printf '[]')
     ISSUE_COUNT=$(printf '%s' "$ISSUE_JSON" | json_len)
-    IDLE_JSON=$(list_idle_students "$STUDENT_NAMES" "$ADVISOR_BRANCH")
+    IDLE_JSON=$(list_idle_students "$STUDENT_NAMES" "$ADVISOR_BRANCH" || printf '[]')
     IDLE_COUNT=$(printf '%s' "$IDLE_JSON" | json_len)
 
     # --- Derive watermark from the data we actually fetched (no gap, no overlap) ---

--- a/k8s/entrypoint-advisor.sh
+++ b/k8s/entrypoint-advisor.sh
@@ -171,11 +171,24 @@ while true; do
     [ -f "$LAST_CHECK_FILE" ] && SINCE=$(cat "$LAST_CHECK_FILE")
 
     # --- Check research state before invoking CC ---
-    REVIEW_JSON=$(list_ready_for_review_prs "$ADVISOR_BRANCH" "$SINCE" || printf '[]')
+    POLL_OK=1
+    if ! REVIEW_JSON=$(list_ready_for_review_prs "$ADVISOR_BRANCH" "$SINCE"); then
+        echo "WARN: failed to list review-ready PRs; treating as empty for this iteration" >&2
+        REVIEW_JSON='[]'
+        POLL_OK=0
+    fi
     REVIEW_COUNT=$(printf '%s' "$REVIEW_JSON" | json_len)
-    ISSUE_JSON=$(check_gh_issues "$ADVISOR_BRANCH" "$SINCE" || printf '[]')
+    if ! ISSUE_JSON=$(check_gh_issues "$ADVISOR_BRANCH" "$SINCE"); then
+        echo "WARN: failed to list GitHub issues; treating as empty for this iteration" >&2
+        ISSUE_JSON='[]'
+        POLL_OK=0
+    fi
     ISSUE_COUNT=$(printf '%s' "$ISSUE_JSON" | json_len)
-    IDLE_JSON=$(list_idle_students "$STUDENT_NAMES" "$ADVISOR_BRANCH" || printf '[]')
+    if ! IDLE_JSON=$(list_idle_students "$STUDENT_NAMES" "$ADVISOR_BRANCH"); then
+        echo "WARN: failed to list idle students; treating as empty for this iteration" >&2
+        IDLE_JSON='[]'
+        POLL_OK=0
+    fi
     IDLE_COUNT=$(printf '%s' "$IDLE_JSON" | json_len)
 
     # --- Derive watermark from the data we actually fetched (no gap, no overlap) ---
@@ -216,9 +229,11 @@ while true; do
     fi
     DURATION=$(( $(date +%s) - START_TS ))
 
-    # --- Advance watermark to max updatedAt of items we fetched (only on success so failed runs retry) ---
-    if [ "$EXIT_CODE" -eq 0 ] && [ -n "$WATERMARK" ]; then
+    # --- Advance watermark only after a complete poll and successful CC run. ---
+    if [ "$EXIT_CODE" -eq 0 ] && [ "$POLL_OK" -eq 1 ] && [ -n "$WATERMARK" ]; then
         echo "$WATERMARK" > "$LAST_CHECK_FILE"
+    elif [ "$EXIT_CODE" -eq 0 ] && [ "$POLL_OK" -ne 1 ]; then
+        echo "=== Poll incomplete; not advancing last-check timestamp ==="
     fi
 
     echo "=== Advisor exited code=$EXIT_CODE after ${DURATION}s at $(date), next check in $SLEEP_TIME_S seconds ==="

--- a/k8s/entrypoint-advisor.sh
+++ b/k8s/entrypoint-advisor.sh
@@ -88,8 +88,6 @@ source "$WORKDIR/k8s/run-senpai-claude.sh"
 export PATH="$HOME/.claude/bin:$PATH"
 source "$WORKDIR/k8s/install-weave-cc-plugin.sh"
 
-# --- Senpai CC plugin (skills + tools for common git tasks; CC uses --plugin-dir SENPAI_PLUGIN for tools) ---
-
 # $GH_REPO comes from the ConfigMap (set by launch.py = owner/repo of the
 # problem-package repo). The gh CLI honours it natively, so every `gh`
 # command and `gh api` call targets the problem-package repo, not senpai,

--- a/k8s/entrypoint-advisor.sh
+++ b/k8s/entrypoint-advisor.sh
@@ -11,6 +11,7 @@ WORKDIR="/workspace/senpai"
 GH_HISTORY_SCOPE="${GH_HISTORY_SCOPE:-branch}"
 export TARGET_WORKDIR="$WORKDIR/$PROBLEM_DIR"
 GIT_CREDENTIAL_FILE="$WORKDIR/.git-credentials"
+SENPAI_PLUGIN="$WORKDIR/plugins/senpai"
 
 echo "=== Senpai Advisor ==="
 echo "Runner repo:  $REPO_URL (branch: $REPO_BRANCH)"
@@ -22,35 +23,8 @@ echo "GitHub history: $GH_HISTORY_SCOPE"
 
 # Senpai runner repo already cloned by the deployment args block
 cd "$WORKDIR"
-git remote set-url --push origin DISABLED
-git config remote.origin.pushurl DISABLED
-git config --unset-all url."https://${GITHUB_TOKEN}@github.com/".insteadOf 2>/dev/null || true
-export SENPAI_REAL_GIT="$(command -v git)"
-mkdir -p .git/hooks
-cat > .git/hooks/pre-push <<'EOF'
-#!/bin/sh
-echo "ERROR: refusing to push from the senpai runner repo; use the cloned target repo instead." >&2
-exit 1
-EOF
-chmod +x .git/hooks/pre-push
-mkdir -p "$WORKDIR/git-guard-bin"
-cat > "$WORKDIR/git-guard-bin/git" <<'EOF'
-#!/bin/sh
-real_git="${SENPAI_REAL_GIT:-/usr/bin/git}"
-if [ "$1" = "push" ]; then
-    top="$("$real_git" rev-parse --show-toplevel 2>/dev/null || true)"
-    if [ -n "${TARGET_WORKDIR:-}" ] && [ "$top" != "${TARGET_WORKDIR%/}" ]; then
-        echo "ERROR: refusing git push outside target repo; cwd=$(pwd), top=${top:-none}, target=$TARGET_WORKDIR" >&2
-        exit 2
-    fi
-fi
-exec "$real_git" "$@"
-EOF
-chmod +x "$WORKDIR/git-guard-bin/git"
-export PATH="$WORKDIR/git-guard-bin:$PATH"
-printf 'https://x-access-token:%s@github.com\n' "$GITHUB_TOKEN" > "$GIT_CREDENTIAL_FILE"
-chmod 600 "$GIT_CREDENTIAL_FILE"
-git config --global credential.helper "store --file=$GIT_CREDENTIAL_FILE"
+source "$SENPAI_PLUGIN/scripts/senpai-gh.sh"
+install_senpai_git_guard "$WORKDIR" "$TARGET_WORKDIR" "$GIT_CREDENTIAL_FILE"
 
 clone_target_repo() {
     local depth=()
@@ -114,9 +88,7 @@ source "$WORKDIR/k8s/run-senpai-claude.sh"
 export PATH="$HOME/.claude/bin:$PATH"
 source "$WORKDIR/k8s/install-weave-cc-plugin.sh"
 
-# --- Register Senpai CC plugin (skills + tools for common git tasks; CC uses --plugin-dir SENPAI_PLUGIN for tools) ---
-SENPAI_PLUGIN="$WORKDIR/plugins/senpai"
-source "$SENPAI_PLUGIN/scripts/senpai-gh.sh"
+# --- Senpai CC plugin (skills + tools for common git tasks; CC uses --plugin-dir SENPAI_PLUGIN for tools) ---
 
 # $GH_REPO comes from the ConfigMap (set by launch.py = owner/repo of the
 # problem-package repo). The gh CLI honours it natively, so every `gh`
@@ -133,8 +105,7 @@ if [ -n "${EXTRA_INSTRUCTIONS_B64:-}" ]; then
 fi
 
 # Add "$KEY_INFO" (reminder of student names etc) to PROMPT
-LOGGING_INFO="W&B entity/project: ${WANDB_ENTITY}/${WANDB_PROJECT}"
-KEY_INFO=$'\n\n Key information:\n\n Students: '"$STUDENT_NAMES"' | GPUs per Student: '"$GPUS_PER_STUDENT"' | Tag: '"$RESEARCH_TAG"' | Target repo: '"$GH_REPO"' | Advisor Branch: '"$ADVISOR_BRANCH"' | '"$LOGGING_INFO"$'\n'
+KEY_INFO=$'\n\n Key information:\n\n Students: '"$STUDENT_NAMES"' | GPUs per Student: '"$GPUS_PER_STUDENT"' | Tag: '"$RESEARCH_TAG"' | Target repo: '"$GH_REPO"' | Advisor Branch: '"$ADVISOR_BRANCH"' | W&B entity/project: '"$WANDB_ENTITY"'/'"$WANDB_PROJECT"$'\n'
 FULL_PROMPT="${PROMPT}"$'\n\n'"${KEY_INFO}"
 
 # Heartbeat prompt for polling
@@ -172,23 +143,11 @@ while true; do
 
     # --- Check research state before invoking CC ---
     POLL_OK=1
-    if ! REVIEW_JSON=$(list_ready_for_review_prs "$ADVISOR_BRANCH" "$SINCE"); then
-        echo "WARN: failed to list review-ready PRs; treating as empty for this iteration" >&2
-        REVIEW_JSON='[]'
-        POLL_OK=0
-    fi
+    REVIEW_JSON=$(poll_or_empty "review-ready PR poll" list_ready_for_review_prs "$ADVISOR_BRANCH" "$SINCE") || POLL_OK=0
     REVIEW_COUNT=$(printf '%s' "$REVIEW_JSON" | json_len)
-    if ! ISSUE_JSON=$(check_gh_issues "$ADVISOR_BRANCH" "$SINCE"); then
-        echo "WARN: failed to list GitHub issues; treating as empty for this iteration" >&2
-        ISSUE_JSON='[]'
-        POLL_OK=0
-    fi
+    ISSUE_JSON=$(poll_or_empty "GitHub issue poll" check_gh_issues "$ADVISOR_BRANCH" "$SINCE") || POLL_OK=0
     ISSUE_COUNT=$(printf '%s' "$ISSUE_JSON" | json_len)
-    if ! IDLE_JSON=$(list_idle_students "$STUDENT_NAMES" "$ADVISOR_BRANCH"); then
-        echo "WARN: failed to list idle students; treating as empty for this iteration" >&2
-        IDLE_JSON='[]'
-        POLL_OK=0
-    fi
+    IDLE_JSON=$(poll_or_empty "idle-student poll" list_idle_students "$STUDENT_NAMES" "$ADVISOR_BRANCH") || POLL_OK=0
     IDLE_COUNT=$(printf '%s' "$IDLE_JSON" | json_len)
 
     # --- Derive watermark from the data we actually fetched (no gap, no overlap) ---

--- a/k8s/entrypoint-advisor.sh
+++ b/k8s/entrypoint-advisor.sh
@@ -103,22 +103,16 @@ LOGDIR="$WORKDIR/advisor_logs"
 mkdir -p "$LOGDIR"
 
 # --- Start Hivemind logging service (streams CC session logs to hivemind.wandb.tools) ---
-if [ "${SENPAI_ENABLE_AGENT_TRACING:-true}" = "true" ]; then
-    mkdir -p ~/.claude/projects
-    uvx --from wandb-hivemind hivemind run &
-    echo "=== Hivemind started (PID=$!) ==="
-else
-    echo "=== Hivemind disabled ==="
-fi
+mkdir -p ~/.claude/projects
+uvx --from wandb-hivemind hivemind run &
+echo "=== Hivemind started (PID=$!) ==="
 
 # --- Load CC run command helper function ---
 source "$WORKDIR/k8s/run-senpai-claude.sh"
 
 # --- Register Weave CC plugin (tools already baked into Docker image) ---
 export PATH="$HOME/.claude/bin:$PATH"
-if [ "${SENPAI_ENABLE_AGENT_TRACING:-true}" = "true" ]; then
-    source "$WORKDIR/k8s/install-weave-cc-plugin.sh"
-fi
+source "$WORKDIR/k8s/install-weave-cc-plugin.sh"
 
 # --- Register Senpai CC plugin (skills + tools for common git tasks; CC uses --plugin-dir SENPAI_PLUGIN for tools) ---
 SENPAI_PLUGIN="$WORKDIR/plugins/senpai"
@@ -139,11 +133,7 @@ if [ -n "${EXTRA_INSTRUCTIONS_B64:-}" ]; then
 fi
 
 # Add "$KEY_INFO" (reminder of student names etc) to PROMPT
-if [ "${WANDB_MODE:-online}" = "disabled" ]; then
-    LOGGING_INFO="Experiment logging: local JSONL metrics only"
-else
-    LOGGING_INFO="W&B entity/project: ${WANDB_ENTITY}/${WANDB_PROJECT}"
-fi
+LOGGING_INFO="W&B entity/project: ${WANDB_ENTITY}/${WANDB_PROJECT}"
 KEY_INFO=$'\n\n Key information:\n\n Students: '"$STUDENT_NAMES"' | GPUs per Student: '"$GPUS_PER_STUDENT"' | Tag: '"$RESEARCH_TAG"' | Target repo: '"$GH_REPO"' | Advisor Branch: '"$ADVISOR_BRANCH"' | '"$LOGGING_INFO"$'\n'
 FULL_PROMPT="${PROMPT}"$'\n\n'"${KEY_INFO}"
 

--- a/k8s/entrypoint-student.sh
+++ b/k8s/entrypoint-student.sh
@@ -9,6 +9,8 @@ set -o pipefail
 
 WORKDIR="/workspace/senpai"
 GH_HISTORY_SCOPE="${GH_HISTORY_SCOPE:-branch}"
+export TARGET_WORKDIR="$WORKDIR/$PROBLEM_DIR"
+GIT_CREDENTIAL_FILE="$WORKDIR/.git-credentials"
 
 echo "=== Senpai Student: $STUDENT_NAME ==="
 echo "Runner repo:  $REPO_URL (branch: $REPO_BRANCH)"
@@ -20,6 +22,34 @@ echo "GPUs:         $(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/n
 # Senpai runner repo already cloned by the deployment args block
 cd "$WORKDIR"
 git remote set-url --push origin DISABLED
+git config remote.origin.pushurl DISABLED
+git config --unset-all url."https://${GITHUB_TOKEN}@github.com/".insteadOf 2>/dev/null || true
+export SENPAI_REAL_GIT="$(command -v git)"
+mkdir -p .git/hooks
+cat > .git/hooks/pre-push <<'EOF'
+#!/bin/sh
+echo "ERROR: refusing to push from the senpai runner repo; use the cloned target repo instead." >&2
+exit 1
+EOF
+chmod +x .git/hooks/pre-push
+mkdir -p "$WORKDIR/git-guard-bin"
+cat > "$WORKDIR/git-guard-bin/git" <<'EOF'
+#!/bin/sh
+real_git="${SENPAI_REAL_GIT:-/usr/bin/git}"
+if [ "$1" = "push" ]; then
+    top="$("$real_git" rev-parse --show-toplevel 2>/dev/null || true)"
+    if [ -n "${TARGET_WORKDIR:-}" ] && [ "$top" != "${TARGET_WORKDIR%/}" ]; then
+        echo "ERROR: refusing git push outside target repo; cwd=$(pwd), top=${top:-none}, target=$TARGET_WORKDIR" >&2
+        exit 2
+    fi
+fi
+exec "$real_git" "$@"
+EOF
+chmod +x "$WORKDIR/git-guard-bin/git"
+export PATH="$WORKDIR/git-guard-bin:$PATH"
+printf 'https://x-access-token:%s@github.com\n' "$GITHUB_TOKEN" > "$GIT_CREDENTIAL_FILE"
+chmod 600 "$GIT_CREDENTIAL_FILE"
+git config --global credential.helper "store --file=$GIT_CREDENTIAL_FILE"
 
 clone_target_repo() {
     local depth=()
@@ -34,6 +64,7 @@ clone_target_repo() {
 # Clone the problem-package repo into $PROBLEM_DIR (bring-your-own-repo —
 # agent commits/PRs live in $TARGET_REPO_URL, not wandb/senpai).
 [ -d "$PROBLEM_DIR/.git" ] || clone_target_repo
+git config --global --unset-all credential.helper 2>/dev/null || true
 
 uv pip install --system -e .
 
@@ -41,22 +72,30 @@ uv pip install --system -e .
 cd "$WORKDIR/$PROBLEM_DIR"
 git config user.name "senpai-$STUDENT_NAME"
 git config user.email "senpai-$STUDENT_NAME@senpai"
+gh repo set-default "$GH_REPO"
+git config credential.helper "store --file=$GIT_CREDENTIAL_FILE"
 if [ "$GH_HISTORY_SCOPE" != "repo" ]; then
     git remote set-branches origin "$ADVISOR_BRANCH"
     git config remote.origin.tagOpt --no-tags
 fi
 
 # --- Start Hivemind (streams CC session logs to hivemind.wandb.tools) ---
-mkdir -p ~/.claude/projects
-uvx --from wandb-hivemind hivemind run &
-echo "=== Hivemind started (PID=$!) ==="
+if [ "${SENPAI_ENABLE_AGENT_TRACING:-true}" = "true" ]; then
+    mkdir -p ~/.claude/projects
+    uvx --from wandb-hivemind hivemind run &
+    echo "=== Hivemind started (PID=$!) ==="
+else
+    echo "=== Hivemind disabled ==="
+fi
 
 # --- Load CC run command helper function ---
 source "$WORKDIR/k8s/run-senpai-claude.sh"
 
 # --- Register Weave Claude Code Plugin (tools already baked into Docker image) ---
 export PATH="$HOME/.claude/bin:$PATH"
-source "$WORKDIR/k8s/install-weave-cc-plugin.sh"
+if [ "${SENPAI_ENABLE_AGENT_TRACING:-true}" = "true" ]; then
+    source "$WORKDIR/k8s/install-weave-cc-plugin.sh"
+fi
 
 # --- Register Senpai CC plugin ---
 SENPAI_PLUGIN="$WORKDIR/plugins/senpai"
@@ -71,7 +110,12 @@ source "$SENPAI_PLUGIN/scripts/senpai-gh.sh"
 TASK_INSTRUCTIONS="$(envsubst < "$WORKDIR/$PROBLEM_DIR/instructions/prompt-student.md" | sed '/^<!--$/,/^-->$/d')"
 PROMPT="${TASK_INSTRUCTIONS}"
 
-KEY_INFO=$'\n\nKey information:\n\nStudent: '"$STUDENT_NAME"' | GPUs per Student: '"$GPUS_PER_STUDENT"' | Target repo: '"$GH_REPO"' | Advisor Branch: '"$ADVISOR_BRANCH"' | W&B entity/project: '"$WANDB_ENTITY"'/'"$WANDB_PROJECT"$'\n'
+if [ "${WANDB_MODE:-online}" = "disabled" ]; then
+    LOGGING_INFO="Experiment logging: local JSONL metrics only"
+else
+    LOGGING_INFO="W&B entity/project: ${WANDB_ENTITY}/${WANDB_PROJECT}"
+fi
+KEY_INFO=$'\n\nKey information:\n\nStudent: '"$STUDENT_NAME"' | GPUs per Student: '"$GPUS_PER_STUDENT"' | Target repo: '"$GH_REPO"' | Advisor Branch: '"$ADVISOR_BRANCH"' | '"$LOGGING_INFO"$'\n'
 FULL_PROMPT="${PROMPT}"$'\n\n'"${KEY_INFO}"
 
 HEARTBEAT_PROMPT="Continue your student loop using the assigned PRs and GitHub issues listed in the Student research state below. The entrypoint owns assignment polling; do not start persistent GitHub polling monitors. For active training, use sparse wakeups plus training_log_status; do not stream per-epoch logs into Monitor."
@@ -107,10 +151,16 @@ while true; do
     echo "=== GPU: $(nvidia-smi --query-gpu=memory.used,memory.total,utilization.gpu --format=csv,noheader 2>/dev/null) ==="
 
     # --- Check for work before invoking CC ---
-    ASSIGNED_JSON=$(student_poll_for_work "$STUDENT_NAME")
+    ASSIGNED_JSON=$(student_poll_for_work "$STUDENT_NAME" || printf '[]')
     ASSIGNED_COUNT=$(printf '%s' "$ASSIGNED_JSON" | json_len)
-    ISSUE_JSON=$(check_gh_issues "student:$STUDENT_NAME")
+    ISSUE_JSON=$(check_gh_issues "student:$STUDENT_NAME" || printf '[]')
     ISSUE_COUNT=$(printf '%s' "$ISSUE_JSON" | json_len)
+
+    if [ "$ASSIGNED_COUNT" -eq 1 ]; then
+        ASSIGNED_HEAD=$(printf '%s' "$ASSIGNED_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin)[0]["headRefName"])')
+        git fetch origin "$ASSIGNED_HEAD"
+        git checkout -B "$ASSIGNED_HEAD" "origin/$ASSIGNED_HEAD"
+    fi
 
     # --- Build triage info ---
     TRIAGE_INFO="## Student research state"

--- a/k8s/entrypoint-student.sh
+++ b/k8s/entrypoint-student.sh
@@ -159,7 +159,7 @@ while true; do
     if [ "$ASSIGNED_COUNT" -eq 1 ]; then
         ASSIGNED_HEAD=$(printf '%s' "$ASSIGNED_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin)[0]["headRefName"])')
         git fetch origin "$ASSIGNED_HEAD"
-        git checkout -B "$ASSIGNED_HEAD" "origin/$ASSIGNED_HEAD"
+        git checkout -B "$ASSIGNED_HEAD" FETCH_HEAD
     fi
 
     # --- Build triage info ---

--- a/k8s/entrypoint-student.sh
+++ b/k8s/entrypoint-student.sh
@@ -65,8 +65,6 @@ source "$WORKDIR/k8s/run-senpai-claude.sh"
 export PATH="$HOME/.claude/bin:$PATH"
 source "$WORKDIR/k8s/install-weave-cc-plugin.sh"
 
-# --- Senpai CC plugin already sourced for setup; CC uses --plugin-dir SENPAI_PLUGIN for tools. ---
-
 # $GH_REPO comes from the ConfigMap (set by launch.py = owner/repo of the
 # problem-package repo). The gh CLI honours it natively, so every `gh`
 # command and `gh api` call targets the problem-package repo, not senpai,

--- a/k8s/entrypoint-student.sh
+++ b/k8s/entrypoint-student.sh
@@ -80,22 +80,16 @@ if [ "$GH_HISTORY_SCOPE" != "repo" ]; then
 fi
 
 # --- Start Hivemind (streams CC session logs to hivemind.wandb.tools) ---
-if [ "${SENPAI_ENABLE_AGENT_TRACING:-true}" = "true" ]; then
-    mkdir -p ~/.claude/projects
-    uvx --from wandb-hivemind hivemind run &
-    echo "=== Hivemind started (PID=$!) ==="
-else
-    echo "=== Hivemind disabled ==="
-fi
+mkdir -p ~/.claude/projects
+uvx --from wandb-hivemind hivemind run &
+echo "=== Hivemind started (PID=$!) ==="
 
 # --- Load CC run command helper function ---
 source "$WORKDIR/k8s/run-senpai-claude.sh"
 
 # --- Register Weave Claude Code Plugin (tools already baked into Docker image) ---
 export PATH="$HOME/.claude/bin:$PATH"
-if [ "${SENPAI_ENABLE_AGENT_TRACING:-true}" = "true" ]; then
-    source "$WORKDIR/k8s/install-weave-cc-plugin.sh"
-fi
+source "$WORKDIR/k8s/install-weave-cc-plugin.sh"
 
 # --- Register Senpai CC plugin ---
 SENPAI_PLUGIN="$WORKDIR/plugins/senpai"
@@ -110,11 +104,7 @@ source "$SENPAI_PLUGIN/scripts/senpai-gh.sh"
 TASK_INSTRUCTIONS="$(envsubst < "$WORKDIR/$PROBLEM_DIR/instructions/prompt-student.md" | sed '/^<!--$/,/^-->$/d')"
 PROMPT="${TASK_INSTRUCTIONS}"
 
-if [ "${WANDB_MODE:-online}" = "disabled" ]; then
-    LOGGING_INFO="Experiment logging: local JSONL metrics only"
-else
-    LOGGING_INFO="W&B entity/project: ${WANDB_ENTITY}/${WANDB_PROJECT}"
-fi
+LOGGING_INFO="W&B entity/project: ${WANDB_ENTITY}/${WANDB_PROJECT}"
 KEY_INFO=$'\n\nKey information:\n\nStudent: '"$STUDENT_NAME"' | GPUs per Student: '"$GPUS_PER_STUDENT"' | Target repo: '"$GH_REPO"' | Advisor Branch: '"$ADVISOR_BRANCH"' | '"$LOGGING_INFO"$'\n'
 FULL_PROMPT="${PROMPT}"$'\n\n'"${KEY_INFO}"
 

--- a/k8s/entrypoint-student.sh
+++ b/k8s/entrypoint-student.sh
@@ -11,6 +11,7 @@ WORKDIR="/workspace/senpai"
 GH_HISTORY_SCOPE="${GH_HISTORY_SCOPE:-branch}"
 export TARGET_WORKDIR="$WORKDIR/$PROBLEM_DIR"
 GIT_CREDENTIAL_FILE="$WORKDIR/.git-credentials"
+SENPAI_PLUGIN="$WORKDIR/plugins/senpai"
 
 echo "=== Senpai Student: $STUDENT_NAME ==="
 echo "Runner repo:  $REPO_URL (branch: $REPO_BRANCH)"
@@ -21,35 +22,8 @@ echo "GPUs:         $(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/n
 
 # Senpai runner repo already cloned by the deployment args block
 cd "$WORKDIR"
-git remote set-url --push origin DISABLED
-git config remote.origin.pushurl DISABLED
-git config --unset-all url."https://${GITHUB_TOKEN}@github.com/".insteadOf 2>/dev/null || true
-export SENPAI_REAL_GIT="$(command -v git)"
-mkdir -p .git/hooks
-cat > .git/hooks/pre-push <<'EOF'
-#!/bin/sh
-echo "ERROR: refusing to push from the senpai runner repo; use the cloned target repo instead." >&2
-exit 1
-EOF
-chmod +x .git/hooks/pre-push
-mkdir -p "$WORKDIR/git-guard-bin"
-cat > "$WORKDIR/git-guard-bin/git" <<'EOF'
-#!/bin/sh
-real_git="${SENPAI_REAL_GIT:-/usr/bin/git}"
-if [ "$1" = "push" ]; then
-    top="$("$real_git" rev-parse --show-toplevel 2>/dev/null || true)"
-    if [ -n "${TARGET_WORKDIR:-}" ] && [ "$top" != "${TARGET_WORKDIR%/}" ]; then
-        echo "ERROR: refusing git push outside target repo; cwd=$(pwd), top=${top:-none}, target=$TARGET_WORKDIR" >&2
-        exit 2
-    fi
-fi
-exec "$real_git" "$@"
-EOF
-chmod +x "$WORKDIR/git-guard-bin/git"
-export PATH="$WORKDIR/git-guard-bin:$PATH"
-printf 'https://x-access-token:%s@github.com\n' "$GITHUB_TOKEN" > "$GIT_CREDENTIAL_FILE"
-chmod 600 "$GIT_CREDENTIAL_FILE"
-git config --global credential.helper "store --file=$GIT_CREDENTIAL_FILE"
+source "$SENPAI_PLUGIN/scripts/senpai-gh.sh"
+install_senpai_git_guard "$WORKDIR" "$TARGET_WORKDIR" "$GIT_CREDENTIAL_FILE"
 
 clone_target_repo() {
     local depth=()
@@ -91,9 +65,7 @@ source "$WORKDIR/k8s/run-senpai-claude.sh"
 export PATH="$HOME/.claude/bin:$PATH"
 source "$WORKDIR/k8s/install-weave-cc-plugin.sh"
 
-# --- Register Senpai CC plugin ---
-SENPAI_PLUGIN="$WORKDIR/plugins/senpai"
-source "$SENPAI_PLUGIN/scripts/senpai-gh.sh"
+# --- Senpai CC plugin already sourced for setup; CC uses --plugin-dir SENPAI_PLUGIN for tools. ---
 
 # $GH_REPO comes from the ConfigMap (set by launch.py = owner/repo of the
 # problem-package repo). The gh CLI honours it natively, so every `gh`
@@ -104,8 +76,7 @@ source "$SENPAI_PLUGIN/scripts/senpai-gh.sh"
 TASK_INSTRUCTIONS="$(envsubst < "$WORKDIR/$PROBLEM_DIR/instructions/prompt-student.md" | sed '/^<!--$/,/^-->$/d')"
 PROMPT="${TASK_INSTRUCTIONS}"
 
-LOGGING_INFO="W&B entity/project: ${WANDB_ENTITY}/${WANDB_PROJECT}"
-KEY_INFO=$'\n\nKey information:\n\nStudent: '"$STUDENT_NAME"' | GPUs per Student: '"$GPUS_PER_STUDENT"' | Target repo: '"$GH_REPO"' | Advisor Branch: '"$ADVISOR_BRANCH"' | '"$LOGGING_INFO"$'\n'
+KEY_INFO=$'\n\nKey information:\n\nStudent: '"$STUDENT_NAME"' | GPUs per Student: '"$GPUS_PER_STUDENT"' | Target repo: '"$GH_REPO"' | Advisor Branch: '"$ADVISOR_BRANCH"' | W&B entity/project: '"$WANDB_ENTITY"'/'"$WANDB_PROJECT"$'\n'
 FULL_PROMPT="${PROMPT}"$'\n\n'"${KEY_INFO}"
 
 HEARTBEAT_PROMPT="Continue your student loop using the assigned PRs and GitHub issues listed in the Student research state below. The entrypoint owns assignment polling; do not start persistent GitHub polling monitors. For active training, use sparse wakeups plus training_log_status; do not stream per-epoch logs into Monitor."

--- a/k8s/launch.py
+++ b/k8s/launch.py
@@ -52,6 +52,9 @@ class Args:
     image: str = "ghcr.io/wandb/senpai:latest"  # container image for students
     wandb_entity: str = "wandb-applied-ai-team"  # W&B entity (team or username)
     wandb_project: str = "senpai-v1"  # W&B project name
+    wandb_mode: str = "online"  # online for W&B runs, disabled for local-only training
+    agent_tracing: bool = True  # stream Claude session traces via Hivemind/Weave
+    human_issues: bool = True  # allow human GitHub issue triage; disable for isolated launches
     advisor_branch: str = "schmidhuber"  # branch the advisor works on inside the problem-package repo (students PR into it; created from the problem-package default branch if missing)
     gh_history_scope: str = "branch"  # branch=normal track memory, fresh=clean ablation, repo=whole-repo memory
     pvc_claim_name: str = "new-pvc"  # PVC name mounted into pods
@@ -82,9 +85,12 @@ def render_student(template: str, student_name: str, tag: str, secret_name: str,
             "GPUS_PER_STUDENT": str(args.gpus_per_student),
             "WANDB_ENTITY": args.wandb_entity,
             "WANDB_PROJECT": args.wandb_project,
+            "WANDB_MODE": args.wandb_mode,
+            "WANDB_DISABLED": "true" if args.wandb_mode == "disabled" else "false",
+            "SENPAI_ENABLE_AGENT_TRACING": "true" if args.agent_tracing and args.wandb_mode != "disabled" else "false",
             "ADVISOR_BRANCH": args.advisor_branch,
             "GH_HISTORY_SCOPE": args.gh_history_scope,
-            "WANDB_MODE": "online",
+            "SENPAI_ENABLE_HUMAN_ISSUES": "true" if args.human_issues else "false",
             "SENPAI_TIMEOUT_MINUTES": str(args.timeout_minutes),
             "SENPAI_MAX_EPOCHS": str(args.max_epochs),
             "PROBLEM_DIR": args.problem_dir,
@@ -121,8 +127,12 @@ def render_advisor(template: str, tag: str, student_list: list[str], secret_name
         "GPUS_PER_STUDENT": str(args.gpus_per_student),
         "WANDB_ENTITY": args.wandb_entity,
         "WANDB_PROJECT": args.wandb_project,
+        "WANDB_MODE": args.wandb_mode,
+        "WANDB_DISABLED": "true" if args.wandb_mode == "disabled" else "false",
+        "SENPAI_ENABLE_AGENT_TRACING": "true" if args.agent_tracing and args.wandb_mode != "disabled" else "false",
         "ADVISOR_BRANCH": args.advisor_branch,
         "GH_HISTORY_SCOPE": args.gh_history_scope,
+        "SENPAI_ENABLE_HUMAN_ISSUES": "true" if args.human_issues else "false",
         "PROBLEM_DIR": args.problem_dir,
         "PVC_MOUNT_PATH": args.pvc_mount_path,
     }
@@ -152,6 +162,10 @@ def main():
         sys.exit("ERROR: --gpus_per_student, --cpu_per_gpu, and --memory_gi_per_gpu must all be at least 1")
     if args.gh_history_scope not in {"branch", "repo", "fresh"}:
         sys.exit("ERROR: --gh_history_scope must be one of: branch, repo, fresh")
+    if args.wandb_mode not in {"online", "offline", "disabled"}:
+        sys.exit("ERROR: --wandb_mode must be one of: online, offline, disabled")
+    if target_repo_slug(args.target_repo_url) == target_repo_slug(args.repo_url):
+        sys.exit("ERROR: --target_repo_url must be a different repo from --repo_url")
 
     github_token = anthropic_api_key = exa_api_key = ""
     if not args.dry_run or args.preflight_only:

--- a/k8s/launch.py
+++ b/k8s/launch.py
@@ -52,8 +52,6 @@ class Args:
     image: str = "ghcr.io/wandb/senpai:latest"  # container image for students
     wandb_entity: str = "wandb-applied-ai-team"  # W&B entity (team or username)
     wandb_project: str = "senpai-v1"  # W&B project name
-    wandb_mode: str = "online"  # online for W&B runs, disabled for local-only training
-    agent_tracing: bool = True  # stream Claude session traces via Hivemind/Weave
     human_issues: bool = True  # allow human GitHub issue triage; disable for isolated launches
     advisor_branch: str = "schmidhuber"  # branch the advisor works on inside the problem-package repo (students PR into it; created from the problem-package default branch if missing)
     gh_history_scope: str = "branch"  # branch=normal track memory, fresh=clean ablation, repo=whole-repo memory
@@ -85,9 +83,7 @@ def render_student(template: str, student_name: str, tag: str, secret_name: str,
             "GPUS_PER_STUDENT": str(args.gpus_per_student),
             "WANDB_ENTITY": args.wandb_entity,
             "WANDB_PROJECT": args.wandb_project,
-            "WANDB_MODE": args.wandb_mode,
-            "WANDB_DISABLED": "true" if args.wandb_mode == "disabled" else "false",
-            "SENPAI_ENABLE_AGENT_TRACING": "true" if args.agent_tracing and args.wandb_mode != "disabled" else "false",
+            "WANDB_MODE": "online",
             "ADVISOR_BRANCH": args.advisor_branch,
             "GH_HISTORY_SCOPE": args.gh_history_scope,
             "SENPAI_ENABLE_HUMAN_ISSUES": "true" if args.human_issues else "false",
@@ -127,9 +123,7 @@ def render_advisor(template: str, tag: str, student_list: list[str], secret_name
         "GPUS_PER_STUDENT": str(args.gpus_per_student),
         "WANDB_ENTITY": args.wandb_entity,
         "WANDB_PROJECT": args.wandb_project,
-        "WANDB_MODE": args.wandb_mode,
-        "WANDB_DISABLED": "true" if args.wandb_mode == "disabled" else "false",
-        "SENPAI_ENABLE_AGENT_TRACING": "true" if args.agent_tracing and args.wandb_mode != "disabled" else "false",
+        "WANDB_MODE": "online",
         "ADVISOR_BRANCH": args.advisor_branch,
         "GH_HISTORY_SCOPE": args.gh_history_scope,
         "SENPAI_ENABLE_HUMAN_ISSUES": "true" if args.human_issues else "false",
@@ -162,8 +156,6 @@ def main():
         sys.exit("ERROR: --gpus_per_student, --cpu_per_gpu, and --memory_gi_per_gpu must all be at least 1")
     if args.gh_history_scope not in {"branch", "repo", "fresh"}:
         sys.exit("ERROR: --gh_history_scope must be one of: branch, repo, fresh")
-    if args.wandb_mode not in {"online", "offline", "disabled"}:
-        sys.exit("ERROR: --wandb_mode must be one of: online, offline, disabled")
     if target_repo_slug(args.target_repo_url) == target_repo_slug(args.repo_url):
         sys.exit("ERROR: --target_repo_url must be a different repo from --repo_url")
 

--- a/k8s/student-deployment.yaml
+++ b/k8s/student-deployment.yaml
@@ -38,9 +38,10 @@ spec:
         args:
         - |
           set -e
-          git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-          git clone --branch "$REPO_BRANCH" --single-branch --depth 1 --no-tags "$REPO_URL" /workspace/senpai
+          repo_auth_url="$(printf '%s' "$REPO_URL" | sed "s#https://github.com/#https://${GITHUB_TOKEN}@github.com/#")"
+          git clone --branch "$REPO_BRANCH" --single-branch --depth 1 --no-tags "$repo_auth_url" /workspace/senpai
           cd /workspace/senpai
+          git remote set-url origin "$REPO_URL"
           bash k8s/entrypoint-student.sh
         envFrom:
         - configMapRef:

--- a/k8s/test-entrypoint-advisor.sh
+++ b/k8s/test-entrypoint-advisor.sh
@@ -67,6 +67,12 @@ case "$SCENARIO" in
         check_gh_issues() { echo '[]'; }
         list_idle_students() { echo '[]'; }
         ;;
+    pollfail)
+        # A partial poll with work should run CC but should not advance the watermark.
+        list_ready_for_review_prs() { echo '[{"number":42,"updatedAt":"2026-04-01T20:00:00Z"}]'; }
+        check_gh_issues() { return 1; }
+        list_idle_students() { echo '[]'; }
+        ;;
 esac
 
 # --- JSON helpers (copied from entrypoint) ---
@@ -103,12 +109,26 @@ while true; do
     [ -f "$LAST_CHECK_FILE" ] && SINCE=$(cat "$LAST_CHECK_FILE")
 
     # --- Check research state ---
-    REVIEW_JSON=$(list_ready_for_review_prs "$ADVISOR_BRANCH" "$SINCE")
+    POLL_OK=1
+    if ! REVIEW_JSON=$(list_ready_for_review_prs "$ADVISOR_BRANCH" "$SINCE"); then
+        echo "WARN: failed to list review-ready PRs; treating as empty for this iteration" >&2
+        REVIEW_JSON='[]'
+        POLL_OK=0
+    fi
     REVIEW_COUNT=$(printf '%s' "$REVIEW_JSON" | json_len)
-    ISSUE_JSON=$(check_gh_issues "$ADVISOR_BRANCH" "$SINCE")
+    if ! ISSUE_JSON=$(check_gh_issues "$ADVISOR_BRANCH" "$SINCE"); then
+        echo "WARN: failed to list GitHub issues; treating as empty for this iteration" >&2
+        ISSUE_JSON='[]'
+        POLL_OK=0
+    fi
     ISSUE_COUNT=$(printf '%s' "$ISSUE_JSON" | json_len)
-    IDLE_JSON=$(list_idle_students "$STUDENT_NAMES" "$ADVISOR_BRANCH")
+    if ! IDLE_JSON=$(list_idle_students "$STUDENT_NAMES" "$ADVISOR_BRANCH"); then
+        echo "WARN: failed to list idle students; treating as empty for this iteration" >&2
+        IDLE_JSON='[]'
+        POLL_OK=0
+    fi
     IDLE_COUNT=$(printf '%s' "$IDLE_JSON" | json_len)
+    WATERMARK=$(max_updated_at "$REVIEW_JSON" "$ISSUE_JSON")
 
     TRIAGE_INFO="=== Research state (since ${SINCE:-boot}): reviews=$REVIEW_COUNT | issues=$ISSUE_COUNT | idle=$IDLE_COUNT ==="
     echo "$TRIAGE_INFO"
@@ -152,9 +172,11 @@ while true; do
     fi
     DURATION=$(( $(date +%s) - START_TS ))
 
-    # --- Update last-check timestamp (only on success) ---
-    if [ "$EXIT_CODE" -eq 0 ]; then
-        date -u +%Y-%m-%dT%H:%M:%SZ > "$LAST_CHECK_FILE"
+    # --- Update last-check timestamp (only after complete poll and success) ---
+    if [ "$EXIT_CODE" -eq 0 ] && [ "$POLL_OK" -eq 1 ] && [ -n "$WATERMARK" ]; then
+        echo "$WATERMARK" > "$LAST_CHECK_FILE"
+    elif [ "$EXIT_CODE" -eq 0 ] && [ "$POLL_OK" -ne 1 ]; then
+        echo "=== Poll incomplete; not advancing last-check timestamp ==="
     fi
 
     echo "=== Exited code=$EXIT_CODE after ${DURATION}s, next check in $SLEEP_TIME_S seconds ==="

--- a/k8s/test-entrypoint-advisor.sh
+++ b/k8s/test-entrypoint-advisor.sh
@@ -110,23 +110,11 @@ while true; do
 
     # --- Check research state ---
     POLL_OK=1
-    if ! REVIEW_JSON=$(list_ready_for_review_prs "$ADVISOR_BRANCH" "$SINCE"); then
-        echo "WARN: failed to list review-ready PRs; treating as empty for this iteration" >&2
-        REVIEW_JSON='[]'
-        POLL_OK=0
-    fi
+    REVIEW_JSON=$(poll_or_empty "review-ready PR poll" list_ready_for_review_prs "$ADVISOR_BRANCH" "$SINCE") || POLL_OK=0
     REVIEW_COUNT=$(printf '%s' "$REVIEW_JSON" | json_len)
-    if ! ISSUE_JSON=$(check_gh_issues "$ADVISOR_BRANCH" "$SINCE"); then
-        echo "WARN: failed to list GitHub issues; treating as empty for this iteration" >&2
-        ISSUE_JSON='[]'
-        POLL_OK=0
-    fi
+    ISSUE_JSON=$(poll_or_empty "GitHub issue poll" check_gh_issues "$ADVISOR_BRANCH" "$SINCE") || POLL_OK=0
     ISSUE_COUNT=$(printf '%s' "$ISSUE_JSON" | json_len)
-    if ! IDLE_JSON=$(list_idle_students "$STUDENT_NAMES" "$ADVISOR_BRANCH"); then
-        echo "WARN: failed to list idle students; treating as empty for this iteration" >&2
-        IDLE_JSON='[]'
-        POLL_OK=0
-    fi
+    IDLE_JSON=$(poll_or_empty "idle-student poll" list_idle_students "$STUDENT_NAMES" "$ADVISOR_BRANCH") || POLL_OK=0
     IDLE_COUNT=$(printf '%s' "$IDLE_JSON" | json_len)
     WATERMARK=$(max_updated_at "$REVIEW_JSON" "$ISSUE_JSON")
 

--- a/plugins/senpai/scripts/senpai-gh.sh
+++ b/plugins/senpai/scripts/senpai-gh.sh
@@ -33,6 +33,58 @@ gh_retry() {
     return 1
 }
 
+poll_or_empty() {
+    local label="$1"
+    shift
+    "$@" || {
+        echo "WARN: $label failed; treating as empty for this iteration" >&2
+        printf '[]\n'
+        return 1
+    }
+}
+
+install_senpai_git_guard() {
+    local workdir="$1" target_workdir="$2" credential_file="$3"
+    if [ -z "$workdir" ] || [ -z "$target_workdir" ] || [ -z "$credential_file" ]; then
+        echo "install_senpai_git_guard: usage: <workdir> <target-workdir> <credential-file>" >&2
+        return 2
+    fi
+
+    git remote set-url --push origin DISABLED
+    git config remote.origin.pushurl DISABLED
+    git config --unset-all url."https://${GITHUB_TOKEN}@github.com/".insteadOf 2>/dev/null || true
+
+    export TARGET_WORKDIR="$target_workdir"
+    export SENPAI_REAL_GIT="${SENPAI_REAL_GIT:-$(command -v git)}"
+
+    mkdir -p .git/hooks "$workdir/git-guard-bin"
+    cat > .git/hooks/pre-push <<'EOF'
+#!/bin/sh
+echo "ERROR: refusing to push from the senpai runner repo; use the cloned target repo instead." >&2
+exit 1
+EOF
+    chmod +x .git/hooks/pre-push
+
+    cat > "$workdir/git-guard-bin/git" <<'EOF'
+#!/bin/sh
+real_git="${SENPAI_REAL_GIT:-/usr/bin/git}"
+if [ "$1" = "push" ]; then
+    top="$("$real_git" rev-parse --show-toplevel 2>/dev/null || true)"
+    if [ -n "${TARGET_WORKDIR:-}" ] && [ "$top" != "${TARGET_WORKDIR%/}" ]; then
+        echo "ERROR: refusing git push outside target repo; cwd=$(pwd), top=${top:-none}, target=$TARGET_WORKDIR" >&2
+        exit 2
+    fi
+fi
+exec "$real_git" "$@"
+EOF
+    chmod +x "$workdir/git-guard-bin/git"
+    export PATH="$workdir/git-guard-bin:$PATH"
+
+    printf 'https://x-access-token:%s@github.com\n' "$GITHUB_TOKEN" > "$credential_file"
+    chmod 600 "$credential_file"
+    git config --global credential.helper "store --file=$credential_file"
+}
+
 require_target_repo() {
     local origin
     origin=$(git config --get remote.origin.url || true)

--- a/plugins/senpai/scripts/senpai-gh.sh
+++ b/plugins/senpai/scripts/senpai-gh.sh
@@ -172,14 +172,24 @@ mark_ready_for_review() {
 
 # Create a real assignment branch before opening a PR.
 #   create_assignment_branch <student> <hypothesis-slug>
+#   create_assignment_branch <student>/<hypothesis-slug>
 create_assignment_branch() {
-    local student="$1" slug="$2" branch="${student}/${slug}"
+    local student="$1" slug="${2:-}"
+    if [ -z "$slug" ] && [[ "$student" == */* ]]; then
+        slug="${student#*/}"
+        student="${student%%/*}"
+    fi
+    if [ -z "$student" ] || [ -z "$slug" ]; then
+        echo "create_assignment_branch: usage: <student> <hypothesis-slug> or <student>/<hypothesis-slug>" >&2
+        return 2
+    fi
+    local branch="${student}/${slug}"
     require_target_repo || return
-    git checkout "$ADVISOR_BRANCH"
-    git pull origin "$ADVISOR_BRANCH"
-    git checkout -b "$branch"
-    git commit --allow-empty -m "assign ${student}: ${slug}"
-    git push -u origin "$branch"
+    git checkout "$ADVISOR_BRANCH" || return
+    git pull origin "$ADVISOR_BRANCH" || return
+    git checkout -b "$branch" || return
+    git commit --allow-empty -m "assign ${student}: ${slug}" || return
+    git push -u origin "$branch" || return
     git rev-list --count "${ADVISOR_BRANCH}..HEAD" | grep -vq '^0$'
 }
 

--- a/plugins/senpai/scripts/senpai-gh.sh
+++ b/plugins/senpai/scripts/senpai-gh.sh
@@ -33,6 +33,16 @@ gh_retry() {
     return 1
 }
 
+require_target_repo() {
+    local origin
+    origin=$(git config --get remote.origin.url || true)
+    case "$origin" in
+        *"${GH_REPO}"*|*"${TARGET_REPO_URL:-__unset__}"*) return 0 ;;
+    esac
+    echo "ERROR: refusing git operation outside target repo; cwd=$(pwd), origin=${origin:-none}, target=${GH_REPO}" >&2
+    return 2
+}
+
 # ---------------------------------------------------------------------------
 # Label operations
 # ---------------------------------------------------------------------------
@@ -67,8 +77,8 @@ swap_gh_pr_label() {
 #   send_pr_back_to_student_with_comment <number> <comment_body>
 send_pr_back_to_student_with_comment() {
     local num="$1" body="$2"
-    gh_retry gh pr comment "$num" --body "$body"
-    gh_retry gh pr ready "$num" --undo
+    gh_retry gh pr comment "$num" --repo "$GH_REPO" --body "$body"
+    gh_retry gh pr ready "$num" --repo "$GH_REPO" --undo
     swap_gh_pr_label "$num" "status:review" "status:wip"
 }
 
@@ -76,8 +86,8 @@ send_pr_back_to_student_with_comment() {
 #   close_pr_with_comment <number> <reason>
 close_pr_with_comment() {
     local num="$1" reason="$2"
-    gh_retry gh pr comment "$num" --body "ADVISOR: Closing PR #${num} because ${reason}."
-    gh_retry gh pr close "$num" --delete-branch
+    gh_retry gh pr comment "$num" --repo "$GH_REPO" --body "ADVISOR: Closing PR #${num} because ${reason}."
+    gh_retry gh pr close "$num" --repo "$GH_REPO" --delete-branch
 }
 
 # Create an assignment PR through the one path that verifies student routing.
@@ -104,7 +114,7 @@ create_assignment_pr_from_file() {
         return 2
     fi
 
-    pr_url=$(gh_retry gh pr create --draft \
+    pr_url=$(gh_retry gh pr create --repo "$GH_REPO" --draft \
         --title "$title" \
         --body-file "$body_file" \
         --label "$base_branch" \
@@ -119,7 +129,7 @@ create_assignment_pr_from_file() {
         return 1
     fi
 
-    details=$(gh_retry gh pr view "$num" --json number,baseRefName,headRefName,labels,isDraft)
+    details=$(gh_retry gh pr view "$num" --repo "$GH_REPO" --json number,baseRefName,headRefName,labels,isDraft)
     python3 - "$student" "$base_branch" "$head_branch" "$details" <<'PY' || return
 import json
 import sys
@@ -156,7 +166,7 @@ PY
 #   mark_ready_for_review <number>
 mark_ready_for_review() {
     local num="$1"
-    gh_retry gh pr ready "$num"
+    gh_retry gh pr ready "$num" --repo "$GH_REPO"
     swap_gh_pr_label "$num" "status:wip" "status:review"  # swap_gh_pr_label uses gh_retry internally
 }
 
@@ -164,6 +174,7 @@ mark_ready_for_review() {
 #   create_assignment_branch <student> <hypothesis-slug>
 create_assignment_branch() {
     local student="$1" slug="$2" branch="${student}/${slug}"
+    require_target_repo || return
     git checkout "$ADVISOR_BRANCH"
     git pull origin "$ADVISOR_BRANCH"
     git checkout -b "$branch"
@@ -184,12 +195,17 @@ json_numbers() { python3 -c "import sys,json; print(','.join(f'#{i[\"number\"]}'
 # Returns empty string if all arrays are empty.  Usage:
 #   max_updated_at "$JSON_BLOB1" "$JSON_BLOB2" ...
 max_updated_at() {
-    python3 -c "
-import json, sys
-items = [i for blob in sys.argv[1:] if blob for i in json.loads(blob)]
-ts = [i['updatedAt'] for i in items if 'updatedAt' in i]
-print(max(ts) if ts else '')
-" "$@"
+    printf '%s\0' "$@" | python3 -c '
+import json
+import sys
+
+items = []
+for blob in sys.stdin.buffer.read().split(b"\0"):
+    if blob:
+        items.extend(json.loads(blob))
+ts = [i["updatedAt"] for i in items if "updatedAt" in i]
+print(max(ts) if ts else "")
+'
 }
 
 # Merge the JSON values emitted by `gh api --paginate --jq '[...]' into one
@@ -352,12 +368,16 @@ GH_LIST_LIMIT="${GH_LIST_LIMIT:-999}"
 check_gh_issues() {
     local role="$1" since="${2:-}"
     local role_issues team_issues
-    role_issues=$(gh_retry gh issue list --label "human" --label "$role" --state open \
+    if [ "${SENPAI_ENABLE_HUMAN_ISSUES:-true}" = "false" ]; then
+        printf '[]\n'
+        return
+    fi
+    role_issues=$(gh_retry gh issue list --repo "$GH_REPO" --label "human" --label "$role" --state open \
         --limit "$GH_LIST_LIMIT" \
-        --json number,title,updatedAt,comments)
-    team_issues=$(gh_retry gh issue list --label "human" --label "team" --state open \
+        --json number,title,updatedAt)
+    team_issues=$(gh_retry gh issue list --repo "$GH_REPO" --label "human" --label "team" --state open \
         --limit "$GH_LIST_LIMIT" \
-        --json number,title,updatedAt,comments)
+        --json number,title,updatedAt)
     printf '[%s,%s]' "$role_issues" "$team_issues" | python3 -c "
 import json, sys
 a, b = json.loads(sys.stdin.read())
@@ -380,7 +400,7 @@ print(json.dumps(merged))
 list_ready_for_review_prs() {
     local branch="$1" since="${2:-}"
     local prs
-    prs=$(gh_retry gh pr list --label "$branch" --label "status:review" \
+    prs=$(gh_retry gh pr list --repo "$GH_REPO" --label "$branch" --label "status:review" \
         --limit "$GH_LIST_LIMIT" \
         --json number,title,headRefName,labels,updatedAt)
     if [ -z "$since" ]; then
@@ -399,7 +419,7 @@ print(json.dumps([p for p in prs if p.get('updatedAt', '') > sys.argv[1]]))
 #   list_all_prs <branch>
 list_all_prs() {
     local branch="$1"
-    gh_retry gh pr list --label "$branch" \
+    gh_retry gh pr list --repo "$GH_REPO" --label "$branch" \
         --limit "$GH_LIST_LIMIT" \
         --json number,title,state,labels,headRefName,updatedAt,isDraft
 }
@@ -413,7 +433,7 @@ student_poll_for_work() {
         echo "student_poll_for_work: missing advisor branch" >&2
         return 2
     fi
-    gh_retry gh pr list --label "$branch" --label "student:${name}" --label "status:wip" \
+    gh_retry gh pr list --repo "$GH_REPO" --label "$branch" --label "student:${name}" --label "status:wip" \
         --limit "$GH_LIST_LIMIT" \
         --json number,title,headRefName,updatedAt,body
 }
@@ -425,7 +445,7 @@ student_poll_for_work() {
 list_idle_students() {
     local students_csv="$1" branch="$2"
     local all_prs
-    all_prs=$(gh_retry gh pr list --label "$branch" --label "status:wip" \
+    all_prs=$(gh_retry gh pr list --repo "$GH_REPO" --label "$branch" --label "status:wip" \
         --limit "$GH_LIST_LIMIT" \
         --json labels)
     printf '%s' "$all_prs" | python3 -c "


### PR DESCRIPTION
## Summary

Harden the isolated experiment launch path so parallel advisor/student fleets can run without cross-adopting pods, routing work across advisor branches, accidentally pushing to the runner repo, or silently reading broad target-repo history when a fresh branch-only run is intended.

This is intentionally a reusable Senpai control-plane improvement, not just an ICML appendix one-off.

## Changes

- Add configurable launch controls for isolated and replicated runs:
  - `--gpus_per_student` with scaled CPU/memory resources.
  - `--human_issues` / `--nohuman_issues` to enable or disable human/team GitHub issue polling for isolated runs.
  - `--gh_history_scope` / `GH_HISTORY_SCOPE` for target clone scope:
    - `fresh`: shallow, branch-only clone for clean isolated experiments.
    - `branch`: branch-only clone with branch history for normal isolated advisor work.
    - `repo`: full repo clone when deliberate whole-repo continuity is desired.
- Document the three intended research modes in `README.md`: isolated ablation, normal branch memory, and deliberate exploration.
- Scope Kubernetes resources and selectors by `research-tag` so concurrent launches do not adopt each other's pods/config.
- Scope student polling by advisor branch label + `student:<name>` + `status:wip`.
- Add launch-time label creation for advisor branch/status/student routing labels.
- Remove the global GitHub token URL rewrite from pods.
- Centralize target-repo credential setup and runner-repo push protection in `plugins/senpai/scripts/senpai-gh.sh` via `install_senpai_git_guard`.
- Add target-repo-only credential handling, `gh repo set-default`, a runner-repo pre-push hook, and a PATH-level `git push` guard so agents cannot push from `/workspace/senpai`.
- Make GitHub issue polling optional and make polling failures return empty JSON instead of crashing the loop on transient API/rate-limit problems.
- Avoid advancing the advisor last-check watermark after incomplete polling, so a transient polling failure cannot hide older unseen PRs or issues.
- Centralize poll fallback handling via `poll_or_empty` so the advisor loop keeps the watermark safety without repeated shell boilerplate.
- Avoid `Argument list too long` in `max_updated_at` by passing JSON blobs through stdin.
- Harden assignment branch creation so advisors can call either `create_assignment_branch <student> <slug>` or `create_assignment_branch <student>/<slug>`, and git failures stop immediately.
- Fetch assigned PR heads explicitly and check out `FETCH_HEAD`, so branch/fresh scoped clones can still start from student PR branches.

## Validation

- `bash -n k8s/entrypoint-advisor.sh k8s/entrypoint-student.sh plugins/senpai/scripts/senpai-gh.sh k8s/test-entrypoint-advisor.sh`
- `uv run python -m py_compile k8s/launch.py`
- `git diff --check -- README.md k8s/entrypoint-advisor.sh k8s/entrypoint-student.sh k8s/test-entrypoint-advisor.sh plugins/senpai/scripts/senpai-gh.sh`
- `bash k8s/test-entrypoint-advisor.sh`
- `SCENARIO=pollfail bash k8s/test-entrypoint-advisor.sh`
- Temporary-repo smoke test for `install_senpai_git_guard` verifying the generated `git push` wrapper blocks pushes outside `TARGET_WORKDIR`.
- Synthetic large JSON check for `max_updated_at`.
- Dry-run rendered expected `1 GPU / 15 CPU / 120Gi` student resources, disabled human issues, branch/fresh clone scope, and no global GitHub token rewrite.
- Copied to the ICML appendix runner branches and smoke-tested in the live pai2d launch:
  - 90/90 pods Running/Ready across 10 concurrent launches.
  - Open PR label audit found no missing branch/student/status routing labels.
  - Spot/raw-log checks found no repeat of the old PR #44 contamination pattern; remaining observed leakage was limited to control-plane issue visibility/survey surfaces, which this PR makes configurable or easier to avoid for isolated runs.

## Notes

This PR is intentionally draft. The changes are already copied to the ICML appendix runner branches for the live ablation, but merging to `main` should remain human-supervised.
