### PR TITLE
[codex] Fix: skills and agents weren't been exposed to CC, install Claude config in pod startup, add skills to researcher-agent agent

### DIFF
--- a/.claude/agents/researcher-agent.md
+++ b/.claude/agents/researcher-agent.md
@@ -7,6 +7,12 @@ description: >
   and systems design, then returns structured summaries with concrete implementation guidance.
 model: opus
 effort: max
+skills:
+  - senpai:survey-prs
+  - list-experiments
+  - wandb-primary
+  - web-search-advanced-research-paper
+  - alphaxiv-paper-lookup
 ---
 
 You are a deep research specialist for machine learning applied to CFD surrogates. Your job is to get the understanding needed to design experiments that actually move the needle.

--- a/.claude/skills/wandb-primary/SKILL.md
+++ b/.claude/skills/wandb-primary/SKILL.md
@@ -74,8 +74,11 @@ This skill covers everything an agent needs to work with Weights & Biases:
 ### Helper libraries
 
 ```python
+import os
 import sys
-sys.path.insert(0, "skills/wandb-primary/scripts")
+from pathlib import Path
+
+sys.path.insert(0, str(Path(os.environ["CLAUDE_SKILL_DIR"]) / "scripts"))
 
 # Weave helpers (traces, evals, GenAI)
 from weave_helpers import (

--- a/.claude/skills/wandb-primary/scripts/wandb_helpers.py
+++ b/.claude/skills/wandb-primary/scripts/wandb_helpers.py
@@ -9,8 +9,11 @@ hyperparameter sweeps, artifacts, and system metrics. These helpers convert
 run data into pandas-friendly structures for analysis.
 
 Usage (in sandbox):
+    import os
     import sys
-    sys.path.insert(0, "skills/wandb-primary/scripts")
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(os.environ["CLAUDE_SKILL_DIR"]) / "scripts"))
     from wandb_helpers import (
         runs_to_dataframe,   # Convert runs to a clean pandas DataFrame
         diagnose_run,        # Quick diagnostic summary of a training run

--- a/.claude/skills/wandb-primary/scripts/weave_helpers.py
+++ b/.claude/skills/wandb-primary/scripts/weave_helpers.py
@@ -9,8 +9,11 @@ evaluations, and scorers. These helpers convert Weave's wrapper types to plain
 Python and extract structured data from calls and evals for pandas analysis.
 
 Usage (in sandbox):
+    import os
     import sys
-    sys.path.insert(0, "skills/wandb-primary/scripts")
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(os.environ["CLAUDE_SKILL_DIR"]) / "scripts"))
     from weave_helpers import (
         unwrap,                  # Recursively convert Weave types -> plain Python
         get_token_usage,         # Extract token counts from a call's summary

--- a/.gitignore
+++ b/.gitignore
@@ -48,5 +48,8 @@ experiment_log/
 advisor_logs/
 student_logs/
 
+# Claude worktrees
+.claude/worktrees/
+
 # Problem packages (brought by the user — cloned in at pod startup)
 target/*

--- a/k8s/entrypoint-advisor.sh
+++ b/k8s/entrypoint-advisor.sh
@@ -69,8 +69,15 @@ fi
 LOGDIR="$WORKDIR/advisor_logs"
 mkdir -p "$LOGDIR"
 
+# --- Install checked-in Claude Code config into user scope ---
+mkdir -p "$HOME/.claude"
+cp -a "$WORKDIR/.claude/." "$HOME/.claude/"
+
+echo "=== Claude config installed ==="
+ls "$HOME/.claude/skills/wandb-primary/SKILL.md" "$HOME/.claude/agents/researcher-agent.md"
+
 # --- Start Hivemind logging service (streams CC session logs to hivemind.wandb.tools) ---
-mkdir -p ~/.claude/projects
+mkdir -p "$HOME/.claude/projects"
 uvx --from wandb-hivemind hivemind run &
 echo "=== Hivemind started (PID=$!) ==="
 

--- a/k8s/entrypoint-student.sh
+++ b/k8s/entrypoint-student.sh
@@ -46,8 +46,15 @@ if [ "$GH_HISTORY_SCOPE" != "repo" ]; then
     git config remote.origin.tagOpt --no-tags
 fi
 
+# --- Install checked-in Claude Code config into user scope ---
+mkdir -p "$HOME/.claude"
+cp -a "$WORKDIR/.claude/." "$HOME/.claude/"
+
+echo "=== Claude config installed ==="
+ls "$HOME/.claude/skills/wandb-primary/SKILL.md" "$HOME/.claude/agents/researcher-agent.md"
+
 # --- Start Hivemind (streams CC session logs to hivemind.wandb.tools) ---
-mkdir -p ~/.claude/projects
+mkdir -p "$HOME/.claude/projects"
 uvx --from wandb-hivemind hivemind run &
 echo "=== Hivemind started (PID=$!) ==="
 


### PR DESCRIPTION
## Summary
- Copy checked-in `.claude` config into `$HOME/.claude` during advisor and student startup.
- Verify `wandb-primary` and `researcher-agent` are present with a simple `ls`.
- Preload researcher dependencies via `researcher-agent` frontmatter `skills`, including current PR survey state.
- Use `CLAUDE_SKILL_DIR` in `wandb-primary` helper import examples.
- Ignore local `.claude/worktrees/`.

## Why
Claude runs from the nested target repo at `/workspace/senpai/$PROBLEM_DIR`, so parent repo `.claude` skills and agents are not discovered. Copying the checked-in config to user scope makes the shared config available from any cwd; declaring researcher skills in frontmatter makes experiment history, W&B, literature search, paper lookup, and current PR survey context available inside the subagent.

## Validation
- `ruby -e` parsed `researcher-agent.md` frontmatter successfully
- `bash -n k8s/entrypoint-advisor.sh`
- `bash -n k8s/entrypoint-student.sh`
- `bash -n k8s/run-senpai-claude.sh`
- `git diff --check`
