### PR TITLE
[codex] Add advisor-action PR polling

### DIFF
--- a/k8s/entrypoint-advisor.sh
+++ b/k8s/entrypoint-advisor.sh
@@ -116,7 +116,7 @@ FULL_PROMPT="${PROMPT}"$'\n\n'"${KEY_INFO}"
 # Heartbeat prompt for polling
 HEARTBEAT_PROMPT="Continue your advisor loop. Attached is the current research state. Review any completed experiment PRs, assign work to all idle students, and check for human gh issues and comments."
 
-# --- Last-check timestamp state for filtering PRs and issues ---
+# --- Last-check timestamp state for filtering GitHub issues ---
 LAST_CHECK_FILE="$LOGDIR/.last_check_ts"
 
 # --- Launch Claude Code Loop ---
@@ -148,19 +148,22 @@ while true; do
 
     # --- Check research state before invoking CC ---
     POLL_OK=1
-    REVIEW_JSON=$(poll_or_empty "review-ready PR poll" list_ready_for_review_prs "$ADVISOR_BRANCH" "$SINCE") || POLL_OK=0
+    REVIEW_JSON=$(poll_or_empty "review-ready PR poll" list_ready_for_review_prs "$ADVISOR_BRANCH") || POLL_OK=0
     REVIEW_COUNT=$(printf '%s' "$REVIEW_JSON" | json_len)
+    ATTENTION_JSON=$(poll_or_empty "attention PR poll" list_attention_prs "$ADVISOR_BRANCH") || POLL_OK=0
+    ATTENTION_COUNT=$(printf '%s' "$ATTENTION_JSON" | json_len)
     ISSUE_JSON=$(poll_or_empty "GitHub issue poll" check_gh_issues "$ADVISOR_BRANCH" "$SINCE") || POLL_OK=0
     ISSUE_COUNT=$(printf '%s' "$ISSUE_JSON" | json_len)
     IDLE_JSON=$(poll_or_empty "idle-student poll" list_idle_students "$STUDENT_NAMES" "$ADVISOR_BRANCH") || POLL_OK=0
     IDLE_COUNT=$(printf '%s' "$IDLE_JSON" | json_len)
 
     # --- Derive watermark from the data we actually fetched (no gap, no overlap) ---
-    WATERMARK=$(max_updated_at "$REVIEW_JSON" "$ISSUE_JSON")
+    WATERMARK=$(max_updated_at "$ISSUE_JSON")
 
     # --- Build triage info (used in logs, CC prompt, and skip check) ---
     TRIAGE_INFO="## Research state (since ${SINCE:-boot})"
     [ "$REVIEW_COUNT" -gt 0 ] && TRIAGE_INFO+=$'\n'"- **GitHub PRs to review ($REVIEW_COUNT):** $(printf '%s' "$REVIEW_JSON" | json_numbers)"
+    [ "$ATTENTION_COUNT" -gt 0 ] && TRIAGE_INFO+=$'\n'"- **GitHub PRs needing attention ($ATTENTION_COUNT):** $(printf '%s' "$ATTENTION_JSON" | json_attention_summary)"
     [ "$ISSUE_COUNT" -gt 0 ]  && TRIAGE_INFO+=$'\n'"- **GitHub issues ($ISSUE_COUNT):** $(printf '%s' "$ISSUE_JSON" | json_numbers)"
     [ "$IDLE_COUNT" -gt 0 ]   && TRIAGE_INFO+=$'\n'"- **Idle students ($IDLE_COUNT):** $(printf '%s' "$IDLE_JSON" | json_join)"
     echo "$TRIAGE_INFO"
@@ -178,7 +181,7 @@ while true; do
         run_senpai_claude $MAX_TURNS "${FULL_PROMPT}"$'\n\n'"${TRIAGE_INFO}" || EXIT_CODE=$?
     else
         # --- Programmatic skip: skip rest of CC loop if nothing actionable ---
-        if [ "$REVIEW_COUNT" -eq 0 ] && [ "$ISSUE_COUNT" -eq 0 ] && [ "$IDLE_COUNT" -eq 0 ]; then
+        if [ "$REVIEW_COUNT" -eq 0 ] && [ "$ATTENTION_COUNT" -eq 0 ] && [ "$ISSUE_COUNT" -eq 0 ] && [ "$IDLE_COUNT" -eq 0 ]; then
             echo "=== Iteration $ITERATION: Nothing actionable, sleeping $SLEEP_TIME_S seconds ==="
             sleep "$SLEEP_TIME_S"
             continue

--- a/k8s/entrypoint-advisor.sh
+++ b/k8s/entrypoint-advisor.sh
@@ -150,8 +150,8 @@ while true; do
     POLL_OK=1
     REVIEW_JSON=$(poll_or_empty "review-ready PR poll" list_ready_for_review_prs "$ADVISOR_BRANCH") || POLL_OK=0
     REVIEW_COUNT=$(printf '%s' "$REVIEW_JSON" | json_len)
