### PR TITLE
[codex] Reduce GitHub polling pressure

### DIFF
--- a/k8s/entrypoint-advisor.sh
+++ b/k8s/entrypoint-advisor.sh
@@ -158,7 +158,8 @@ LAST_CHECK_FILE="$LOGDIR/.last_check_ts"
 # --- Launch Claude Code Loop ---
 export IS_SANDBOX=1
 
-SLEEP_TIME_S=300
+SLEEP_TIME_S="${SENPAI_ADVISOR_POLL_INTERVAL_S:-${SENPAI_POLL_INTERVAL_S:-600}}"
+POLL_JITTER_S="${SENPAI_ADVISOR_POLL_JITTER_S:-${SENPAI_POLL_JITTER_S:-120}}"
 MAX_TURNS=100000
 export SENPAI_CLAUDE_TIMEOUT_SECONDS="${SENPAI_CLAUDE_TIMEOUT_SECONDS:-3600}"
 
@@ -222,8 +223,8 @@ while true; do
     else
         # --- Programmatic skip: skip rest of CC loop if nothing actionable ---
         if [ "$REVIEW_COUNT" -eq 0 ] && [ "$ADVISOR_ACTION_COUNT" -eq 0 ] && [ "$ISSUE_COUNT" -eq 0 ] && [ "$IDLE_COUNT" -eq 0 ] && [ "$POD_ANOMALY_COUNT" -eq 0 ]; then
-            echo "=== Iteration $ITERATION: Nothing actionable, sleeping $SLEEP_TIME_S seconds ==="
-            sleep "$SLEEP_TIME_S"
+            echo "=== Iteration $ITERATION: Nothing actionable, sleeping $SLEEP_TIME_S seconds + up to ${POLL_JITTER_S}s jitter ==="
+            senpai_sleep_with_jitter "$SLEEP_TIME_S" "$POLL_JITTER_S"
             continue
         fi
 
@@ -247,6 +248,6 @@ while true; do
         echo "=== Poll incomplete; not advancing last-check timestamp ==="
     fi
 
-    echo "=== Advisor exited code=$EXIT_CODE after ${DURATION}s at $(date), next check in $SLEEP_TIME_S seconds ==="
-    sleep "$SLEEP_TIME_S"
+    echo "=== Advisor exited code=$EXIT_CODE after ${DURATION}s at $(date), next check in $SLEEP_TIME_S seconds + up to ${POLL_JITTER_S}s jitter ==="
+    senpai_sleep_with_jitter "$SLEEP_TIME_S" "$POLL_JITTER_S"
 done

--- a/k8s/entrypoint-student.sh
+++ b/k8s/entrypoint-student.sh
@@ -101,7 +101,8 @@ export IS_SANDBOX=1
 
 LOGDIR="$WORKDIR/student_logs"
 mkdir -p "$LOGDIR"
-SLEEP_TIME_S=300
+SLEEP_TIME_S="${SENPAI_STUDENT_POLL_INTERVAL_S:-${SENPAI_POLL_INTERVAL_S:-600}}"
+POLL_JITTER_S="${SENPAI_STUDENT_POLL_JITTER_S:-${SENPAI_POLL_JITTER_S:-120}}"
 MAX_TURNS=100000
 
 ITERATION=0
@@ -164,7 +165,7 @@ while true; do
                 comment_on_pr "$num" "$DUPLICATE_BODY"
             fi
         done
-        sleep "$SLEEP_TIME_S"
+        senpai_sleep_with_jitter "$SLEEP_TIME_S" "$POLL_JITTER_S"
         continue
     fi
 
@@ -172,8 +173,8 @@ while true; do
     # is no work, do not enter Claude Code; idle model sessions tend to invent
     # their own polling loops and can miss the label-based assignment contract.
     if [ "$ASSIGNED_COUNT" -eq 0 ] && [ "$ISSUE_COUNT" -eq 0 ]; then
-        echo "=== No work assigned, sleeping $SLEEP_TIME_S seconds without invoking Claude ==="
-        sleep "$SLEEP_TIME_S"
+        echo "=== No work assigned, sleeping $SLEEP_TIME_S seconds + up to ${POLL_JITTER_S}s jitter without invoking Claude ==="
+        senpai_sleep_with_jitter "$SLEEP_TIME_S" "$POLL_JITTER_S"
         continue
     fi
 
@@ -195,10 +196,10 @@ while true; do
     fi
     DURATION=$(( $(date +%s) - START_TS ))
 
-    echo "=== Claude exited code=$EXIT_CODE after ${DURATION}s at $(date), next check in $SLEEP_TIME_S seconds ==="
+    echo "=== Claude exited code=$EXIT_CODE after ${DURATION}s at $(date), next check in $SLEEP_TIME_S seconds + up to ${POLL_JITTER_S}s jitter ==="
     if [ "$EXIT_CODE" -eq 124 ]; then
         echo "=== Claude watchdog fired; re-polling immediately ==="
         continue
     fi
