### PR TITLE
[codex] Guard student watchdog against orphaned runs

### DIFF
--- a/k8s/student-claude-watchdog.sh
+++ b/k8s/student-claude-watchdog.sh
@@ -14,6 +14,7 @@ STUDENT_CLAUDE_WATCHDOG_INTERVAL_S="${STUDENT_CLAUDE_WATCHDOG_INTERVAL_S:-60}"
 STUDENT_CLAUDE_MIN_RUNTIME_S="${STUDENT_CLAUDE_MIN_RUNTIME_S:-600}"
 STUDENT_CLAUDE_STALE_LOG_S="${STUDENT_CLAUDE_STALE_LOG_S:-1200}"
 STUDENT_CLAUDE_KILL_GRACE_S="${STUDENT_CLAUDE_KILL_GRACE_S:-15}"
+STUDENT_ASSIGNMENT_DRIFT_GRACE_S="${STUDENT_ASSIGNMENT_DRIFT_GRACE_S:-1800}"
 
 student_file_mtime_s() {
     stat -c %Y "$1" 2>/dev/null || stat -f %m "$1"
@@ -33,6 +34,17 @@ print(",".join(f"#{number}" for number in numbers))
 student_has_active_training() {
     ps -eo pid,ppid,comm,args |
         awk '$3 ~ /^(python[0-9.]*|torchrun)$/ && $0 ~ /train[.]py/ { found = 1 } END { exit !found }'
+}
+
+student_training_pids() {
+    ps -eo pid,ppid,comm,args |
+        awk '$3 ~ /^(python[0-9.]*|torchrun|pt_elastic)$/ && $0 ~ /train[.]py/ { print $1 }'
+}
+
+student_training_snapshot() {
+    ps -eo pid,ppid,etimes,pcpu,pmem,comm,args |
+        awk '$6 ~ /^(python[0-9.]*|torchrun|pt_elastic)$/ && $0 ~ /train[.]py/ { print }' |
+        head -20
 }
 
 student_log_watchdog_trigger() {
@@ -59,6 +71,55 @@ student_stop_claude_tree() {
     kill -0 "$pid" 2>/dev/null && student_kill_process_tree KILL "$pid"
 }
 
+student_stop_training_trees() {
+    local pids pid
+    pids=$(student_training_pids | sort -nr)
+    [ -n "$pids" ] || return 0
+
+    echo "=== Claude watchdog: stopping active train.py processes ==="
+    printf '%s\n' "$pids" | while IFS= read -r pid; do
+        [ -n "$pid" ] || continue
+        student_kill_process_tree TERM "$pid"
+    done
+
+    sleep "$STUDENT_CLAUDE_KILL_GRACE_S"
+
+    printf '%s\n' "$pids" | while IFS= read -r pid; do
+        [ -n "$pid" ] || continue
+        kill -0 "$pid" 2>/dev/null && student_kill_process_tree KILL "$pid"
+    done
+}
+
+student_comment_watchdog_stop() {
+    local reason="$1" start_numbers="$2" current_numbers="$3" snapshot body num
+    [ -n "$start_numbers" ] || return 0
+
+    snapshot=$(student_training_snapshot || true)
+    [ -n "$snapshot" ] || snapshot="(no active train.py process found at comment time)"
+    body=$(cat <<EOF
+STUDENT-WATCHDOG: stopping this student invocation on $(hostname).
+
+Reason: ${reason}
+Original assignment: ${start_numbers:-none}
+Current assignment: ${current_numbers:-none}
+
+Active training processes before termination:
+
+\`\`\`
+${snapshot}
+\`\`\`
+
+The watchdog only takes this action after the assignment drift remains stable for ${STUDENT_ASSIGNMENT_DRIFT_GRACE_S}s, so transient GitHub/API wobbles should not trigger it.
+EOF
+)
+
+    printf '%s\n' "$start_numbers" | tr ',' '\n' | sed 's/^#//' |
+    while IFS= read -r num; do
+        [ -n "$num" ] || continue
+        gh_retry gh pr comment "$num" --repo "$GH_REPO" --body "$body" || true
+    done
+}
+
 run_student_claude_with_watchdog() {
     local assigned_json="$1"
     shift
@@ -70,6 +131,7 @@ run_student_claude_with_watchdog() {
     local claude_pid=$!
     local start_ts now_ts runtime log_mtime log_age
     local current_json current_numbers poll_status reason rc active_training
+    local assignment_drift_numbers="" assignment_drift_first_ts=0 assignment_drift_age=0
     local watchdog_fired=0
     start_ts=$(date +%s)
 
@@ -79,7 +141,6 @@ run_student_claude_with_watchdog() {
 
         now_ts=$(date +%s)
         runtime=$((now_ts - start_ts))
-        [ "$runtime" -lt "$STUDENT_CLAUDE_MIN_RUNTIME_S" ] && continue
 
         reason=""
         active_training=0
@@ -92,15 +153,35 @@ run_student_claude_with_watchdog() {
                 current_numbers=$(printf '%s' "$current_json" | student_assignment_numbers)
                 if [ "$current_numbers" != "$start_numbers" ]; then
                     if [ "$active_training" -eq 0 ]; then
-                        reason="assignment changed from ${start_numbers:-none} to ${current_numbers:-none}"
+                        if [ "$runtime" -ge "$STUDENT_CLAUDE_MIN_RUNTIME_S" ]; then
+                            reason="assignment changed from ${start_numbers:-none} to ${current_numbers:-none}"
+                        else
+                            echo "=== Claude watchdog: assignment changed but no train.py is active; waiting until minimum runtime before stopping Claude ==="
+                        fi
                     else
-                        echo "=== Claude watchdog: assignment changed but train.py is active; waiting ==="
+                        if [ "$assignment_drift_numbers" != "$current_numbers" ]; then
+                            assignment_drift_numbers="$current_numbers"
+                            assignment_drift_first_ts="$now_ts"
+                        fi
+                        assignment_drift_age=$((now_ts - assignment_drift_first_ts))
+                        if [ "$assignment_drift_age" -ge "$STUDENT_ASSIGNMENT_DRIFT_GRACE_S" ]; then
+                            reason="assignment changed from ${start_numbers:-none} to ${current_numbers:-none} for ${assignment_drift_age}s while train.py is active"
+                        else
+                            echo "=== Claude watchdog: assignment changed but train.py is active; waiting ${assignment_drift_age}/${STUDENT_ASSIGNMENT_DRIFT_GRACE_S}s before intervention ==="
+                        fi
                     fi
+                else
+                    assignment_drift_numbers=""
+                    assignment_drift_first_ts=0
                 fi
             else
                 echo "=== Claude watchdog: assignment poll failed; leaving Claude running ==="
+                assignment_drift_numbers=""
+                assignment_drift_first_ts=0
             fi
         fi
+
+        [ "$runtime" -lt "$STUDENT_CLAUDE_MIN_RUNTIME_S" ] && [ -z "$reason" ] && continue
 
         if [ -z "$reason" ] && [ "$active_training" -eq 0 ]; then
             log_mtime=$(student_file_mtime_s "$LOGFILE" 2>/dev/null || printf '%s' "$now_ts")
@@ -112,6 +193,10 @@ run_student_claude_with_watchdog() {
 
         if [ -n "$reason" ]; then
             student_log_watchdog_trigger "=== Claude watchdog: stopping stale student invocation (${reason}) ==="
+            if [ "$active_training" -eq 1 ]; then
+                student_comment_watchdog_stop "$reason" "$start_numbers" "${current_numbers:-}" || true
+            fi
+            student_stop_training_trees
             student_stop_claude_tree "$claude_pid"
             watchdog_fired=1
             break

--- a/plugins/senpai/scripts/senpai-gh.sh
+++ b/plugins/senpai/scripts/senpai-gh.sh
@@ -134,12 +134,14 @@ send_pr_back_to_student_with_comment() {
     swap_gh_pr_label "$num" "status:review" "status:wip"
 }
 
-# Close a dead-end PR: comment explaining why, close, delete remote branch.
+# Close a dead-end PR: comment explaining why and close it. Keep the remote
+# branch so humans can reopen/recover assignments without reconstructing refs.
 #   close_pr_with_comment <number> <reason>
 close_pr_with_comment() {
     local num="$1" reason="$2"
+
     gh_retry gh pr comment "$num" --repo "$GH_REPO" --body "ADVISOR: Closing PR #${num} because ${reason}."
-    gh_retry gh pr close "$num" --repo "$GH_REPO" --delete-branch
+    gh_retry gh pr close "$num" --repo "$GH_REPO"
 }
 
 # Create an assignment PR through the one path that verifies student routing.

--- a/plugins/senpai/skills/senpai-gh/SKILL.md
+++ b/plugins/senpai/skills/senpai-gh/SKILL.md
@@ -44,7 +44,7 @@ GitHub's `gh pr edit --remove-label X --add-label Y` silently strips **all other
 | Function | What it does |
 |---|---|
 | `send_pr_back_to_student_with_comment <pr#> <comment>` | Send a PR back to the student with feedback. Comment on the PR, convert back to draft, swap `status:review` → `status:wip`. |
-| `close_pr_with_comment <pr#> <reason>` | Close a dead-end PR with a comment explaining why. Comment with reason, close the PR, delete the remote branch. |
+| `close_pr_with_comment <pr#> <reason>` | Close a dead-end PR with a comment explaining why. Keeps the remote branch so the PR can be reopened or recovered if needed. |
 | `create_assignment_pr_from_file <student> <head-branch> <title> <body-file> [base-branch]` | Create a draft assignment PR, then fail if the student already has a `status:wip` PR or if required base/head, draft, or routing labels are missing. |
 
 ### Student actions


### PR DESCRIPTION
## Summary

- Add a deterministic 30-minute stable assignment-drift grace window to the student Claude watchdog.
- When drift persists while `train.py` is active, comment on the original PR, terminate active training process trees, stop Claude, and let the outer loop immediately re-poll.
- Preserve remote branches when closing active `status:wip` student PRs so closed assignments can be reopened/recovered without reconstructing deleted refs.

## Why

The watchdog already detected assignment drift, but if `train.py` was active it waited forever. That allowed closed or reassigned PR runs to keep consuming GPUs indefinitely. This keeps transient GitHub/API wobble tolerance while giving the harness a deterministic escape hatch.

## Validation

```bash
bash -n k8s/student-claude-watchdog.sh
bash -n plugins/senpai/scripts/senpai-gh.sh
git diff --check -- k8s/student-claude-watchdog.sh plugins/senpai/scripts/senpai-gh.sh plugins/senpai/skills/senpai-gh/SKILL.md
```