-    ATTENTION_JSON=$(poll_or_empty "attention PR poll" list_attention_prs "$ADVISOR_BRANCH") || POLL_OK=0
-    ATTENTION_COUNT=$(printf '%s' "$ATTENTION_JSON" | json_len)
+    ADVISOR_ACTION_JSON=$(poll_or_empty "advisor-action PR poll" list_prs_requiring_advisor_action "$ADVISOR_BRANCH") || POLL_OK=0
+    ADVISOR_ACTION_COUNT=$(printf '%s' "$ADVISOR_ACTION_JSON" | json_len)
     ISSUE_JSON=$(poll_or_empty "GitHub issue poll" check_gh_issues "$ADVISOR_BRANCH" "$SINCE") || POLL_OK=0
     ISSUE_COUNT=$(printf '%s' "$ISSUE_JSON" | json_len)
     IDLE_JSON=$(poll_or_empty "idle-student poll" list_idle_students "$STUDENT_NAMES" "$ADVISOR_BRANCH") || POLL_OK=0
@@ -163,7 +163,7 @@ while true; do
     # --- Build triage info (used in logs, CC prompt, and skip check) ---
     TRIAGE_INFO="## Research state (since ${SINCE:-boot})"
     [ "$REVIEW_COUNT" -gt 0 ] && TRIAGE_INFO+=$'\n'"- **GitHub PRs to review ($REVIEW_COUNT):** $(printf '%s' "$REVIEW_JSON" | json_numbers)"
-    [ "$ATTENTION_COUNT" -gt 0 ] && TRIAGE_INFO+=$'\n'"- **GitHub PRs needing attention ($ATTENTION_COUNT):** $(printf '%s' "$ATTENTION_JSON" | json_attention_summary)"
+    [ "$ADVISOR_ACTION_COUNT" -gt 0 ] && TRIAGE_INFO+=$'\n'"- **GitHub PRs requiring advisor action ($ADVISOR_ACTION_COUNT):** $(printf '%s' "$ADVISOR_ACTION_JSON" | json_advisor_action_summary)"
     [ "$ISSUE_COUNT" -gt 0 ]  && TRIAGE_INFO+=$'\n'"- **GitHub issues ($ISSUE_COUNT):** $(printf '%s' "$ISSUE_JSON" | json_numbers)"
     [ "$IDLE_COUNT" -gt 0 ]   && TRIAGE_INFO+=$'\n'"- **Idle students ($IDLE_COUNT):** $(printf '%s' "$IDLE_JSON" | json_join)"
     echo "$TRIAGE_INFO"
@@ -181,7 +181,7 @@ while true; do
         run_senpai_claude $MAX_TURNS "${FULL_PROMPT}"$'\n\n'"${TRIAGE_INFO}" || EXIT_CODE=$?
     else
         # --- Programmatic skip: skip rest of CC loop if nothing actionable ---
-        if [ "$REVIEW_COUNT" -eq 0 ] && [ "$ATTENTION_COUNT" -eq 0 ] && [ "$ISSUE_COUNT" -eq 0 ] && [ "$IDLE_COUNT" -eq 0 ]; then
+        if [ "$REVIEW_COUNT" -eq 0 ] && [ "$ADVISOR_ACTION_COUNT" -eq 0 ] && [ "$ISSUE_COUNT" -eq 0 ] && [ "$IDLE_COUNT" -eq 0 ]; then
             echo "=== Iteration $ITERATION: Nothing actionable, sleeping $SLEEP_TIME_S seconds ==="
             sleep "$SLEEP_TIME_S"
             continue

--- a/k8s/entrypoint-student.sh
+++ b/k8s/entrypoint-student.sh
@@ -142,6 +142,22 @@ while true; do
     echo "=== Log: $LOGFILE ==="
     echo "$TRIAGE_INFO" > "$LOGFILE"
 
+    if [ "$ASSIGNED_COUNT" -gt 1 ]; then
+        DUPLICATE_NUMBERS=$(printf '%s' "$ASSIGNED_JSON" | json_numbers)
+        DUPLICATE_MARKER="STUDENT-DUPLICATE-ASSIGNMENT"
+        DUPLICATE_BODY="${DUPLICATE_MARKER}: student:${STUDENT_NAME} has ${ASSIGNED_COUNT} active status:wip PRs (${DUPLICATE_NUMBERS}) on ${ADVISOR_BRANCH}. The student loop is skipping work until the advisor leaves exactly one active assignment."
+        echo "ERROR: ${DUPLICATE_BODY}"
+        printf '%s' "$ASSIGNED_JSON" | python3 -c 'import json,sys; print("\n".join(str(pr["number"]) for pr in json.loads(sys.stdin.read())))' |
+        while IFS= read -r num; do
+            [ -z "$num" ] && continue
+            if ! pr_issue_comments "$num" | grep -q "$DUPLICATE_MARKER"; then
+                gh_retry gh pr comment "$num" --repo "$GH_REPO" --body "$DUPLICATE_BODY"
+            fi
+        done
+        sleep "$SLEEP_TIME_S"
+        continue
+    fi
+
     # The shell loop is the source of truth for assignment polling. If there
     # is no work, do not enter Claude Code; idle model sessions tend to invent
     # their own polling loops and can miss the label-based assignment contract.

--- a/k8s/test-entrypoint-advisor.sh
+++ b/k8s/test-entrypoint-advisor.sh
@@ -38,38 +38,39 @@ case "$SCENARIO" in
     mixed)
         # 1 PR to review, 0 issues, alice is idle
         list_ready_for_review_prs() { echo '[{"number":42,"title":"test PR","updatedAt":"2026-04-01T20:00:00Z"}]'; }
