### PR TITLE
Harden advisor routing and GitHub calls

### DIFF
--- a/k8s/entrypoint-advisor.sh
+++ b/k8s/entrypoint-advisor.sh
@@ -155,6 +155,7 @@ export IS_SANDBOX=1
 
 SLEEP_TIME_S=300
 MAX_TURNS=100000
+export SENPAI_CLAUDE_TIMEOUT_SECONDS="${SENPAI_CLAUDE_TIMEOUT_SECONDS:-3600}"
 
 ITERATION=0
 while true; do
@@ -181,7 +182,7 @@ while true; do
     POLL_OK=1
     REVIEW_JSON=$(poll_or_empty "review-ready PR poll" list_ready_for_review_prs "$ADVISOR_BRANCH") || POLL_OK=0
     REVIEW_COUNT=$(printf '%s' "$REVIEW_JSON" | json_len)
-    ADVISOR_ACTION_JSON=$(poll_or_empty "advisor-action PR poll" list_prs_requiring_advisor_action "$ADVISOR_BRANCH") || POLL_OK=0
+    ADVISOR_ACTION_JSON=$(poll_or_empty "advisor-action PR poll" list_prs_requiring_advisor_action "$ADVISOR_BRANCH" "${SENPAI_STALE_WIP_SECONDS:-7200}" "$STUDENT_NAMES") || POLL_OK=0
     ADVISOR_ACTION_COUNT=$(printf '%s' "$ADVISOR_ACTION_JSON" | json_len)
     ISSUE_JSON=$(poll_or_empty "GitHub issue poll" check_gh_issues "$ADVISOR_BRANCH" "$SINCE") || POLL_OK=0
     ISSUE_COUNT=$(printf '%s' "$ISSUE_JSON" | json_len)

--- a/k8s/entrypoint-student.sh
+++ b/k8s/entrypoint-student.sh
@@ -154,7 +154,7 @@ while true; do
         while IFS= read -r num; do
             [ -z "$num" ] && continue
             if ! pr_issue_comments "$num" | grep -q "$DUPLICATE_MARKER"; then
-                gh_retry gh pr comment "$num" --repo "$GH_REPO" --body "$DUPLICATE_BODY"
+                comment_on_pr "$num" "$DUPLICATE_BODY"
             fi
         done
         sleep "$SLEEP_TIME_S"

--- a/k8s/run-senpai-claude.sh
+++ b/k8s/run-senpai-claude.sh
@@ -19,7 +19,8 @@ run_senpai_claude() {
         --plugin-dir "$SENPAI_PLUGIN"
         --dangerously-skip-permissions)
     if [ -n "${SENPAI_CLAUDE_TIMEOUT_SECONDS:-}" ] && command -v timeout >/dev/null 2>&1; then
-        claude_cmd=(timeout "$SENPAI_CLAUDE_TIMEOUT_SECONDS" "${claude_cmd[@]}")
+        local kill_after="${SENPAI_CLAUDE_TIMEOUT_KILL_AFTER_SECONDS:-30}"
+        claude_cmd=(timeout -k "$kill_after" "$SENPAI_CLAUDE_TIMEOUT_SECONDS" "${claude_cmd[@]}")
     fi
 
     # Pipe prompt via stdin instead of -p to keep prompt text out of the process

--- a/k8s/run-senpai-claude.sh
+++ b/k8s/run-senpai-claude.sh
@@ -11,17 +11,20 @@ run_senpai_claude() {
     local max_turns=$1 user_prompt=$2
     shift 2
     export CLAUDE_PLUGIN_ROOT="$SENPAI_PLUGIN"
+    local claude_cmd=(claude "$@" -p -
+        --model "claude-opus-4-7[1m]"
+        --effort "max"
+        --max-turns "$max_turns"
+        --output-format stream-json --verbose
+        --plugin-dir "$SENPAI_PLUGIN"
+        --dangerously-skip-permissions)
+    if [ -n "${SENPAI_CLAUDE_TIMEOUT_SECONDS:-}" ] && command -v timeout >/dev/null 2>&1; then
+        claude_cmd=(timeout "$SENPAI_CLAUDE_TIMEOUT_SECONDS" "${claude_cmd[@]}")
+    fi
 
     # Pipe prompt via stdin instead of -p to keep prompt text out of the process
     # cmdline. Agents use `pkill -f "train.py"` to kill training runs, and -p
     # embeds the prompt (which mentions train.py) in the cmdline, causing the
     # agent to accidentally kill its own Claude Code process.
-    printf '%s' "$user_prompt" | claude "$@" -p - \
-        --model "claude-opus-4-7[1m]" \
-        --effort "max" \
-        --max-turns "$max_turns" \
-        --output-format stream-json --verbose \
-        --plugin-dir "$SENPAI_PLUGIN" \
-        --dangerously-skip-permissions \
-        >> "$LOGFILE" 2>&1
+    printf '%s' "$user_prompt" | "${claude_cmd[@]}" >> "$LOGFILE" 2>&1
 }