-    sleep "$SLEEP_TIME_S"
+    senpai_sleep_with_jitter "$SLEEP_TIME_S" "$POLL_JITTER_S"
 done

--- a/k8s/student-claude-watchdog.sh
+++ b/k8s/student-claude-watchdog.sh
@@ -10,7 +10,8 @@
 # forever inside a child shell, the outer loop never polls again and can miss a
 # closed/reassigned PR. This wrapper keeps the polling loop in charge.
 
-STUDENT_CLAUDE_WATCHDOG_INTERVAL_S="${STUDENT_CLAUDE_WATCHDOG_INTERVAL_S:-60}"
+STUDENT_CLAUDE_WATCHDOG_INTERVAL_S="${STUDENT_CLAUDE_WATCHDOG_INTERVAL_S:-300}"
+STUDENT_CLAUDE_WATCHDOG_JITTER_S="${STUDENT_CLAUDE_WATCHDOG_JITTER_S:-60}"
 STUDENT_CLAUDE_MIN_RUNTIME_S="${STUDENT_CLAUDE_MIN_RUNTIME_S:-600}"
 STUDENT_CLAUDE_STALE_LOG_S="${STUDENT_CLAUDE_STALE_LOG_S:-1200}"
 STUDENT_CLAUDE_KILL_GRACE_S="${STUDENT_CLAUDE_KILL_GRACE_S:-15}"
@@ -136,7 +137,7 @@ run_student_claude_with_watchdog() {
     start_ts=$(date +%s)
 
     while kill -0 "$claude_pid" 2>/dev/null; do
-        sleep "$STUDENT_CLAUDE_WATCHDOG_INTERVAL_S"
+        senpai_sleep_with_jitter "$STUDENT_CLAUDE_WATCHDOG_INTERVAL_S" "$STUDENT_CLAUDE_WATCHDOG_JITTER_S"
         kill -0 "$claude_pid" 2>/dev/null || break
 
         now_ts=$(date +%s)

--- a/plugins/senpai/scripts/senpai-gh.sh
+++ b/plugins/senpai/scripts/senpai-gh.sh
@@ -23,7 +23,7 @@
 SENPAI_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # ---------------------------------------------------------------------------
-# Retry helper: up to 6 attempts with 15s backoff, then fail loudly.
+# Retry helpers.
 # ---------------------------------------------------------------------------
 senpai_run_with_timeout() {
     local timeout_seconds="${SENPAI_GH_TIMEOUT_SECONDS:-120}"
@@ -35,17 +35,84 @@ senpai_run_with_timeout() {
     fi
 }
 
+senpai_random_jitter_s() {
+    local max="${1:-0}"
+    case "$max" in
+        ''|*[!0-9]*) max=0 ;;
+    esac
+    [ "$max" -le 0 ] && { printf '0\n'; return; }
+
+    python3 - "$max" <<'PY' 2>/dev/null || printf '0\n'
+import random
+import sys
+
+print(random.randint(0, int(sys.argv[1])))
+PY
+}
+
+senpai_sleep_with_jitter() {
+    local base="${1:-0}" jitter="${2:-0}" extra total
+    case "$base" in
+        ''|*[!0-9]*) base=0 ;;
+    esac
+    extra=$(senpai_random_jitter_s "$jitter")
+    total=$((base + extra))
+    [ "$total" -gt 0 ] && sleep "$total"
+}
+
+gh_rate_limit_backoff_s() {
+    local err_file="$1" reset now wait max jitter
+    grep -qi "API rate limit exceeded\\|rate limit" "$err_file" || { printf '0\n'; return; }
+
+    reset=$(gh api rate_limit --jq '.resources.core.reset' 2>/dev/null || true)
+    case "$reset" in
+        ''|*[!0-9]*) printf '0\n'; return ;;
+    esac
+
+    now=$(date +%s)
+    wait=$((reset - now + 5))
+    [ "$wait" -le 0 ] && { printf '0\n'; return; }
+
+    max="${SENPAI_GH_RATE_LIMIT_MAX_SLEEP_SECONDS:-900}"
+    case "$max" in
+        ''|*[!0-9]*) max=900 ;;
+    esac
+    [ "$wait" -gt "$max" ] && wait="$max"
+
+    jitter=$(senpai_random_jitter_s "${SENPAI_GH_RATE_LIMIT_JITTER_S:-30}")
+    printf '%s\n' "$((wait + jitter))"
+}
+
 gh_retry() {
-    local attempt status
+    local attempt status out err backoff
     for attempt in 1 2 3 4 5 6; do
-        senpai_run_with_timeout "$@" && return 0
+        out=$(mktemp "${TMPDIR:-/tmp}/senpai-gh-out.XXXXXX") || return
+        err=$(mktemp "${TMPDIR:-/tmp}/senpai-gh-err.XXXXXX") || { rm -f "$out"; return; }
+
+        senpai_run_with_timeout "$@" >"$out" 2>"$err"
         status=$?
+        if [ "$status" -eq 0 ]; then
+            cat "$out"
+            rm -f "$out" "$err"
+            return 0
+        fi
+        cat "$err" >&2
         if [ "$attempt" -eq 6 ]; then
             echo "gh_retry: attempt $attempt failed with status $status; giving up" >&2
+            rm -f "$out" "$err"
             return "$status"
         fi
-        echo "gh_retry: attempt $attempt failed with status $status, retrying in 15s..." >&2
-        sleep 15
+
+        backoff=$(gh_rate_limit_backoff_s "$err")
+        if [ "${backoff:-0}" -gt 0 ]; then
+            echo "gh_retry: rate limit detected on attempt $attempt, retrying in ${backoff}s..." >&2
+            rm -f "$out" "$err"
+            sleep "$backoff"
+        else
+            echo "gh_retry: attempt $attempt failed with status $status, retrying in 15s..." >&2
+            rm -f "$out" "$err"
+            senpai_sleep_with_jitter 15 "${SENPAI_GH_RETRY_JITTER_S:-5}"
+        fi
     done
     return 1
 }