+        list_attention_prs() { echo '[]'; }
         check_gh_issues() { echo '[]'; }
         list_idle_students() { echo '["alice"]'; }
         ;;
     idle)
         # nothing actionable — should hit the skip branch every time
         list_ready_for_review_prs() { echo '[]'; }
+        list_attention_prs() { echo '[]'; }
         check_gh_issues() { echo '[]'; }
         list_idle_students() { echo '[]'; }
         ;;
     busy)
         # PRs to review, issues open, multiple idle students
         list_ready_for_review_prs() { echo '[{"number":1,"updatedAt":"2026-04-01T20:00:00Z"},{"number":2,"updatedAt":"2026-04-01T21:00:00Z"}]'; }
+        list_attention_prs() { echo '[{"number":3,"reasons":["stale_wip","duplicate_student_wip"],"updatedAt":"2026-04-01T18:00:00Z"}]'; }
         check_gh_issues() { echo '[{"number":10,"title":"help","updatedAt":"2026-04-01T19:00:00Z"}]'; }
         list_idle_students() { echo '["bob","charlie"]'; }
         ;;
     since)
-        # Tests timestamp filtering: iteration 1 sees everything, iteration 2+ sees nothing new
+        # Review PRs are level-triggered; issues still use the timestamp filter.
         CALL_COUNT=0
         list_ready_for_review_prs() {
             CALL_COUNT=$((CALL_COUNT + 1))
-            if [ "$CALL_COUNT" -le 1 ]; then
-                echo '[{"number":42,"updatedAt":"2026-04-01T20:00:00Z"}]'
-            else
-                echo '[]'  # already seen
-            fi
+            echo '[{"number":42,"updatedAt":"2026-04-01T20:00:00Z"}]'
         }
+        list_attention_prs() { echo '[]'; }
         check_gh_issues() { echo '[]'; }
         list_idle_students() { echo '[]'; }
         ;;
     pollfail)
         # A partial poll with work should run CC but should not advance the watermark.
         list_ready_for_review_prs() { echo '[{"number":42,"updatedAt":"2026-04-01T20:00:00Z"}]'; }
+        list_attention_prs() { return 1; }
         check_gh_issues() { return 1; }
         list_idle_students() { echo '[]'; }
         ;;
@@ -79,6 +80,7 @@ esac
 json_len() { python3 -c "import sys,json; print(len(json.loads(sys.stdin.read())))"; }
 json_join() { python3 -c "import sys,json; print(','.join(json.loads(sys.stdin.read())))"; }
 json_numbers() { python3 -c "import sys,json; print(','.join(f'#{i[\"number\"]}' for i in json.loads(sys.stdin.read())))"; }
+json_attention_summary() { python3 -c 'import sys,json; print(",".join("#{}[{}]".format(i["number"], ",".join(i.get("reasons", []))) for i in json.loads(sys.stdin.read())))'; }
 
 # --- Test config ---
 LOGDIR="$WORKDIR/advisor_logs"
@@ -110,19 +112,21 @@ while true; do
 
     # --- Check research state ---
     POLL_OK=1
-    REVIEW_JSON=$(poll_or_empty "review-ready PR poll" list_ready_for_review_prs "$ADVISOR_BRANCH" "$SINCE") || POLL_OK=0
+    REVIEW_JSON=$(poll_or_empty "review-ready PR poll" list_ready_for_review_prs "$ADVISOR_BRANCH") || POLL_OK=0
     REVIEW_COUNT=$(printf '%s' "$REVIEW_JSON" | json_len)
+    ATTENTION_JSON=$(poll_or_empty "attention PR poll" list_attention_prs "$ADVISOR_BRANCH") || POLL_OK=0
+    ATTENTION_COUNT=$(printf '%s' "$ATTENTION_JSON" | json_len)
     ISSUE_JSON=$(poll_or_empty "GitHub issue poll" check_gh_issues "$ADVISOR_BRANCH" "$SINCE") || POLL_OK=0
     ISSUE_COUNT=$(printf '%s' "$ISSUE_JSON" | json_len)
     IDLE_JSON=$(poll_or_empty "idle-student poll" list_idle_students "$STUDENT_NAMES" "$ADVISOR_BRANCH") || POLL_OK=0
     IDLE_COUNT=$(printf '%s' "$IDLE_JSON" | json_len)
-    WATERMARK=$(max_updated_at "$REVIEW_JSON" "$ISSUE_JSON")
+    WATERMARK=$(max_updated_at "$ISSUE_JSON")
 
-    TRIAGE_INFO="=== Research state (since ${SINCE:-boot}): reviews=$REVIEW_COUNT | issues=$ISSUE_COUNT | idle=$IDLE_COUNT ==="
+    TRIAGE_INFO="=== Research state (since ${SINCE:-boot}): reviews=$REVIEW_COUNT | attention=$ATTENTION_COUNT | issues=$ISSUE_COUNT | idle=$IDLE_COUNT ==="
     echo "$TRIAGE_INFO"
 
     # --- Skip if nothing actionable ---
