### PR TITLE
[codex] Harden Hivemind startup auth

### DIFF
--- a/k8s/entrypoint-advisor.sh
+++ b/k8s/entrypoint-advisor.sh
@@ -114,9 +114,8 @@ echo "=== Claude config installed ==="
 ls "$HOME/.claude/skills/wandb-primary/SKILL.md" "$HOME/.claude/agents/researcher-agent.md"
 
 # --- Start Hivemind logging service (streams CC session logs to hivemind.wandb.tools) ---
-mkdir -p "$HOME/.claude/projects"
-uvx --from wandb-hivemind hivemind run &
-echo "=== Hivemind started (PID=$!) ==="
+source "$WORKDIR/k8s/start-hivemind.sh"
+start_hivemind
 
 # --- Load CC run command helper function ---
 source "$WORKDIR/k8s/run-senpai-claude.sh"

--- a/k8s/entrypoint-student.sh
+++ b/k8s/entrypoint-student.sh
@@ -62,9 +62,8 @@ echo "=== Claude config installed ==="
 ls "$HOME/.claude/skills/wandb-primary/SKILL.md" "$HOME/.claude/agents/researcher-agent.md"
 
 # --- Start Hivemind (streams CC session logs to hivemind.wandb.tools) ---
-mkdir -p "$HOME/.claude/projects"
-uvx --from wandb-hivemind hivemind run &
-echo "=== Hivemind started (PID=$!) ==="
+source "$WORKDIR/k8s/start-hivemind.sh"
+start_hivemind
 
 # --- Load CC run command helper function ---
 source "$WORKDIR/k8s/run-senpai-claude.sh"

--- a/k8s/start-hivemind.sh
+++ b/k8s/start-hivemind.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+
+start_hivemind() {
+    mkdir -p "$HOME/.claude/projects"
+    export GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+
+    (
+        while true; do
+            if ! uvx --from wandb-hivemind hivemind whoami 2>/dev/null | grep -q "Status:      Valid"; then
+                if [ -n "${GH_TOKEN:-}" ]; then
+                    echo "=== Hivemind login refresh ($(date)) ==="
+                    uvx --from wandb-hivemind hivemind login --method gh \
+                        || echo "=== Hivemind login failed; run will retry auth ==="
+                else
+                    echo "=== Hivemind login skipped: GH_TOKEN/GITHUB_TOKEN not set ==="
+                fi
+            fi
+
+            echo "=== Hivemind run starting ($(date)) ==="
+            if uvx --from wandb-hivemind hivemind run; then
+                code=0
+            else
+                code=$?
+            fi
+            echo "=== Hivemind exited code=$code at $(date), restarting in ${HIVEMIND_RESTART_SLEEP_S:-60}s ==="
+            sleep "${HIVEMIND_RESTART_SLEEP_S:-60}"
+        done
+    ) &
+
+    echo "=== Hivemind supervisor started (PID=$!) ==="
+}


### PR DESCRIPTION
## Summary

- add a tiny `start_hivemind` helper shared by advisor and student entrypoints
- expose `GH_TOKEN` from the existing `GITHUB_TOKEN` secret for `gh`-based Hivemind auth
- refresh Hivemind login when local credentials are missing and restart `hivemind run` if it exits

## Why

During the yi DrivAerML restart, all student pods hit `httpx.ReadTimeout` during Hivemind `/v1/auth/exchange`. Because the entrypoint launched `hivemind run` as a fire-and-forget background process, the daemon crashed once and stayed dead, while the student loop kept running.

This keeps the fix deliberately small: preflight auth when needed, then supervise the daemon with a simple retry loop.

## Validation

- `bash -n k8s/start-hivemind.sh k8s/entrypoint-student.sh k8s/entrypoint-advisor.sh`
- `shellcheck` unavailable locally
