### PR TITLE
[codex] Guard experiment handoffs and merges - prevent false merges

### DIFF
--- a/k8s/entrypoint-advisor.sh
+++ b/k8s/entrypoint-advisor.sh
@@ -10,6 +10,7 @@ set -o pipefail
 WORKDIR="/workspace/senpai"
 GH_HISTORY_SCOPE="${GH_HISTORY_SCOPE:-branch}"
 TARGET_REPO_BRANCH="${TARGET_REPO_BRANCH:-}"
+export SENPAI_ROLE="advisor"
 export TARGET_WORKDIR="$WORKDIR/$PROBLEM_DIR"
 GIT_CREDENTIAL_FILE="$WORKDIR/.git-credentials"
 SENPAI_PLUGIN="$WORKDIR/plugins/senpai"
@@ -83,6 +84,7 @@ git config user.name "senpai-advisor"
 git config user.email "senpai-advisor@senpai"
 gh repo set-default "$GH_REPO"
 git config credential.helper "store --file=$GIT_CREDENTIAL_FILE"
+install_senpai_target_git_guard "$TARGET_WORKDIR"
 
 # --- Create or checkout advisor branch ---
 if [ "$GH_HISTORY_SCOPE" != "repo" ]; then

--- a/k8s/entrypoint-student.sh
+++ b/k8s/entrypoint-student.sh
@@ -10,6 +10,7 @@ set -o pipefail
 WORKDIR="/workspace/senpai"
 GH_HISTORY_SCOPE="${GH_HISTORY_SCOPE:-branch}"
 TARGET_REPO_BRANCH="${TARGET_REPO_BRANCH:-}"
+export SENPAI_ROLE="student"
 export TARGET_WORKDIR="$WORKDIR/$PROBLEM_DIR"
 GIT_CREDENTIAL_FILE="$WORKDIR/.git-credentials"
 SENPAI_PLUGIN="$WORKDIR/plugins/senpai"
@@ -49,6 +50,7 @@ git config user.name "senpai-$STUDENT_NAME"
 git config user.email "senpai-$STUDENT_NAME@senpai"
 gh repo set-default "$GH_REPO"
 git config credential.helper "store --file=$GIT_CREDENTIAL_FILE"
+install_senpai_target_git_guard "$TARGET_WORKDIR"
 if [ "$GH_HISTORY_SCOPE" != "repo" ]; then
     git remote set-branches origin "$ADVISOR_BRANCH"
     git config remote.origin.tagOpt --no-tags