-    if [ "$REVIEW_COUNT" -eq 0 ] && [ "$ISSUE_COUNT" -eq 0 ] && [ "$IDLE_COUNT" -eq 0 ]; then
+    if [ "$REVIEW_COUNT" -eq 0 ] && [ "$ATTENTION_COUNT" -eq 0 ] && [ "$ISSUE_COUNT" -eq 0 ] && [ "$IDLE_COUNT" -eq 0 ]; then
         echo "=== Nothing actionable, sleeping $SLEEP_TIME_S seconds ==="
         sleep "$SLEEP_TIME_S"
         [ "$ITERATION" -ge "$MAX_ITERATIONS" ] && break
@@ -133,6 +137,10 @@ while true; do
     if [ "$REVIEW_COUNT" -gt 0 ]; then
         REVIEW_NUMS=$(printf '%s' "$REVIEW_JSON" | json_numbers)
         TRIAGE_INFO="${TRIAGE_INFO} | Review PRs: ${REVIEW_NUMS}"
+    fi
+    if [ "$ATTENTION_COUNT" -gt 0 ]; then
+        ATTENTION_SUMMARY=$(printf '%s' "$ATTENTION_JSON" | json_attention_summary)
+        TRIAGE_INFO="${TRIAGE_INFO} | Attention PRs: ${ATTENTION_SUMMARY}"
     fi
     if [ "$ISSUE_COUNT" -gt 0 ]; then
         ISSUE_NUMS=$(printf '%s' "$ISSUE_JSON" | json_numbers)

--- a/k8s/test-entrypoint-advisor.sh
+++ b/k8s/test-entrypoint-advisor.sh
@@ -38,21 +38,21 @@ case "$SCENARIO" in
     mixed)
         # 1 PR to review, 0 issues, alice is idle
         list_ready_for_review_prs() { echo '[{"number":42,"title":"test PR","updatedAt":"2026-04-01T20:00:00Z"}]'; }
-        list_attention_prs() { echo '[]'; }
+        list_prs_requiring_advisor_action() { echo '[]'; }
         check_gh_issues() { echo '[]'; }
         list_idle_students() { echo '["alice"]'; }
         ;;
     idle)
         # nothing actionable — should hit the skip branch every time
         list_ready_for_review_prs() { echo '[]'; }
-        list_attention_prs() { echo '[]'; }
+        list_prs_requiring_advisor_action() { echo '[]'; }
         check_gh_issues() { echo '[]'; }
         list_idle_students() { echo '[]'; }
         ;;
     busy)
         # PRs to review, issues open, multiple idle students
         list_ready_for_review_prs() { echo '[{"number":1,"updatedAt":"2026-04-01T20:00:00Z"},{"number":2,"updatedAt":"2026-04-01T21:00:00Z"}]'; }
-        list_attention_prs() { echo '[{"number":3,"reasons":["stale_wip","duplicate_student_wip"],"updatedAt":"2026-04-01T18:00:00Z"}]'; }
+        list_prs_requiring_advisor_action() { echo '[{"number":3,"reasons":["stale_wip","duplicate_student_wip"],"updatedAt":"2026-04-01T18:00:00Z"}]'; }
         check_gh_issues() { echo '[{"number":10,"title":"help","updatedAt":"2026-04-01T19:00:00Z"}]'; }
         list_idle_students() { echo '["bob","charlie"]'; }
         ;;
@@ -63,14 +63,14 @@ case "$SCENARIO" in
             CALL_COUNT=$((CALL_COUNT + 1))
             echo '[{"number":42,"updatedAt":"2026-04-01T20:00:00Z"}]'
         }
-        list_attention_prs() { echo '[]'; }
+        list_prs_requiring_advisor_action() { echo '[]'; }
         check_gh_issues() { echo '[]'; }
         list_idle_students() { echo '[]'; }
         ;;
     pollfail)
         # A partial poll with work should run CC but should not advance the watermark.
         list_ready_for_review_prs() { echo '[{"number":42,"updatedAt":"2026-04-01T20:00:00Z"}]'; }
-        list_attention_prs() { return 1; }
+        list_prs_requiring_advisor_action() { return 1; }
         check_gh_issues() { return 1; }
         list_idle_students() { echo '[]'; }
         ;;
@@ -80,7 +80,7 @@ esac
 json_len() { python3 -c "import sys,json; print(len(json.loads(sys.stdin.read())))"; }
 json_join() { python3 -c "import sys,json; print(','.join(json.loads(sys.stdin.read())))"; }
 json_numbers() { python3 -c "import sys,json; print(','.join(f'#{i[\"number\"]}' for i in json.loads(sys.stdin.read())))"; }
-json_attention_summary() { python3 -c 'import sys,json; print(",".join("#{}[{}]".format(i["number"], ",".join(i.get("reasons", []))) for i in json.loads(sys.stdin.read())))'; }
+json_advisor_action_summary() { python3 -c 'import sys,json; print(",".join("#{}[{}]".format(i["number"], ",".join(i.get("reasons", []))) for i in json.loads(sys.stdin.read())))'; }
 
 # --- Test config ---
 LOGDIR="$WORKDIR/advisor_logs"
@@ -114,19 +114,19 @@ while true; do
     POLL_OK=1
     REVIEW_JSON=$(poll_or_empty "review-ready PR poll" list_ready_for_review_prs "$ADVISOR_BRANCH") || POLL_OK=0
     REVIEW_COUNT=$(printf '%s' "$REVIEW_JSON" | json_len)
