### PR TITLE
[codex] Document auto-nanogpt launch plan

### DIFF
--- a/launches/auto-nanogpt-extra-instructions.md
+++ b/launches/auto-nanogpt-extra-instructions.md
@@ -1,0 +1,61 @@
+# Auto-nanoGPT Launch Extra Instructions
+
+This target is not a physical AI, CFD, or surrogate-modelling task. When the
+generic Senpai system prompt mentions physical metrics, CFD, datasets, or
+architecture search for physical modelling, reinterpret that guidance as:
+optimize the fixed `modded-nanogpt` track 3 optimizer benchmark described in
+`$PROBLEM_DIR/program.md`.
+
+Keep the task close to the public `modded-nanogpt` track 3 benchmark:
+
+- The objective is lower optimizer steps to FineWeb validation loss below 3.28.
+- Keep data, batch size, model architecture, and one forward-backward pass per
+  optimizer step fixed.
+- Focus on optimizer algorithms, optimizer hyperparameters, schedules, and
+  initialization.
+- Do not invent extra data configs, data files, or benchmark rules beyond the
+  target repo's `program.md` and the official track 3 README.
+
+Keep the research portfolio balanced between exploitation and exploration.
+Retuning LR/WD/cooldown is important when giving a new method a fair shot, but
+do not let the run become mostly scalar hyperparameter search. Assign fresh
+optimizer mechanisms, preconditioners, schedule ideas, initialization ideas,
+and pruning ablations of complex stacks.
+
+Be deliberate about step budgets. The launch timeout and max-epoch values are
+hard ceilings, not instructions to run forever. Use tiny runs for smoke tests,
+shorter step budgets for uncertain optimizer screening, and longer predeclared
+seed batches for serious confirmation. Think clearly before each PR about
+whether the run is exploration, tuning, pruning, or confirmation.
+
+Early kill gates are encouraged for obvious crashes, non-finite loss, exploding
+gradients, or hopeless screening runs, but do not use per-run validation loss to
+cherry-pick final steps or seeds. Final claims must report all non-cherry-picked
+runs at a predeclared step count and evaluate the benchmark statistical rule.
+
+Use W&B aggressively. Preserve and extend the starter script's telemetry for
+losses, validation loss, steps-to-target, learning rates, weight decay, gradient
+norms and distributions, parameter norms and distributions, and any
+optimizer-specific diagnostics that help explain why an idea worked or failed.
+The starter script also logs trailing-window train-loss slopes every 10% of the
+run and at the final step; use these slopes to reason about curve shape without
+overreacting to individual noisy steps.
+
+Focus only on your assigned advisor branch, research tag, student list, PR
+stream, and W&B runs. Ignore work that is not labeled with your branch/tag. Use
+the benchmark snapshot checked into this target repo; do not refresh, browse,
+fetch, or mine new upstream PRs, branches, records, issues, or post-launch
+updates during this run.
+
+Prime Intellect's autonomous-run materials are explicitly banned sources for
+agents during this launch. Do not open, fetch, browse, search within, clone,
+cite, summarize, or use:
+
+- `https://www.primeintellect.ai/auto-nanogpt`
+- `https://github.com/PrimeIntellect-ai/experiments-autonomous-speedrunning`
+- any raw GitHub URLs, files, branches, issues, pull requests, or archives under
+  that repository
+
+Those links are named only so you know what not to read. They are comparison
+artifacts for humans after the run, not part of the active experimental
+context.

