### PR TITLE
[codex] Export Claude plugin root for runner sessions

### DIFF
--- a/k8s/run-senpai-claude.sh
+++ b/k8s/run-senpai-claude.sh
@@ -10,6 +10,8 @@
 run_senpai_claude() {
     local max_turns=$1 user_prompt=$2
     shift 2
+    export CLAUDE_PLUGIN_ROOT="$SENPAI_PLUGIN"
+
     # Pipe prompt via stdin instead of -p to keep prompt text out of the process
     # cmdline. Agents use `pkill -f "train.py"` to kill training runs, and -p
     # embeds the prompt (which mentions train.py) in the cmdline, causing the


### PR DESCRIPTION
## Summary

- Export `CLAUDE_PLUGIN_ROOT=$SENPAI_PLUGIN` before invoking Claude from `run_senpai_claude`.

## Why

Student/advisor instructions and senpai plugin skills source helpers with `${CLAUDE_PLUGIN_ROOT}/scripts/senpai-gh.sh`. In live pods, Claude Bash had `CLAUDE_PLUGIN_ROOT` empty, so those calls degraded to `/scripts/senpai-gh.sh` and failed unless a temporary symlink existed.

`--plugin-dir` tells Claude where the plugin is, but it does not guarantee the Bash tool environment has `CLAUDE_PLUGIN_ROOT`. Exporting it in the shared runner fixes both student and advisor sessions.

## Validation

- `git diff --check -- k8s/run-senpai-claude.sh`
- `bash -n k8s/run-senpai-claude.sh`