-    ATTENTION_JSON=$(poll_or_empty "attention PR poll" list_attention_prs "$ADVISOR_BRANCH") || POLL_OK=0
-    ATTENTION_COUNT=$(printf '%s' "$ATTENTION_JSON" | json_len)
+    ADVISOR_ACTION_JSON=$(poll_or_empty "advisor-action PR poll" list_prs_requiring_advisor_action "$ADVISOR_BRANCH") || POLL_OK=0
+    ADVISOR_ACTION_COUNT=$(printf '%s' "$ADVISOR_ACTION_JSON" | json_len)
     ISSUE_JSON=$(poll_or_empty "GitHub issue poll" check_gh_issues "$ADVISOR_BRANCH" "$SINCE") || POLL_OK=0
     ISSUE_COUNT=$(printf '%s' "$ISSUE_JSON" | json_len)
     IDLE_JSON=$(poll_or_empty "idle-student poll" list_idle_students "$STUDENT_NAMES" "$ADVISOR_BRANCH") || POLL_OK=0
     IDLE_COUNT=$(printf '%s' "$IDLE_JSON" | json_len)
     WATERMARK=$(max_updated_at "$ISSUE_JSON")
 
-    TRIAGE_INFO="=== Research state (since ${SINCE:-boot}): reviews=$REVIEW_COUNT | attention=$ATTENTION_COUNT | issues=$ISSUE_COUNT | idle=$IDLE_COUNT ==="
+    TRIAGE_INFO="=== Research state (since ${SINCE:-boot}): reviews=$REVIEW_COUNT | advisor_action=$ADVISOR_ACTION_COUNT | issues=$ISSUE_COUNT | idle=$IDLE_COUNT ==="
     echo "$TRIAGE_INFO"
 
     # --- Skip if nothing actionable ---
-    if [ "$REVIEW_COUNT" -eq 0 ] && [ "$ATTENTION_COUNT" -eq 0 ] && [ "$ISSUE_COUNT" -eq 0 ] && [ "$IDLE_COUNT" -eq 0 ]; then
+    if [ "$REVIEW_COUNT" -eq 0 ] && [ "$ADVISOR_ACTION_COUNT" -eq 0 ] && [ "$ISSUE_COUNT" -eq 0 ] && [ "$IDLE_COUNT" -eq 0 ]; then
         echo "=== Nothing actionable, sleeping $SLEEP_TIME_S seconds ==="
         sleep "$SLEEP_TIME_S"
         [ "$ITERATION" -ge "$MAX_ITERATIONS" ] && break
@@ -138,9 +138,9 @@ while true; do
         REVIEW_NUMS=$(printf '%s' "$REVIEW_JSON" | json_numbers)
         TRIAGE_INFO="${TRIAGE_INFO} | Review PRs: ${REVIEW_NUMS}"
     fi
-    if [ "$ATTENTION_COUNT" -gt 0 ]; then
-        ATTENTION_SUMMARY=$(printf '%s' "$ATTENTION_JSON" | json_attention_summary)
-        TRIAGE_INFO="${TRIAGE_INFO} | Attention PRs: ${ATTENTION_SUMMARY}"
+    if [ "$ADVISOR_ACTION_COUNT" -gt 0 ]; then
+        ADVISOR_ACTION_SUMMARY=$(printf '%s' "$ADVISOR_ACTION_JSON" | json_advisor_action_summary)
+        TRIAGE_INFO="${TRIAGE_INFO} | Advisor-action PRs: ${ADVISOR_ACTION_SUMMARY}"
     fi
     if [ "$ISSUE_COUNT" -gt 0 ]; then
         ISSUE_NUMS=$(printf '%s' "$ISSUE_JSON" | json_numbers)