--- a/launches/launch-auto-nanogpt.sh
+++ b/launches/launch-auto-nanogpt.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+target_repo_url="https://github.com/morganmcg1/auto-nanogpt-senpai.git"
+target_repo_branch="senpai-launch-20260515"
+extra_instructions="launches/auto-nanogpt-extra-instructions.md"
+wandb_project="senpai-auto-nanogpt"
+timeout_minutes="30240"
+max_epochs="100000"
+
+env_file="${SENPAI_ENV_FILE:-}"
+if [[ -z "${env_file}" ]]; then
+  if [[ -f ".env" ]]; then
+    env_file=".env"
+  elif [[ -f "${HOME}/ML/senpai/.env" ]]; then
+    env_file="${HOME}/ML/senpai/.env"
+  fi
+fi
+if [[ -n "${env_file}" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "${env_file}"
+  set +a
+fi
+
+if [[ -n "${SENPAI_PYTHON:-}" ]]; then
+  launch_cmd=("${SENPAI_PYTHON}")
+elif python -c "import simple_parsing" >/dev/null 2>&1; then
+  launch_cmd=(python)
+elif command -v uv >/dev/null 2>&1; then
+  launch_cmd=(uv run python)
+else
+  echo "Could not find Python with simple_parsing. Install the Senpai deps or set SENPAI_PYTHON." >&2
+  exit 1
+fi
+
+for rep in 1 2 3 4 5; do
+  tag="auto-nanogpt-r${rep}"
+  "${launch_cmd[@]}" k8s/launch.py \
+    --tag "${tag}" \
+    --advisor \
+    --target_repo_url "${target_repo_url}" \
+    --target_repo_branch "${target_repo_branch}" \
+    --advisor_branch "${tag}" \
+    --gh_history_scope fresh \
+    --n_students 8 \
+    --student_prefix "r${rep}" \
+    --gpus_per_student 8 \
+    --timeout_minutes "${timeout_minutes}" \
+    --max_epochs "${max_epochs}" \
+    --wandb_project "${wandb_project}" \
+    --extra_instructions "${extra_instructions}" \
+    "$@"
+done

--- a/launches/launch-auto-nanogpt.sh
+++ b/launches/launch-auto-nanogpt.sh
@@ -36,7 +36,7 @@ else
 fi
 
 for rep in 1 2 3 4 5; do
-  tag="auto-nanogpt-r${rep}"
+  tag="auto-nanogpt-1gpu-r${rep}"
   "${launch_cmd[@]}" k8s/launch.py \
     --tag "${tag}" \
     --advisor \
@@ -45,8 +45,8 @@ for rep in 1 2 3 4 5; do
     --advisor_branch "${tag}" \
     --gh_history_scope fresh \
     --n_students 8 \
-    --student_prefix "r${rep}" \
-    --gpus_per_student 8 \
+    --student_prefix "g1r${rep}" \
+    --gpus_per_student 1 \
     --timeout_minutes "${timeout_minutes}" \
     --max_epochs "${max_epochs}" \
     --wandb_entity "${wandb_entity}" \

--- a/launches/launch-auto-nanogpt.sh
+++ b/launches/launch-auto-nanogpt.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 target_repo_url="https://github.com/morganmcg1/modded-nanogpt-senpai.git"
 target_repo_branch="senpai-launch-20260515"
 extra_instructions="launches/auto-nanogpt-extra-instructions.md"
-wandb_entity="morganmcg1"
+wandb_entity="wandb-applied-ai-team"
 wandb_project="modded-nanogpt-senpai"
 timeout_minutes="30240"
 max_epochs="100000"

--- a/launches/launch-auto-nanogpt.sh
+++ b/launches/launch-auto-nanogpt.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-target_repo_url="https://github.com/morganmcg1/auto-nanogpt-senpai.git"
+target_repo_url="https://github.com/morganmcg1/modded-nanogpt-senpai.git"
 target_repo_branch="senpai-launch-20260515"
 extra_instructions="launches/auto-nanogpt-extra-instructions.md"
-wandb_project="senpai-auto-nanogpt"
+wandb_entity="morganmcg1"
+wandb_project="modded-nanogpt-senpai"
 timeout_minutes="30240"
 max_epochs="100000"
 
@@ -48,6 +49,7 @@ for rep in 1 2 3 4 5; do
     --gpus_per_student 8 \
     --timeout_minutes "${timeout_minutes}" \
     --max_epochs "${max_epochs}" \
+    --wandb_entity "${wandb_entity}" \
     --wandb_project "${wandb_project}" \
     --extra_instructions "${extra_instructions}" \
     "$@"


### PR DESCRIPTION
## Summary

Adds a small launch bundle for the auto-nanoGPT Senpai experiment:

- `launches/launch-auto-nanogpt.sh` launches five independent 1-GPU/student tags, each with one advisor and eight students.
- `launches/auto-nanogpt-extra-instructions.md` documents the task framing, fairness controls, source restrictions, telemetry expectations, and step-budget guidance passed through `--extra_instructions`.

This PR is intentionally documentation plus launch plumbing only. It does not change the default Senpai config or runtime prompts.

## Target Snapshot

The launch is pinned to the target package snapshot:

- target repo: `https://github.com/morganmcg1/modded-nanogpt-senpai.git`
- target branch: `senpai-launch-20260515`
- target commit at branch creation: `0ba525c`

That target branch contains the forked `modded-nanogpt` benchmark plus Senpai target files, W&B telemetry, shared FineWeb PVC cache support, and explicit source/fairness instructions in `program.md` and `instructions/prompt-advisor.md`.

## Experiment Plan

The launch script creates:

- tags/branches: `auto-nanogpt-1gpu-r1` through `auto-nanogpt-1gpu-r5`
- students per advisor: `8`
- GPUs per student: `1`
- timeout: `30240` minutes, three weeks
- max epochs: `100000`, treated as a hard ceiling rather than a target
- W&B entity/project: `wandb-applied-ai-team/modded-nanogpt-senpai`
- history scope: `fresh`
- corrected total GPU footprint: `40` student GPUs

## Fairness Controls

The extra instructions keep the run close to the public `modded-nanogpt` track 3 benchmark:

- optimize steps to FineWeb validation loss below `3.28`
- keep dataset, batch size, model architecture, and one forward-backward pass per optimizer step fixed
- focus on optimizer algorithms, schedules, initialization, and optimizer hyperparameters
- balance exploitation with exploration, avoiding a run that is mostly scalar LR/WD search
- use predeclared step counts and non-cherry-picked seed batches for final claims
- focus each advisor only on its own branch/tag/PR/W&B stream
- use the checked-in target snapshot; do not refresh post-launch upstream PRs, records, branches, or issues

The instructions explicitly ban agents from reading or using Prime Intellect's released autonomous-run materials, including:

- `https://www.primeintellect.ai/auto-nanogpt`
- `https://github.com/PrimeIntellect-ai/experiments-autonomous-speedrunning`
- raw GitHub URLs, files, branches, issues, PRs, or archives under that repo

Those are named only as banned sources/comparison artifacts for humans after the run.

## Data And Telemetry

FineWeb has been pre-cached on `pai-2` at:

- `/mnt/new-pvc/datasets/fineweb10B`
- verified file count: `21`
- verified size: `4.0G`

The target training script falls back to normal download behavior if needed, but Senpai pods should use the shared PVC cache automatically through `PVC_MOUNT_PATH`.

The target logs W&B metrics including validation loss, steps-to-target, train loss slopes over trailing 10% windows, grad norms, grad-to-weight norm, weight stats, per-type/per-param stats, and sampled histograms.

## Validation

Validated locally from `/Users/mmcguire/ML/senpai`:

- `bash -n launches/launch-auto-nanogpt.sh`
- `SENPAI_PYTHON=.venv/bin/python launches/launch-auto-nanogpt.sh --dry_run`
- `SENPAI_PYTHON=.venv/bin/python launches/launch-auto-nanogpt.sh --preflight_only`

Preflight passed for GitHub push access, target branch existence, Anthropic API key, and Exa API key for all five planned launches.

## Launched

The initial launch from commit `44b359c21c03a9540c5d11f336abb9adc5fcc8c2` used `--gpus_per_student 8` by mistake, creating an oversized `auto-nanogpt-r1` through `auto-nanogpt-r5` stream. That fleet was stopped, all old k8s deployments/configmaps/secrets were deleted, and the old target PR stream against `auto-nanogpt-r*` branches was closed as an aborted launch artifact.

The corrected five-replication launch was applied from branch `codex/auto-nanogpt-launch` at commit `a76f45a48fe005d54726ff80013994b162c40b48`.

Corrected verification showed:

- corrected tags/branches: `auto-nanogpt-1gpu-r1` through `auto-nanogpt-1gpu-r5`
- advisors ready: `5/5`
- students ready: `40/40`
- total deployments ready: `45/45`
- GPUs requested by corrected auto-nanoGPT fleet: `40`
- per replicate: `8` one-GPU student deployments plus one CPU-only advisor

W&B corrected launch report: https://wandb.ai/wandb-applied-ai-team/modded-nanogpt-senpai/reports/Auto-nanoGPT-Senpai-corrected-1-GPU-launch--VmlldzoxNjg5MjI0Mg==