--- a/k8s/student-claude-watchdog.sh
+++ b/k8s/student-claude-watchdog.sh
@@ -116,7 +116,7 @@ EOF
     printf '%s\n' "$start_numbers" | tr ',' '\n' | sed 's/^#//' |
     while IFS= read -r num; do
         [ -n "$num" ] || continue
-        gh_retry gh pr comment "$num" --repo "$GH_REPO" --body "$body" || true
+        comment_on_pr "$num" "$body" || true
     done
 }
 

--- a/plugins/senpai/scripts/senpai-gh.sh
+++ b/plugins/senpai/scripts/senpai-gh.sh
@@ -25,14 +25,43 @@ SENPAI_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # ---------------------------------------------------------------------------
 # Retry helper: up to 6 attempts with 15s backoff, then fail loudly.
 # ---------------------------------------------------------------------------
+senpai_run_with_timeout() {
+    local timeout_seconds="${SENPAI_GH_TIMEOUT_SECONDS:-120}"
+    if command -v timeout >/dev/null 2>&1; then
+        timeout "$timeout_seconds" "$@"
+    else
+        "$@"
+    fi
+}
+
 gh_retry() {
-    local attempt
+    local attempt status
     for attempt in 1 2 3 4 5 6; do
-        "$@" && return 0
-        echo "gh_retry: attempt $attempt failed, retrying in 15s..." >&2
+        senpai_run_with_timeout "$@" && return 0
+        status=$?
+        if [ "$attempt" -eq 6 ]; then
+            echo "gh_retry: attempt $attempt failed with status $status; giving up" >&2
+            return "$status"
+        fi
+        echo "gh_retry: attempt $attempt failed with status $status, retrying in 15s..." >&2
         sleep 15
     done
     return 1
+}
+
+comment_on_pr() {
+    local num="$1" body="$2" tmp status
+    if [ -z "$num" ]; then
+        echo "comment_on_pr: usage: <pr-number> <body>" >&2
+        return 2
+    fi
+
+    tmp=$(mktemp "${TMPDIR:-/tmp}/senpai-gh-comment.XXXXXX") || return
+    printf '%s' "$body" > "$tmp"
+    gh_retry gh pr comment "$num" --repo "$GH_REPO" --body-file "$tmp"
+    status=$?
+    rm -f "$tmp"
+    return "$status"
 }
 
 poll_or_empty() {
@@ -135,7 +164,7 @@ swap_gh_pr_label() {
     # DELETE the old label — retry transient failures, tolerate 404 (already gone).
     local attempt err
     for attempt in 1 2 3 4 5 6; do
-        err=$(gh api "repos/${GH_REPO}/issues/${num}/labels/${remove}" \
+        err=$(senpai_run_with_timeout gh api "repos/${GH_REPO}/issues/${num}/labels/${remove}" \
             --method DELETE --silent 2>&1) && break
         echo "$err" | grep -q "404" && break
         echo "swap_gh_pr_label: DELETE attempt $attempt failed, retrying in 15s..." >&2
@@ -156,7 +185,7 @@ swap_gh_pr_label() {
 #   send_pr_back_to_student_with_comment <number> <comment_body>
 send_pr_back_to_student_with_comment() {
     local num="$1" body="$2"
-    gh_retry gh pr comment "$num" --repo "$GH_REPO" --body "$body"
+    comment_on_pr "$num" "$body"
     gh_retry gh pr ready "$num" --repo "$GH_REPO" --undo
     swap_gh_pr_label "$num" "status:review" "status:wip"
 }
@@ -197,7 +226,7 @@ senpai_merge_winner_preflight() {
 close_pr_with_comment() {
     local num="$1" reason="$2"
 
-    gh_retry gh pr comment "$num" --repo "$GH_REPO" --body "ADVISOR: Closing PR #${num} because ${reason}."
+    comment_on_pr "$num" "ADVISOR: Closing PR #${num} because ${reason}."
     gh_retry gh pr close "$num" --repo "$GH_REPO"
 }
 
@@ -328,7 +357,10 @@ items = json.loads(sys.stdin.read())
 parts = []
 for item in items:
     reasons = ",".join(item.get("reasons", []))
-    parts.append("#{}[{}]".format(item["number"], reasons))
+    detail = ""
+    if item.get("unknownStudentLabels"):
+        detail = " unknown={}".format("|".join(item["unknownStudentLabels"]))
+    parts.append("#{}[{}{}]".format(item["number"], reasons, detail))
 print(",".join(parts))
 '
 }
@@ -810,9 +842,9 @@ print(json.dumps([
 # List open PRs requiring advisor action, even when they have not been updated
 # since the last heartbeat.
 # Returns a JSON array with a `reasons` list on each PR.
-#   list_prs_requiring_advisor_action <branch> [stale_wip_seconds]
+#   list_prs_requiring_advisor_action <branch> [stale_wip_seconds] [student_names_csv]
 list_prs_requiring_advisor_action() {
-    local branch="$1" stale_seconds="${2:-${SENPAI_STALE_WIP_SECONDS:-7200}}"
+    local branch="$1" stale_seconds="${2:-${SENPAI_STALE_WIP_SECONDS:-7200}}" students_csv="${3:-${STUDENT_NAMES:-}}"
     local prs comments_by_pr num comments row actions
     prs=$(rest_base_pull_details "$branch")
     comments_by_pr=""
@@ -838,6 +870,7 @@ from datetime import datetime, timezone
 
 branch = sys.argv[1]
 stale_seconds = int(sys.argv[2])
+known_students = {s.strip() for s in sys.argv[3].split(",") if s.strip()}
 now = datetime.now(timezone.utc)
 raw_prs, raw_comments = sys.stdin.buffer.read().split(b"\0", 1)
 prs = json.loads(raw_prs)
@@ -858,9 +891,11 @@ metadata = {}
 for pr in prs:
     labels = label_names(pr)
     students = sorted(label.removeprefix("student:") for label in labels if label.startswith("student:"))
-    metadata[pr["number"]] = (labels, students)
+    unknown_students = [student for student in students if known_students and student not in known_students]
+    routed_students = [student for student in students if not known_students or student in known_students]
+    metadata[pr["number"]] = (labels, students, routed_students, unknown_students)
     if "status:wip" in labels:
-        for student in students:
+        for student in routed_students:
             student_wips[student].append(pr["number"])
 
 duplicate_wips = {
@@ -873,12 +908,16 @@ duplicate_wips = {
 conflict_re = re.compile(r"merge conflict|rebase conflict|cannot automatically merge|can.t automatically merge|conflicts? with", re.I)
 prs_requiring_advisor_action = []
 for pr in prs:
-    labels, students = metadata[pr["number"]]
+    labels, students, routed_students, unknown_students = metadata[pr["number"]]
     reasons = []
     if branch not in labels:
         reasons.append("missing_branch_label")
     if not students:
         reasons.append("missing_student_label")
+    if unknown_students:
+        reasons.append("unknown_student_label")
+    if students and not routed_students:
+        reasons.append("unroutable_student_label")
     if pr["number"] in duplicate_wips:
         reasons.append("duplicate_student_wip")
     if "status:wip" in labels:
@@ -899,10 +938,12 @@ for pr in prs:
     if reasons:
         item = dict(pr)
         item["reasons"] = sorted(set(reasons), key=reasons.index)
+        if unknown_students:
+            item["unknownStudentLabels"] = [f"student:{student}" for student in unknown_students]
         prs_requiring_advisor_action.append(item)
 
 print(json.dumps(prs_requiring_advisor_action))
-' "$branch" "$stale_seconds")
+' "$branch" "$stale_seconds" "$students_csv")
     suppress_live_stale_wips "$actions"
 }
 

--- a/plugins/senpai/scripts/senpai-gh.sh
+++ b/plugins/senpai/scripts/senpai-gh.sh
@@ -28,7 +28,8 @@ SENPAI_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 senpai_run_with_timeout() {
     local timeout_seconds="${SENPAI_GH_TIMEOUT_SECONDS:-120}"
     if command -v timeout >/dev/null 2>&1; then
-        timeout "$timeout_seconds" "$@"
+        local kill_after="${SENPAI_GH_TIMEOUT_KILL_AFTER_SECONDS:-30}"
+        timeout -k "$kill_after" "$timeout_seconds" "$@"
     else
         "$@"
     fi

--- a/plugins/senpai/skills/senpai-gh/SKILL.md
+++ b/plugins/senpai/skills/senpai-gh/SKILL.md
@@ -43,6 +43,7 @@ GitHub's `gh pr edit --remove-label X --add-label Y` silently strips **all other
 
 | Function | What it does |
 |---|---|
+| `comment_on_pr <pr#> <comment>` | Leave a PR comment via a temporary body file, avoiding giant shell command lines. |
 | `send_pr_back_to_student_with_comment <pr#> <comment>` | Send a PR back to the student with feedback. Comment on the PR, convert back to draft, swap `status:review` → `status:wip`. |
 | `senpai_merge_winner_preflight <pr#> [problem-dir]` | Refuse unsafe winner merges with a specific error if the PR lacks terminal `SENPAI-RESULT`, has a newer hold comment, is draft/WIP, has bad labels, or has merge conflicts. |
 | `close_pr_with_comment <pr#> <reason>` | Close a dead-end PR with a comment explaining why. Keeps the remote branch so the PR can be reopened or recovered if needed. |
@@ -65,7 +66,7 @@ The default repo for `gh` is set via the injected `GH_REPO` env var, so no `--re
 | `issue_comments <issue#>` | Read all issue comments through REST pagination. Returns JSON array. |
 | `issue_with_comments <issue#>` | Read one issue and all comments through REST pagination. Returns JSON object. |
 | `list_ready_for_review_prs <branch>` | List PRs with `status:review` on a branch. Returns JSON array. |
-| `list_prs_requiring_advisor_action <branch>` | List open branch PRs requiring advisor action, with `reasons` such as stale WIP, duplicate student WIP, missing routing labels, or rebase conflicts. Returns JSON array. |
+| `list_prs_requiring_advisor_action <branch> [stale_wip_seconds] [student_names_csv]` | List open branch PRs requiring advisor action, with `reasons` such as stale WIP, duplicate student WIP, missing, unknown, or unroutable student labels, or rebase conflicts. Returns JSON array. |
 | `list_all_prs <branch>` | List all open PRs on a branch (any status). Returns JSON array. |
 | `student_poll_for_work <student_name> [branch]` | List branch-scoped WIP PRs assigned to a student. Returns JSON array. |
 | `list_idle_students <names_csv> <branch>` | Print names of students with no `status:wip` PR, one per line. |
@@ -83,6 +84,9 @@ source "${CLAUDE_PLUGIN_ROOT}/scripts/senpai-gh.sh"
 
 # Advisor sends a PR back for revision
 send_pr_back_to_student_with_comment 1842 "ADVISOR: Promising direction but didn't beat baseline. Try lr=1e-3 with cosine annealing."
+
+# Leave a plain comment
+comment_on_pr 1842 "ADVISOR: Please stop the current run; the branch is no longer assigned."
 
 # Student marks PR ready for review
 mark_ready_for_review 1842

--- a/plugins/senpai/skills/survey-prs/SKILL.md
+++ b/plugins/senpai/skills/survey-prs/SKILL.md
@@ -45,7 +45,7 @@ list_idle_students "$STUDENT_NAMES" "$ADVISOR_BRANCH"
 2. **Categorize** each PR by its status labels:
    - `status:review` — ready for advisor review
    - `status:wip` — student is working on it (note which student from the `student:*` label)
-   - advisor-action reasons from `list_prs_requiring_advisor_action` — stale WIP, duplicate student WIP, missing routing labels, blocked/needs-rebase state, or merge-conflict comments
+   - advisor-action reasons from `list_prs_requiring_advisor_action` — stale WIP, duplicate student WIP, missing/unknown/unroutable routing labels, blocked/needs-rebase state, or merge-conflict comments
    - Draft with no status — may be newly created or stalled
 
 3. **Return a structured summary** in this format:

--- a/system_instructions/CLAUDE-ADVISOR.md
+++ b/system_instructions/CLAUDE-ADVISOR.md
@@ -41,6 +41,9 @@ source "${CLAUDE_PLUGIN_ROOT}/scripts/senpai-gh.sh"
 # Send a PR back to the student with feedback
 send_pr_back_to_student_with_comment <pr#> "ADVISOR: <feedback>"
 
+# Leave a plain advisor comment on a PR
+comment_on_pr <pr#> "ADVISOR: <comment>"
+
 # Check whether a winner is safe to merge before invoking merge-winner
 senpai_merge_winner_preflight <pr#> "$PROBLEM_DIR"
 
@@ -62,7 +65,7 @@ You run inside a pod entrypoint harness: it invokes Claude Code, passes the late
 1. **Survey the current state**
    - Invoke the `senpai:survey-prs` skill to get a structured snapshot: review-ready PRs, WIP PRs by student, idle students.
    - Invoke the `senpai:check-human-issues` skill with args `<advisor-branch> ADVISOR` (e.g. `noam ADVISOR`) to check for messages from the human research team. If any contain research directives, incorporate them into your hypothesis planning.
-   - Identify priorities: PRs ready for review, then new hypothesis research, then assigning new work to idle students (including students that have just become idle if you just closed their PRs after reviewing them)
+   - Identify priorities: PRs ready for review, advisor-action PRs and student pod anomalies, then new hypothesis research, then assigning new work to idle students (including students that have just become idle if you just closed their PRs after reviewing them). If a PR has an unknown or unroutable `student:*` label, fix that routing before assigning more work.
    - Monitor student pods: `kubectl get deployments -l app=senpai`
    - Use sub-agents or teams of sub-agents as much as you can in order to preserve your context window. 
 
@@ -119,6 +122,7 @@ You run inside a pod entrypoint harness: it invokes Claude Code, passes the late
 
 3. **Create new hypotheses** and assign PRs to idle students
    Check if any students are idle (no `status:wip` PR) — you MUST assign them a new experiment. This is not optional. Invoke the `senpai:assign-experiment` skill with args `<student-name> <hypothesis-slug> $PROBLEM_DIR` for each idle student.
+   Do not create assignment PRs with raw `gh pr create` or manual labels. The assignment skill uses `create_assignment_pr_from_file`, which verifies the base branch, head branch, draft status, and exact `student:<name>` routing label.
 
    In multi-benchmark targets like `target/icml2026`, the default unit of work
    should be a hypothesis family that is tested across all relevant datasets,

--- a/system_instructions/CLAUDE-STUDENT.md
+++ b/system_instructions/CLAUDE-STUDENT.md
@@ -32,6 +32,9 @@ mark_ready_for_review <pr#>
 pr_body <pr#>
 pr_all_comments <pr#>
 
+# Leave a comment without putting long markdown in the shell command line.
+comment_on_pr <pr#> "STUDENT: <question or comment>"
+
 # Summarize training logs after sparse wakeups.
 training_log_status <logfile> [more-logfiles...]
 
@@ -66,7 +69,7 @@ swap_gh_pr_label <pr#> "status:wip" "status:review"
    **Asking questions to the advisor:** You can comment on the PR if you need more information. Identify yourself as the student, then swap the label so the advisor sees it:
    ```bash
    source "${CLAUDE_PLUGIN_ROOT}/scripts/senpai-gh.sh"
-   gh pr comment <number> -b "STUDENT: <question or comment>"
+   comment_on_pr <number> "STUDENT: <question or comment>"
    gh pr ready <number> --undo
    swap_gh_pr_label <number> "status:wip" "status:review"
    ```


### PR DESCRIPTION
## Summary
- bound GitHub helper calls and advisor Claude invocations so one hung CLI command cannot wedge an advisor indefinitely
- add `comment_on_pr`, which posts via `--body-file`, and use it for advisor/student operational comments
- validate `student:*` labels against the active student roster so foreign or unroutable labels become advisor-action PRs before more work is assigned

## Tests
- `bash -n plugins/senpai/scripts/senpai-gh.sh k8s/entrypoint-advisor.sh k8s/entrypoint-student.sh k8s/student-claude-watchdog.sh k8s/run-senpai-claude.sh`
- mocked `list_prs_requiring_advisor_action` check for unknown/unroutable student labels
- mocked `comment_on_pr` check for `--body-file` usage
- mocked `run_senpai_claude` timeout wrapper check
- `bash k8s/test-entrypoint-advisor.sh`