--- a/plugins/senpai/scripts/senpai-gh.sh
+++ b/plugins/senpai/scripts/senpai-gh.sh
@@ -155,7 +155,7 @@ close_pr_with_comment() {
 #   create_assignment_pr_from_file <student> <head-branch> <title> <body-file> [base-branch]
 create_assignment_pr_from_file() {
     local student="$1" head_branch="$2" title="$3" body_file="$4" base_branch="${5:-${ADVISOR_BRANCH:-}}"
-    local pr_url num details
+    local existing existing_count pr_url num details
 
     if [ -z "$student" ] || [ -z "$head_branch" ] || [ -z "$title" ] || [ -z "$body_file" ] || [ -z "$base_branch" ]; then
         echo "create_assignment_pr_from_file: usage: <student> <head-branch> <title> <body-file> [base-branch]" >&2
@@ -164,6 +164,13 @@ create_assignment_pr_from_file() {
     if [ ! -f "$body_file" ]; then
         echo "create_assignment_pr_from_file: body file not found: $body_file" >&2
         return 2
+    fi
+
+    existing=$(student_poll_for_work "$student" "$base_branch")
+    existing_count=$(printf '%s' "$existing" | json_len)
+    if [ "$existing_count" -gt 0 ]; then
+        echo "create_assignment_pr_from_file: student:${student} already has active status:wip PR(s): $(printf '%s' "$existing" | json_numbers)" >&2
+        return 1
     fi
 
     pr_url=$(gh_retry gh pr create --repo "$GH_REPO" --draft \
@@ -252,6 +259,19 @@ create_assignment_branch() {
 json_len() { python3 -c "import sys,json; print(len(json.loads(sys.stdin.read())))"; }
 json_join() { python3 -c "import sys,json; print(','.join(json.loads(sys.stdin.read())))"; }
 json_numbers() { python3 -c "import sys,json; print(','.join(f'#{i[\"number\"]}' for i in json.loads(sys.stdin.read())))"; }
+json_attention_summary() {
+    python3 -c '
+import json
+import sys
+
+items = json.loads(sys.stdin.read())
+parts = []
+for item in items:
+    reasons = ",".join(item.get("reasons", []))
+    parts.append("#{}[{}]".format(item["number"], reasons))
+print(",".join(parts))
+'
+}
 
 # Print the maximum updatedAt timestamp from one or more JSON arrays.
 # Returns empty string if all arrays are empty.  Usage:
@@ -457,23 +477,14 @@ print(json.dumps(merged))
 
 # List PRs that are ready for advisor review on a given branch.
 # Returns a JSON array.
-# Optional second arg: ISO timestamp — only return PRs updated after it.
+# Optional second arg is accepted for backward compatibility but intentionally
+# ignored: review-ready PRs are level-triggered until the advisor resolves them.
 #   list_ready_for_review_prs <branch> [since]
 list_ready_for_review_prs() {
-    local branch="$1" since="${2:-}"
-    local prs
-    prs=$(gh_retry gh pr list --repo "$GH_REPO" --label "$branch" --label "status:review" \
+    local branch="$1"
+    gh_retry gh pr list --repo "$GH_REPO" --label "$branch" --label "status:review" \
         --limit "$GH_LIST_LIMIT" \
-        --json number,title,headRefName,labels,updatedAt)
-    if [ -z "$since" ]; then
-        printf '%s' "$prs"
-    else
-        printf '%s' "$prs" | python3 -c "
-import json, sys
-prs = json.loads(sys.stdin.read())
-print(json.dumps([p for p in prs if p.get('updatedAt', '') > sys.argv[1]]))
-" "$since"
-    fi
+        --json number,title,headRefName,labels,updatedAt
 }
 
 # List all open PRs on a branch (any status).
@@ -484,6 +495,106 @@ list_all_prs() {
     gh_retry gh pr list --repo "$GH_REPO" --label "$branch" \
         --limit "$GH_LIST_LIMIT" \
         --json number,title,state,labels,headRefName,updatedAt,isDraft
+}
+
+# List open PRs that should wake the advisor even when they have not been
+# updated since the last heartbeat.
+# Returns a JSON array with a `reasons` list on each PR.
+#   list_attention_prs <branch> [stale_wip_seconds]
+list_attention_prs() {
+    local branch="$1" stale_seconds="${2:-${SENPAI_STALE_WIP_SECONDS:-7200}}"
+    local prs comments_by_pr num comments row
+    prs=$(gh_retry gh pr list --repo "$GH_REPO" --base "$branch" --state open \
+        --limit "$GH_LIST_LIMIT" \
+        --json number,title,baseRefName,headRefName,labels,updatedAt,isDraft,mergeStateStatus,mergeable)
+    comments_by_pr=""
+    while IFS= read -r num; do
+        [ -z "$num" ] && continue
+        comments=$(pr_issue_comments "$num") || return
+        row=$(printf '%s\0%s' "$num" "$comments" | python3 -c '
+import json
+import sys
+
+num, comments = sys.stdin.buffer.read().split(b"\0", 1)
+print(json.dumps({"number": int(num), "comments": json.loads(comments)}))
+')
+        comments_by_pr+="${row}"$'\n'
+    done < <(printf '%s' "$prs" | python3 -c 'import json,sys; print("\n".join(str(pr["number"]) for pr in json.loads(sys.stdin.read())))')
+
+    printf '%s\0%s' "$prs" "$comments_by_pr" | python3 -c '
+import json
+import re
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+
+branch = sys.argv[1]
+stale_seconds = int(sys.argv[2])
+now = datetime.now(timezone.utc)
+raw_prs, raw_comments = sys.stdin.buffer.read().split(b"\0", 1)
+prs = json.loads(raw_prs)
+comments_by_pr = {}
+for line in raw_comments.decode().splitlines():
+    if line.strip():
+        row = json.loads(line)
+        comments_by_pr[row["number"]] = row["comments"]
+
+def parse_ts(value):
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+def label_names(pr):
+    return {label.get("name", "") for label in pr.get("labels", [])}
+
+student_wips = defaultdict(list)
+metadata = {}
+for pr in prs:
+    labels = label_names(pr)
+    students = sorted(label.removeprefix("student:") for label in labels if label.startswith("student:"))
+    metadata[pr["number"]] = (labels, students)
+    if "status:wip" in labels:
+        for student in students:
+            student_wips[student].append(pr["number"])
+
+duplicate_wips = {
+    number
+    for numbers in student_wips.values()
+    if len(numbers) > 1
+    for number in numbers
+}
+
+conflict_re = re.compile(r"merge conflict|rebase conflict|cannot automatically merge|can.t automatically merge|conflicts? with", re.I)
+attention = []
+for pr in prs:
+    labels, students = metadata[pr["number"]]
+    reasons = []
+    if branch not in labels:
+        reasons.append("missing_branch_label")
+    if not students:
+        reasons.append("missing_student_label")
+    if pr["number"] in duplicate_wips:
+        reasons.append("duplicate_student_wip")
+    if "status:wip" in labels:
+        age = (now - parse_ts(pr["updatedAt"])).total_seconds()
+        if age > stale_seconds:
+            reasons.append("stale_wip")
+    if "status:needs-rebase" in labels:
+        reasons.append("needs_rebase")
+    if "status:blocked" in labels:
+        reasons.append("blocked_wip")
+    if pr.get("mergeStateStatus") in {"BEHIND", "DIRTY"} or pr.get("mergeable") == "CONFLICTING":
+        reasons.append("needs_rebase")
+    comment_text = "\n".join(comment.get("body", "") for comment in comments_by_pr.get(pr["number"], []))
+    if conflict_re.search(comment_text):
+        reasons.append("merge_conflict_comment")
+    if pr.get("isDraft") and "status:review" in labels:
+        reasons.append("draft_but_claimed_mergeable")
+    if reasons:
+        item = dict(pr)
+        item["reasons"] = sorted(set(reasons), key=reasons.index)
+        attention.append(item)
+
+print(json.dumps(attention))
+' "$branch" "$stale_seconds"
 }
 
 # List WIP PRs assigned to a specific student on the current advisor branch.

--- a/plugins/senpai/scripts/senpai-gh.sh
+++ b/plugins/senpai/scripts/senpai-gh.sh
@@ -259,7 +259,7 @@ create_assignment_branch() {
 json_len() { python3 -c "import sys,json; print(len(json.loads(sys.stdin.read())))"; }
 json_join() { python3 -c "import sys,json; print(','.join(json.loads(sys.stdin.read())))"; }
 json_numbers() { python3 -c "import sys,json; print(','.join(f'#{i[\"number\"]}' for i in json.loads(sys.stdin.read())))"; }
-json_attention_summary() {
+json_advisor_action_summary() {
     python3 -c '
 import json
 import sys
@@ -497,11 +497,11 @@ list_all_prs() {
         --json number,title,state,labels,headRefName,updatedAt,isDraft
 }
 
-# List open PRs that should wake the advisor even when they have not been
-# updated since the last heartbeat.
+# List open PRs requiring advisor action, even when they have not been updated
+# since the last heartbeat.
 # Returns a JSON array with a `reasons` list on each PR.
-#   list_attention_prs <branch> [stale_wip_seconds]
-list_attention_prs() {
+#   list_prs_requiring_advisor_action <branch> [stale_wip_seconds]
+list_prs_requiring_advisor_action() {
     local branch="$1" stale_seconds="${2:-${SENPAI_STALE_WIP_SECONDS:-7200}}"
     local prs comments_by_pr num comments row
     prs=$(gh_retry gh pr list --repo "$GH_REPO" --base "$branch" --state open \
@@ -563,7 +563,7 @@ duplicate_wips = {
 }
 
 conflict_re = re.compile(r"merge conflict|rebase conflict|cannot automatically merge|can.t automatically merge|conflicts? with", re.I)
-attention = []
+prs_requiring_advisor_action = []
 for pr in prs:
     labels, students = metadata[pr["number"]]
     reasons = []
@@ -591,9 +591,9 @@ for pr in prs:
     if reasons:
         item = dict(pr)
         item["reasons"] = sorted(set(reasons), key=reasons.index)
-        attention.append(item)
+        prs_requiring_advisor_action.append(item)
 
-print(json.dumps(attention))
+print(json.dumps(prs_requiring_advisor_action))
 ' "$branch" "$stale_seconds"
 }
 

--- a/plugins/senpai/skills/senpai-gh/SKILL.md
+++ b/plugins/senpai/skills/senpai-gh/SKILL.md
@@ -45,7 +45,7 @@ GitHub's `gh pr edit --remove-label X --add-label Y` silently strips **all other
 |---|---|
 | `send_pr_back_to_student_with_comment <pr#> <comment>` | Send a PR back to the student with feedback. Comment on the PR, convert back to draft, swap `status:review` → `status:wip`. |
 | `close_pr_with_comment <pr#> <reason>` | Close a dead-end PR with a comment explaining why. Comment with reason, close the PR, delete the remote branch. |
-| `create_assignment_pr_from_file <student> <head-branch> <title> <body-file> [base-branch]` | Create a draft assignment PR, then fail if the required base/head, draft, or routing labels are missing. |
+| `create_assignment_pr_from_file <student> <head-branch> <title> <body-file> [base-branch]` | Create a draft assignment PR, then fail if the student already has a `status:wip` PR or if required base/head, draft, or routing labels are missing. |
 
 ### Student actions
 
@@ -64,6 +64,7 @@ The default repo for `gh` is set via the injected `GH_REPO` env var, so no `--re
 | `issue_comments <issue#>` | Read all issue comments through REST pagination. Returns JSON array. |
 | `issue_with_comments <issue#>` | Read one issue and all comments through REST pagination. Returns JSON object. |
 | `list_ready_for_review_prs <branch>` | List PRs with `status:review` on a branch. Returns JSON array. |
+| `list_attention_prs <branch>` | List open branch PRs that need advisor attention, with `reasons` such as stale WIP, duplicate student WIP, missing routing labels, or rebase conflicts. Returns JSON array. |
 | `list_all_prs <branch>` | List all open PRs on a branch (any status). Returns JSON array. |
 | `student_poll_for_work <student_name> [branch]` | List branch-scoped WIP PRs assigned to a student. Returns JSON array. |
 | `list_idle_students <names_csv> <branch>` | Print names of students with no `status:wip` PR, one per line. |

--- a/plugins/senpai/skills/senpai-gh/SKILL.md
+++ b/plugins/senpai/skills/senpai-gh/SKILL.md
@@ -64,7 +64,7 @@ The default repo for `gh` is set via the injected `GH_REPO` env var, so no `--re
 | `issue_comments <issue#>` | Read all issue comments through REST pagination. Returns JSON array. |
 | `issue_with_comments <issue#>` | Read one issue and all comments through REST pagination. Returns JSON object. |
 | `list_ready_for_review_prs <branch>` | List PRs with `status:review` on a branch. Returns JSON array. |
-| `list_attention_prs <branch>` | List open branch PRs that need advisor attention, with `reasons` such as stale WIP, duplicate student WIP, missing routing labels, or rebase conflicts. Returns JSON array. |
+| `list_prs_requiring_advisor_action <branch>` | List open branch PRs requiring advisor action, with `reasons` such as stale WIP, duplicate student WIP, missing routing labels, or rebase conflicts. Returns JSON array. |
 | `list_all_prs <branch>` | List all open PRs on a branch (any status). Returns JSON array. |
 | `student_poll_for_work <student_name> [branch]` | List branch-scoped WIP PRs assigned to a student. Returns JSON array. |
 | `list_idle_students <names_csv> <branch>` | Print names of students with no `status:wip` PR, one per line. |

--- a/plugins/senpai/skills/survey-prs/SKILL.md
+++ b/plugins/senpai/skills/survey-prs/SKILL.md
@@ -35,6 +35,9 @@ list_all_prs "$ADVISOR_BRANCH"
 # Just the review-ready ones
 list_ready_for_review_prs "$ADVISOR_BRANCH"
 
+# PRs with stale, blocked, conflicting, duplicate, or malformed assignment state
+list_attention_prs "$ADVISOR_BRANCH"
+
 # Who's idle
 list_idle_students "$STUDENT_NAMES" "$ADVISOR_BRANCH"
 ```
@@ -42,6 +45,7 @@ list_idle_students "$STUDENT_NAMES" "$ADVISOR_BRANCH"
 2. **Categorize** each PR by its status labels:
    - `status:review` — ready for advisor review
    - `status:wip` — student is working on it (note which student from the `student:*` label)
+   - attention reasons from `list_attention_prs` — stale WIP, duplicate student WIP, missing routing labels, blocked/needs-rebase state, or merge-conflict comments
    - Draft with no status — may be newly created or stalled
 
 3. **Return a structured summary** in this format:

--- a/plugins/senpai/skills/survey-prs/SKILL.md
+++ b/plugins/senpai/skills/survey-prs/SKILL.md
@@ -36,7 +36,7 @@ list_all_prs "$ADVISOR_BRANCH"
 list_ready_for_review_prs "$ADVISOR_BRANCH"
 
 # PRs with stale, blocked, conflicting, duplicate, or malformed assignment state
-list_attention_prs "$ADVISOR_BRANCH"
+list_prs_requiring_advisor_action "$ADVISOR_BRANCH"
 
 # Who's idle
 list_idle_students "$STUDENT_NAMES" "$ADVISOR_BRANCH"
@@ -45,7 +45,7 @@ list_idle_students "$STUDENT_NAMES" "$ADVISOR_BRANCH"
 2. **Categorize** each PR by its status labels:
    - `status:review` — ready for advisor review
    - `status:wip` — student is working on it (note which student from the `student:*` label)
-   - attention reasons from `list_attention_prs` — stale WIP, duplicate student WIP, missing routing labels, blocked/needs-rebase state, or merge-conflict comments
+   - advisor-action reasons from `list_prs_requiring_advisor_action` — stale WIP, duplicate student WIP, missing routing labels, blocked/needs-rebase state, or merge-conflict comments
    - Draft with no status — may be newly created or stalled
 
 3. **Return a structured summary** in this format:


### PR DESCRIPTION
We hit issues where the outer loop polling would identify students to review, but then not re-raise that during normal polling even if the PR still needed review. It should keep getting noted until the status changes again.

## Summary

- make `status:review` polling level-triggered so unresolved review PRs keep waking the advisor
- add `list_prs_requiring_advisor_action` to detect stale WIPs, duplicate student WIPs, missing routing labels, blocked/needs-rebase state, and merge-conflict comments
- wire advisor-action PRs into advisor triage/skip logic and guard students from running Claude when assigned multiple active WIP PRs
- document the new helper in the Senpai skills

## Validation

- `bash -n k8s/entrypoint-advisor.sh k8s/entrypoint-student.sh k8s/test-entrypoint-advisor.sh plugins/senpai/scripts/senpai-gh.sh`
- `git diff --check`
- `for scenario in mixed idle busy since pollfail; do SCENARIO="$scenario" bash k8s/test-entrypoint-advisor.sh >/tmp/senpai-advisor-test-$scenario.log; done`
- read-only live smoke test: `GH_REPO=morganmcg1/DrivAerML GH_LIST_LIMIT=50 ... list_prs_requiring_advisor_action yi` reported advisor-action PRs including duplicate WIP and merge-conflict reasons