--- a/k8s/student-claude-watchdog.sh
+++ b/k8s/student-claude-watchdog.sh
@@ -131,7 +131,7 @@ run_student_claude_with_watchdog() {
     local claude_pid=$!
     local start_ts now_ts runtime log_mtime log_age
     local current_json current_numbers poll_status reason rc active_training
-    local assignment_drift_numbers="" assignment_drift_first_ts=0 assignment_drift_age=0
+    local assignment_drift_active=0 assignment_drift_numbers="" assignment_drift_first_ts=0 assignment_drift_age=0
     local watchdog_fired=0
     start_ts=$(date +%s)
 
@@ -159,9 +159,10 @@ run_student_claude_with_watchdog() {
                             echo "=== Claude watchdog: assignment changed but no train.py is active; waiting until minimum runtime before stopping Claude ==="
                         fi
                     else
-                        if [ "$assignment_drift_numbers" != "$current_numbers" ]; then
+                        if [ "$assignment_drift_active" -eq 0 ] || [ "$assignment_drift_numbers" != "$current_numbers" ]; then
                             assignment_drift_numbers="$current_numbers"
                             assignment_drift_first_ts="$now_ts"
+                            assignment_drift_active=1
                         fi
                         assignment_drift_age=$((now_ts - assignment_drift_first_ts))
                         if [ "$assignment_drift_age" -ge "$STUDENT_ASSIGNMENT_DRIFT_GRACE_S" ]; then
@@ -171,11 +172,13 @@ run_student_claude_with_watchdog() {
                         fi
                     fi
                 else
+                    assignment_drift_active=0
                     assignment_drift_numbers=""
                     assignment_drift_first_ts=0
                 fi
             else
                 echo "=== Claude watchdog: assignment poll failed; leaving Claude running ==="
+                assignment_drift_active=0
                 assignment_drift_numbers=""
                 assignment_drift_first_ts=0
             fi

--- a/plugins/senpai/scripts/senpai-gh.sh
+++ b/plugins/senpai/scripts/senpai-gh.sh
@@ -20,6 +20,8 @@
 # This library wraps that pattern so nobody has to remember (or get
 # bitten by) the footgun.
 
+SENPAI_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # ---------------------------------------------------------------------------
 # Retry helper: up to 6 attempts with 15s backoff, then fail loudly.
 # ---------------------------------------------------------------------------
@@ -85,6 +87,31 @@ EOF
     git config --global credential.helper "store --file=$credential_file"
 }
 
+install_senpai_target_git_guard() {
+    local target_workdir="$1"
+    if [ -z "$target_workdir" ] || [ ! -d "$target_workdir/.git" ]; then
+        echo "install_senpai_target_git_guard: target repo not found: ${target_workdir:-<missing>}" >&2
+        return 2
+    fi
+
+    mkdir -p "$target_workdir/.git/hooks"
+    cat > "$target_workdir/.git/hooks/pre-push" <<'EOF'
+#!/bin/sh
+while read -r local_ref _ remote_ref _; do
+    [ "$remote_ref" = "refs/heads/$ADVISOR_BRANCH" ] || continue
+    [ "$SENPAI_ROLE" != "student" ] || {
+        echo "SENPAI-GIT-GUARD: students must not push $ADVISOR_BRANCH" >&2
+        exit 2
+    }
+    [ "$SENPAI_ROLE" != "advisor" ] || [ "$local_ref" = "refs/heads/$ADVISOR_BRANCH" ] || {
+        echo "SENPAI-GIT-GUARD: advisor must push $ADVISOR_BRANCH from local $ADVISOR_BRANCH, not ${local_ref:-<unknown>}" >&2
+        exit 2
+    }
+done
+EOF
+    chmod +x "$target_workdir/.git/hooks/pre-push"
+}
+
 require_target_repo() {
     local origin
     origin=$(git config --get remote.origin.url || true)
@@ -132,6 +159,36 @@ send_pr_back_to_student_with_comment() {
     gh_retry gh pr comment "$num" --repo "$GH_REPO" --body "$body"
     gh_retry gh pr ready "$num" --repo "$GH_REPO" --undo
     swap_gh_pr_label "$num" "status:review" "status:wip"
+}
+
+# Require a terminal structured result comment before a student can hand a PR
+# to the advisor. This makes "ready for review" a durable workflow state rather
+# than a bare label flip.
+#   senpai_require_terminal_result <number>
+senpai_require_terminal_result() {
+    local num="$1" comments
+    comments=$(pr_all_comments "$num") || return
+    printf '%s' "$comments" | python3 "$SENPAI_SCRIPT_DIR/senpai-pr-guard.py" require-terminal-result "$num"
+}
+
+# Refuse unsafe merges before `senpai:merge-winner` can squash a PR. This guard
+# checks GitHub workflow state plus the latest structured student result marker.
+# It intentionally does not query or mutate W&B; runs already record their git
+# commit SHA, and the PR result comment remains the workflow contract.
+#   senpai_merge_winner_preflight <number> [problem-dir]
+senpai_merge_winner_preflight() {
+    local num="$1" pr comments
+    if [ -z "$num" ]; then
+        echo "senpai_merge_winner_preflight: usage: <pr-number> [problem-dir]" >&2
+        return 2
+    fi
+
+    pr=$(gh_retry gh pr view "$num" --repo "$GH_REPO" \
+        --json number,title,state,isDraft,labels,baseRefName,headRefName,mergeStateStatus,mergeable,files) || return
+    comments=$(pr_all_comments "$num") || return
+
+    printf '%s\0%s' "$pr" "$comments" |
+        python3 "$SENPAI_SCRIPT_DIR/senpai-pr-guard.py" merge-preflight "$num" "${ADVISOR_BRANCH:-}"
 }
 
 # Close a dead-end PR: comment explaining why and close it. Keep the remote
@@ -227,6 +284,7 @@ PY
 #   mark_ready_for_review <number>
 mark_ready_for_review() {
     local num="$1"
+    senpai_require_terminal_result "$num" || return
     gh_retry gh pr ready "$num" --repo "$GH_REPO"
     swap_gh_pr_label "$num" "status:wip" "status:review"  # swap_gh_pr_label uses gh_retry internally
 }

--- a/plugins/senpai/scripts/senpai-pr-guard.py
+++ b/plugins/senpai/scripts/senpai-pr-guard.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+
+import json
+import re
+import sys
+
+
+HOLD_RE = re.compile(r"SENPAI-HOLD|hold the merge|do not merge|don't merge|hold .*until", re.I)
+
+
+def stamp(comment):
+    return comment.get("createdAt") or comment.get("submittedAt") or comment.get("updatedAt") or ""
+
+
+def result_markers(comments, errors):
+    markers = []
+    for comment in comments:
+        for line in (comment.get("body") or "").splitlines():
+            if "SENPAI-RESULT:" not in line:
+                continue
+            try:
+                markers.append((stamp(comment), json.loads(line.split("SENPAI-RESULT:", 1)[1].strip())))
+            except json.JSONDecodeError as exc:
+                errors.append(f"Invalid SENPAI-RESULT JSON at {stamp(comment) or 'unknown time'}: {exc}")
+    return sorted(markers)
+
+
+def terminal_result_error(markers):
+    if not markers:
+        return "No terminal SENPAI-RESULT marker found. The student must post final structured results before merge."
+    _, result = markers[-1]
+    if not result.get("terminal"):
+        return "Latest SENPAI-RESULT is not terminal=true."
+    if result.get("pending_arms") or result.get("pending_runs"):
+        return "Latest SENPAI-RESULT still reports pending arms/runs."
+    return None
+
+
+def refuse(num, errors):
+    print(f"SENPAI-MERGE-REFUSED: PR #{num} is not safe to merge.", file=sys.stderr)
+    for error in errors:
+        print(f"- {error}", file=sys.stderr)
+    print("Next steps:", file=sys.stderr)
+    print("- If work is still running or held, leave the PR in WIP/hold and wait.", file=sys.stderr)
+    print("- If work is done, ask the student for a terminal SENPAI-RESULT marker and resubmit.", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def require_terminal_result(num, comments):
+    errors = []
+    markers = result_markers(comments, errors)
+    error = terminal_result_error(markers)
+    if error:
+        errors.append(error)
+    if errors:
+        print(f"SENPAI-RESULT-REQUIRED: PR #{num} cannot be marked ready.", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        print('Add one line like: SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"]}', file=sys.stderr)
+        raise SystemExit(1)
+    print(f"SENPAI-RESULT: terminal marker found on PR #{num} at {markers[-1][0] or 'unknown time'}")
+
+
+def merge_preflight(num, advisor_branch, pr, comments):
+    labels = {label["name"] for label in pr["labels"]}
+    errors = []
+
+    if pr["state"] != "OPEN":
+        errors.append(f"PR state is {pr['state']}, expected OPEN.")
+    if pr["isDraft"]:
+        errors.append("PR is still draft.")
+    if "status:review" not in labels:
+        errors.append("PR is missing status:review.")
+    if "status:wip" in labels:
+        errors.append("PR still has status:wip; active assignments must not be merged.")
+    if advisor_branch and advisor_branch not in labels:
+        errors.append(f"PR is missing advisor branch label {advisor_branch}.")
+    if not any(label.startswith("student:") for label in labels):
+        errors.append("PR is missing a student:<name> label.")
+    for label in ("status:hold", "status:blocked", "status:needs-rebase"):
+        if label in labels:
+            errors.append(f"PR has {label}.")
+    if pr["mergeStateStatus"] == "DIRTY" or pr["mergeable"] == "CONFLICTING":
+        errors.append("GitHub reports merge conflicts; send the PR back for rebase.")
+
+    markers = result_markers(comments, errors)
+    error = terminal_result_error(markers)
+    if error:
+        errors.append(error)
+
+    holds = sorted(
+        (stamp(comment), (comment.get("body") or "").splitlines()[0][:160])
+        for comment in comments
+        if HOLD_RE.search(comment.get("body") or "")
+    )
+    if holds and (not markers or holds[-1][0] > markers[-1][0]):
+        errors.append(f"Latest hold comment is newer than the terminal result ({holds[-1][0] or 'unknown time'}: {holds[-1][1]!r}).")
+
+    if errors:
+        refuse(num, errors)
+    print(f"SENPAI-MERGE-PREFLIGHT: PR #{num} passed merge preflight.")
+
+
+def main():
+    mode = sys.argv[1]
+    if mode == "require-terminal-result":
+        require_terminal_result(sys.argv[2], json.load(sys.stdin))
+        return
+
+    raw_pr, raw_comments = sys.stdin.buffer.read().split(b"\0", 1)
+    merge_preflight(sys.argv[2], sys.argv[3], json.loads(raw_pr), json.loads(raw_comments))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/senpai/skills/merge-winner/SKILL.md
+++ b/plugins/senpai/skills/merge-winner/SKILL.md
@@ -29,10 +29,22 @@ Note: `$ADVISOR_BRANCH` is available as an environment variable.
 
 ## Steps
 
-1. **Squash-merge the PR:**
+1. **Run the merge preflight. Do not skip this.**
+
+The preflight refuses unsafe merges and prints a specific error explaining why:
+missing terminal results, active hold comments, WIP/draft state, bad labels, or
+merge conflicts. If it refuses, stop. Do not bypass it with raw `gh pr merge`;
+read the error and follow up on the PR.
 
 ```bash
-gh pr merge $0 --squash
+source "${CLAUDE_PLUGIN_ROOT}/scripts/senpai-gh.sh"
+senpai_merge_winner_preflight $0 "$1"
+```
+
+2. **Squash-merge the PR:**
+
+```bash
+gh pr merge $0 --squash --repo "$GH_REPO"
 ```
 
 If this fails due to merge conflicts, send the PR back for rebase instead:
@@ -44,13 +56,13 @@ send_pr_back_to_student_with_comment $0 "ADVISOR: Rebasing needed — the adviso
 
 Then stop — don't proceed with baseline update.
 
-2. **Pull the updated branch:**
+3. **Pull the updated branch:**
 
 ```bash
 git checkout "$ADVISOR_BRANCH" && git pull origin "$ADVISOR_BRANCH"
 ```
 
-3. **Update BASELINE.md** by appending the new baseline entry. Read the winning metrics from the PR comments and the W&B run metrics. The entry should include:
+4. **Update BASELINE.md** by appending the new baseline entry. Read the winning metrics from the PR comments and the W&B run metrics. The entry should include:
 
 ```markdown
 ## <YYYY-MM-DD HH:MM> — PR #<number>: <title>
@@ -61,7 +73,7 @@ git checkout "$ADVISOR_BRANCH" && git pull origin "$ADVISOR_BRANCH"
 - **Reproduce:** `cd "$1" && python train.py <full command>`
 ```
 
-4. **Commit and push the baseline update:**
+5. **Commit and push the baseline update:**
 
 ```bash
 git add BASELINE.md

--- a/plugins/senpai/skills/senpai-gh/SKILL.md
+++ b/plugins/senpai/skills/senpai-gh/SKILL.md
@@ -44,6 +44,7 @@ GitHub's `gh pr edit --remove-label X --add-label Y` silently strips **all other
 | Function | What it does |
 |---|---|
 | `send_pr_back_to_student_with_comment <pr#> <comment>` | Send a PR back to the student with feedback. Comment on the PR, convert back to draft, swap `status:review` → `status:wip`. |
+| `senpai_merge_winner_preflight <pr#> [problem-dir]` | Refuse unsafe winner merges with a specific error if the PR lacks terminal `SENPAI-RESULT`, has a newer hold comment, is draft/WIP, has bad labels, or has merge conflicts. |
 | `close_pr_with_comment <pr#> <reason>` | Close a dead-end PR with a comment explaining why. Keeps the remote branch so the PR can be reopened or recovered if needed. |
 | `create_assignment_pr_from_file <student> <head-branch> <title> <body-file> [base-branch]` | Create a draft assignment PR, then fail if the student already has a `status:wip` PR or if required base/head, draft, or routing labels are missing. |
 
@@ -51,7 +52,7 @@ GitHub's `gh pr edit --remove-label X --add-label Y` silently strips **all other
 
 | Function | What it does |
 |---|---|
-| `mark_ready_for_review <pr#>` | Mark a PR as ready for advisor review. Mark the PR as ready + swap `status:wip` → `status:review`. |
+| `mark_ready_for_review <pr#>` | Require a terminal `SENPAI-RESULT` marker, then mark the PR as ready + swap `status:wip` → `status:review`. |
 
 ### Queries (both roles)
 

--- a/plugins/senpai/skills/submit-experiment-results/SKILL.md
+++ b/plugins/senpai/skills/submit-experiment-results/SKILL.md
@@ -26,7 +26,15 @@ You've run the experiment, posted a results comment on the experiment PR — now
 
 ## Before you call this
 
-Make sure you've already posted a results comment on the experiment PR with metrics, W&B run ID, analysis, and suggested follow-ups
+Make sure you've already posted a results comment on the experiment PR with metrics, W&B run ID, analysis, and suggested follow-ups.
+
+The comment must include a valid one-line terminal result marker before the Results section:
+
+```markdown
+SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"<metric>","value":<number>},"test_metric":{"name":"<metric>","value":<number>}}
+```
+
+Use `terminal=true` only when every advisor-required arm/run is finished or intentionally aborted. If any arm or W&B run can still change the conclusion, leave the PR as `status:wip`.
 
 ## Steps
 
@@ -50,5 +58,7 @@ git push origin "$(git branch --show-current)"
 source "${CLAUDE_PLUGIN_ROOT}/scripts/senpai-gh.sh"
 mark_ready_for_review $0
 ```
+
+`mark_ready_for_review` refuses the handoff if the terminal `SENPAI-RESULT` marker is missing, invalid JSON, or still reports pending arms/runs. Read the error, fix the PR comment, and retry.
 
 That's it. The advisor will pick it up in their next review cycle.

--- a/system_instructions/CLAUDE-ADVISOR.md
+++ b/system_instructions/CLAUDE-ADVISOR.md
@@ -41,6 +41,9 @@ source "${CLAUDE_PLUGIN_ROOT}/scripts/senpai-gh.sh"
 # Send a PR back to the student with feedback
 send_pr_back_to_student_with_comment <pr#> "ADVISOR: <feedback>"
 
+# Check whether a winner is safe to merge before invoking merge-winner
+senpai_merge_winner_preflight <pr#> "$PROBLEM_DIR"
+
 # Close a dead-end PR
 close_pr_with_comment <pr#> "<reason>"
 
@@ -79,7 +82,9 @@ You run inside a pod entrypoint harness: it invokes Claude Code, passes the late
    send_pr_back_to_student_with_comment <number> "ADVISOR: <comment to student>"
    ```
 
-   **b. Merge winners sequentially, best first.** A PR is a winner if its best primary validation metric is lower than the current baseline. Merge aggressively — even small improvements compound over rounds. Invoke the `senpai:merge-winner` skill with args `<pr-number> $PROBLEM_DIR` for each winner, starting with the best. The skill handles the squash-merge, baseline update, and branch pull.
+   **b. Merge winners sequentially, best first.** A PR is a winner if its best primary validation metric is lower than the current baseline and the student has posted a terminal `SENPAI-RESULT` marker with `terminal=true` and `pending_arms=false`. Merge aggressively once the result is terminal — even small improvements compound over rounds. Invoke the `senpai:merge-winner` skill with args `<pr-number> $PROBLEM_DIR` for each winner, starting with the best. The skill runs `senpai_merge_winner_preflight`, then handles the squash-merge, baseline update, and branch pull.
+
+   If `merge-winner` refuses, do not bypass it with raw `gh pr merge`. Read the refusal message. It means the PR is still draft/WIP, lacks terminal structured results, has a newer hold comment, has bad labels, or has merge conflicts. Follow up on the PR, fix the state, and rerun the skill only after the reason is resolved.
 
    **c. Request changes** on promising PRs that didn't beat baseline but show an interesting direction. Leave specific feedback on what variation to try next, then send back:
    ```bash
@@ -198,6 +203,14 @@ Use `python train.py --help` from the active target to copy exact CLI flag spell
 
 The experiment results will be added by the student in a new PR comment. Ensure you check the PR's comments for these results and any other feedback or questions from the student.
 
+Terminal results must include a valid single-line marker:
+
+```markdown
+SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"<metric>","value":<number>},"test_metric":{"name":"<metric>","value":<number>}}
+```
+
+Do not merge from partial prose updates, even if one arm is merge-eligible. If you tell a student to hold a merge, wait for another arm, or confirm after an EP gate, treat that as a merge blocker until a later terminal `SENPAI-RESULT` supersedes it.
+
 For paper-facing benchmark comparisons, insist on the matching test metric and,
 when possible, test evaluated from the best validation checkpoint rather than
 the terminal epoch.
@@ -217,7 +230,7 @@ Use the researcher-agent to explore new ideas and research directions and other 
 
 ## Decision criteria
 
-- **Merge** if the primary validation metric is lower than the current baseline — even by a small amount. Small improvements compound across rounds. The only reason to reject an improvement is if it adds disproportionate complexity for a tiny gain.
+- **Merge** if the primary validation metric is lower than the current baseline and the PR has terminal structured results — even by a small amount. Small improvements compound across rounds. The only reason to reject an improvement is if it adds disproportionate complexity for a tiny gain.
 - **Request changes** if the direction is promising but didn't beat baseline — the student should try a variation (different weight, different schedule, etc.).
 - **Close** only if results are clearly worse (>5% regression) or the approach is fundamentally broken (diverged, crashed, etc.).
 - When in doubt between merge and close, **merge**. We want to compound improvements.

--- a/system_instructions/CLAUDE-STUDENT.md
+++ b/system_instructions/CLAUDE-STUDENT.md
@@ -98,10 +98,12 @@ swap_gh_pr_label <pr#> "status:wip" "status:review"
    - Start your comment with:
    ```markdown
    STUDENT <your-name>:
+   SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"<metric>","value":<number>},"test_metric":{"name":"<metric>","value":<number>}}
 
    ## Results
 
    ```
+   - The `SENPAI-RESULT` line must be valid single-line JSON. Set `terminal=true` only when every advisor-required arm/run is finished or intentionally aborted and no pending result could change the conclusion. Set `pending_arms=true` for partial updates and do not submit for review yet.
    - All key metrics required by `$PROBLEM_DIR/program.md` and the PR baseline.
    - When a dataset has a literature-facing test target or reference, include
      that reference beside your reported test metric.


### PR DESCRIPTION
## Summary

- require terminal `SENPAI-RESULT` markers before students can mark experiment PRs ready for review
- add `senpai_merge_winner_preflight` so `merge-winner` refuses draft/WIP PRs, missing terminal results, active hold comments, bad labels, and merge conflicts with actionable errors
- fix the student watchdog assignment-drift timer sentinel so `none` does not look decades stale, and install target-repo pre-push guards for advisor/student roles

## Validation

- `bash -n plugins/senpai/scripts/senpai-gh.sh k8s/student-claude-watchdog.sh k8s/entrypoint-advisor.sh k8s/entrypoint-student.sh`
- `git diff --check origin/main..HEAD -- <changed files>`
- local fake-data checks for #571-style held merge refusal, terminal-result preflight pass, and advisor assignment-branch push guard refusal

## Notes

This intentionally does not add git metadata to W&B runs. Existing runs already log the commit SHA at launch; this PR keeps the lifecycle contract in GitHub comments and helper preflights.