@@ -163,14 +230,30 @@ swap_gh_pr_label() {
     local num="$1" remove="$2" add="$3"
 
     # DELETE the old label — retry transient failures, tolerate 404 (already gone).
-    local attempt err
+    local attempt err_file err backoff
     for attempt in 1 2 3 4 5 6; do
-        err=$(senpai_run_with_timeout gh api "repos/${GH_REPO}/issues/${num}/labels/${remove}" \
-            --method DELETE --silent 2>&1) && break
-        echo "$err" | grep -q "404" && break
-        echo "swap_gh_pr_label: DELETE attempt $attempt failed, retrying in 15s..." >&2
+        err_file=$(mktemp "${TMPDIR:-/tmp}/senpai-gh-err.XXXXXX") || return
+        if senpai_run_with_timeout gh api "repos/${GH_REPO}/issues/${num}/labels/${remove}" \
+            --method DELETE --silent 2>"$err_file"; then
+            rm -f "$err_file"
+            break
+        fi
+        err=$(cat "$err_file")
+        cat "$err_file" >&2
+        if echo "$err" | grep -q "404"; then
+            rm -f "$err_file"
+            break
+        fi
+        backoff=$(gh_rate_limit_backoff_s "$err_file")
+        rm -f "$err_file"
         [ "$attempt" -eq 6 ] && return 1
-        sleep 15
+        if [ "${backoff:-0}" -gt 0 ]; then
+            echo "swap_gh_pr_label: rate limit detected on DELETE attempt $attempt, retrying in ${backoff}s..." >&2
+            sleep "$backoff"
+        else
+            echo "swap_gh_pr_label: DELETE attempt $attempt failed, retrying in 15s..." >&2
+            senpai_sleep_with_jitter 15 "${SENPAI_GH_RETRY_JITTER_S:-5}"
+        fi
     done
 
     # POST the new label (gh_retry gives 6 attempts on transient failure).


### PR DESCRIPTION
## Summary

This PR reduces GitHub API pressure from large Senpai fleets without changing the research workflow semantics.

Changes:
- Make advisor and student entrypoint poll intervals env-configurable, defaulting from 5 minutes to 10 minutes.
- Add per-pod polling jitter so fleets do not synchronize their GitHub requests.
- Slow the student Claude watchdog assignment poll from 60s to 300s, also with jitter.
- Teach `gh_retry` and label-swap retry logic to detect GitHub rate-limit errors and back off toward the core reset time instead of retrying every 15s.

## Why

The Charlie/Willow pai2i fleet exhausted the shared GitHub core limit while the pods themselves were healthy. At 160 students plus 20 advisors, synchronized 5-minute polling is enough to consume the limit before accounting for advisor review scans and per-PR detail/comment reads.

## Validation

- `bash -n plugins/senpai/scripts/senpai-gh.sh k8s/entrypoint-advisor.sh k8s/entrypoint-student.sh k8s/student-claude-watchdog.sh`
- Fake-`gh` shell check for the rate-limit backoff path.
- `gh_retry` success-path stdout preservation check.
- `SCENARIO=idle bash k8s/test-entrypoint-advisor.sh`
- `SCENARIO=mixed bash k8s/test-entrypoint-advisor.sh`
