### PR TITLE
[codex] Add advisor Claude watchdog

### DIFF
--- a/k8s/advisor-claude-watchdog.sh
+++ b/k8s/advisor-claude-watchdog.sh
@@ -18,16 +18,19 @@ ADVISOR_CLAUDE_KILL_GRACE_S="${ADVISOR_CLAUDE_KILL_GRACE_S:-15}"
 ADVISOR_CLAUDE_SELF_PGREP_STALE_S="${ADVISOR_CLAUDE_SELF_PGREP_STALE_S:-300}"
 ADVISOR_CLAUDE_SELF_PGREP_PATTERNS="${ADVISOR_CLAUDE_SELF_PGREP_PATTERNS:-wandb_sparse_val.py}"
 
+# Read log mtimes portably so stale-output checks work on Linux and macOS.
 advisor_file_mtime_s() {
     stat -c %Y "$1" 2>/dev/null || stat -f %m "$1"
 }
 
+# Emit intervention messages to both pod logs and the current Claude log.
 advisor_log_watchdog_trigger() {
     local message="$1"
     echo "$message"
     [ -n "${LOGFILE:-}" ] && printf '%s\n' "$message" >> "$LOGFILE"
 }
 
+# Walk child processes so the watchdog can see shells below timeout wrappers.
 advisor_descendant_pids() {
     local pid="$1" child
 
@@ -37,6 +40,7 @@ advisor_descendant_pids() {
     done
 }
 
+# Include the root process because the stuck waiter can be the watched shell.
 advisor_tree_pids() {
     local pid="$1"
     [ -n "$pid" ] || return 0
@@ -45,6 +49,7 @@ advisor_tree_pids() {
     advisor_descendant_pids "$pid"
 }
 
+# Signal a whole process tree so child wait shells cannot survive their parent.
 advisor_kill_process_tree() {
     local signal="$1" pid="$2" child
     [ -n "$pid" ] || return 0
@@ -56,6 +61,7 @@ advisor_kill_process_tree() {
     kill "-$signal" "$pid" 2>/dev/null || true
 }
 
+# Stop selected process trees gently, then force-kill anything still alive.
 advisor_stop_process_trees() {
     local pids="$1" pid
     [ -n "$pids" ] || return 0
@@ -73,6 +79,7 @@ advisor_stop_process_trees() {
     done
 }
 
+# Check whether a pattern still belongs to real work, not just waiter commands.
 advisor_real_pattern_process_exists() {
     local pattern="$1"
 
@@ -86,6 +93,7 @@ advisor_real_pattern_process_exists() {
         '
 }
 
+# Find waiters whose broad pgrep pattern only matches the waiter itself.
 advisor_self_pgrep_wait_pids() {
     local root_pid="$1" pattern pid line
 
@@ -105,6 +113,7 @@ advisor_self_pgrep_wait_pids() {
     done | sort -nu
 }
 
+# Run Claude under supervision and return 124 when the outer loop should re-poll.
 run_advisor_claude_with_watchdog() {
     run_senpai_claude "$@" &
     local claude_pid=$!

--- a/k8s/advisor-claude-watchdog.sh
+++ b/k8s/advisor-claude-watchdog.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+
+# Watchdog for advisor Claude Code invocations.
+#
+# The advisor entrypoint owns PR/issue/student polling. If Claude blocks
+# forever inside a child shell, the outer loop never polls again. This wrapper
+# keeps the polling loop in charge and handles known self-referential wait
+# failures, such as `pgrep -f wandb_sparse_val.py` matching the waiter itself.
+
+ADVISOR_CLAUDE_WATCHDOG_INTERVAL_S="${ADVISOR_CLAUDE_WATCHDOG_INTERVAL_S:-60}"
+ADVISOR_CLAUDE_MIN_RUNTIME_S="${ADVISOR_CLAUDE_MIN_RUNTIME_S:-600}"
+ADVISOR_CLAUDE_STALE_LOG_S="${ADVISOR_CLAUDE_STALE_LOG_S:-1200}"
+ADVISOR_CLAUDE_KILL_GRACE_S="${ADVISOR_CLAUDE_KILL_GRACE_S:-15}"
+ADVISOR_CLAUDE_SELF_PGREP_STALE_S="${ADVISOR_CLAUDE_SELF_PGREP_STALE_S:-300}"
+ADVISOR_CLAUDE_SELF_PGREP_PATTERNS="${ADVISOR_CLAUDE_SELF_PGREP_PATTERNS:-wandb_sparse_val.py}"
+
+advisor_file_mtime_s() {
+    stat -c %Y "$1" 2>/dev/null || stat -f %m "$1"
+}
+
+advisor_log_watchdog_trigger() {
+    local message="$1"
+    echo "$message"
+    [ -n "${LOGFILE:-}" ] && printf '%s\n' "$message" >> "$LOGFILE"
+}
+
+advisor_descendant_pids() {
+    local pid="$1" child
+
+    for child in $(pgrep -P "$pid" 2>/dev/null || true); do
+        printf '%s\n' "$child"
+        advisor_descendant_pids "$child"
+    done
+}
+
+advisor_tree_pids() {
+    local pid="$1"
+    [ -n "$pid" ] || return 0
+
+    printf '%s\n' "$pid"
+    advisor_descendant_pids "$pid"
+}
+
+advisor_kill_process_tree() {
+    local signal="$1" pid="$2" child
+    [ -n "$pid" ] || return 0
+
+    for child in $(pgrep -P "$pid" 2>/dev/null || true); do
+        advisor_kill_process_tree "$signal" "$child"
+    done
+
+    kill "-$signal" "$pid" 2>/dev/null || true
+}
+
+advisor_stop_process_trees() {
+    local pids="$1" pid
+    [ -n "$pids" ] || return 0
+
+    printf '%s\n' "$pids" | while IFS= read -r pid; do
+        [ -n "$pid" ] || continue
+        advisor_kill_process_tree TERM "$pid"
+    done
+
+    sleep "$ADVISOR_CLAUDE_KILL_GRACE_S"
+
+    printf '%s\n' "$pids" | while IFS= read -r pid; do
+        [ -n "$pid" ] || continue
+        kill -0 "$pid" 2>/dev/null && advisor_kill_process_tree KILL "$pid"
+    done
+}
+
+advisor_real_pattern_process_exists() {
+    local pattern="$1"
+
+    ps -eo pid=,comm=,args= |
+        awk -v pattern="$pattern" '
+            index($0, pattern) == 0 { next }
+            $2 ~ /^(sh|bash|zsh|dash|awk|grep|pgrep|ps|sleep|sed|sort|head|tail|cut|timeout)$/ { next }
+            $0 ~ /pgrep[[:space:]]+-f/ { next }
+            { found = 1 }
+            END { exit !found }
+        '
+}
+
+advisor_self_pgrep_wait_pids() {
+    local root_pid="$1" pattern pid line
+
+    for pattern in $ADVISOR_CLAUDE_SELF_PGREP_PATTERNS; do
+        [ -n "$pattern" ] || continue
+        advisor_real_pattern_process_exists "$pattern" && continue
+
+        for pid in $(advisor_tree_pids "$root_pid"); do
+            line=$(ps -o comm= -o args= -p "$pid" 2>/dev/null || true)
+            [ -n "$line" ] || continue
+            case "$line" in
+                *"pgrep -f $pattern"*|*"pgrep -f '$pattern'"*|*"pgrep -f \"$pattern\""*)
+                    printf '%s\n' "$pid"
+                    ;;
+            esac
+        done
+    done | sort -nu
+}
+
+run_advisor_claude_with_watchdog() {
+    run_senpai_claude "$@" &
+    local claude_pid=$!
+    local start_ts now_ts runtime log_mtime log_age reason rc self_pgrep_wait_pids
+    local watchdog_fired=0
+    start_ts=$(date +%s)
+
+    while kill -0 "$claude_pid" 2>/dev/null; do
+        sleep "$ADVISOR_CLAUDE_WATCHDOG_INTERVAL_S"
+        kill -0 "$claude_pid" 2>/dev/null || break
+
+        now_ts=$(date +%s)
+        runtime=$((now_ts - start_ts))
+        reason=""
+
+        self_pgrep_wait_pids=$(advisor_self_pgrep_wait_pids "$claude_pid")
+        if [ -n "$self_pgrep_wait_pids" ]; then
+            if [ "$runtime" -ge "$ADVISOR_CLAUDE_SELF_PGREP_STALE_S" ]; then
+                advisor_log_watchdog_trigger "=== Advisor Claude watchdog: stopping self-matching pgrep wait children after ${runtime}s: $(printf '%s' "$self_pgrep_wait_pids" | tr '\n' ' ')==="
+                advisor_stop_process_trees "$self_pgrep_wait_pids"
+                watchdog_fired=1
+            else
+                echo "=== Advisor Claude watchdog: saw self-matching pgrep wait; waiting ${runtime}/${ADVISOR_CLAUDE_SELF_PGREP_STALE_S}s before intervention ==="
+            fi
+        fi
+
+        [ "$runtime" -lt "$ADVISOR_CLAUDE_MIN_RUNTIME_S" ] && continue
+
+        log_mtime=$(advisor_file_mtime_s "$LOGFILE" 2>/dev/null || printf '%s' "$now_ts")
+        log_age=$((now_ts - log_mtime))
+        if [ "$log_age" -ge "$ADVISOR_CLAUDE_STALE_LOG_S" ]; then
+            reason="Claude log stale for ${log_age}s"
+        fi
+
+        if [ -n "$reason" ]; then
+            advisor_log_watchdog_trigger "=== Advisor Claude watchdog: stopping stale advisor invocation (${reason}) ==="
+            advisor_stop_process_trees "$claude_pid"
+            watchdog_fired=1
+            break
+        fi
+    done
+
+    rc=0
+    wait "$claude_pid" || rc=$?
+    if [ "$watchdog_fired" -eq 1 ]; then
+        return 124
+    fi
+    return "$rc"
+}

--- a/k8s/entrypoint-advisor.sh
+++ b/k8s/entrypoint-advisor.sh
@@ -124,6 +124,7 @@ start_hivemind
 
 # --- Load CC run command helper function ---
 source "$WORKDIR/k8s/run-senpai-claude.sh"
+source "$WORKDIR/k8s/advisor-claude-watchdog.sh"
 
 # --- Register Weave CC plugin (tools already baked into Docker image) ---
 export PATH="$HOME/.claude/bin:$PATH"
@@ -219,7 +220,7 @@ while true; do
         echo "=== Iteration $ITERATION: Using FULL prompt + triage ==="
         echo "$FULL_PROMPT"
         echo "$TRIAGE_INFO"
-        run_senpai_claude $MAX_TURNS "${FULL_PROMPT}"$'\n\n'"${TRIAGE_INFO}" || EXIT_CODE=$?
+        run_advisor_claude_with_watchdog $MAX_TURNS "${FULL_PROMPT}"$'\n\n'"${TRIAGE_INFO}" || EXIT_CODE=$?
     else
         # --- Programmatic skip: skip rest of CC loop if nothing actionable ---
         if [ "$REVIEW_COUNT" -eq 0 ] && [ "$ADVISOR_ACTION_COUNT" -eq 0 ] && [ "$ISSUE_COUNT" -eq 0 ] && [ "$IDLE_COUNT" -eq 0 ] && [ "$POD_ANOMALY_COUNT" -eq 0 ]; then
@@ -237,7 +238,7 @@ while true; do
             CONTINUE_PROMPT="${CONTINUE_PROMPT}"$'\n\n# Launch isolation and run-limit reminder\n\n'"${EXTRA_LAUNCH_INSTRUCTIONS}"
         fi
         CONTINUE_PROMPT="${CONTINUE_PROMPT}"$'\n\n'"${TRIAGE_INFO}"
-        run_senpai_claude 1000 "$CONTINUE_PROMPT" -c || EXIT_CODE=$?
+        run_advisor_claude_with_watchdog 1000 "$CONTINUE_PROMPT" -c || EXIT_CODE=$?
     fi
     DURATION=$(( $(date +%s) - START_TS ))
 
@@ -249,5 +250,9 @@ while true; do
     fi
 
     echo "=== Advisor exited code=$EXIT_CODE after ${DURATION}s at $(date), next check in $SLEEP_TIME_S seconds + up to ${POLL_JITTER_S}s jitter ==="
+    if [ "$EXIT_CODE" -eq 124 ]; then
+        echo "=== Advisor Claude watchdog fired; re-polling immediately ==="
+        continue
+    fi
     senpai_sleep_with_jitter "$SLEEP_TIME_S" "$POLL_JITTER_S"
 done

--- a/system_instructions/CLAUDE-ADVISOR.md
+++ b/system_instructions/CLAUDE-ADVISOR.md
@@ -187,6 +187,7 @@ You run inside a pod entrypoint harness: it invokes Claude Code, passes the late
 - Use `ScheduleWakeup` for loop re-entry.
 - Use `Monitor` for condition waits over PR state, pod state, logs, or GPU status.
 - Use a background `until ...; do sleep N; done` loop only for a bounded local check.
+- Do not wait for your own background commands with broad `pgrep -f "<wandb name or args>"` patterns. The waiting shell command line contains that pattern too, so `pgrep -f` can match the waiter itself forever. Capture the PID when you launch a background command and use `wait "$pid"`, a task id, or a pidfile instead.
 
 ### Give new experiments the best possible chance of success
 


### PR DESCRIPTION
## Summary

Adds a small advisor-side Claude watchdog so the advisor entrypoint keeps control of polling when Claude blocks inside a child shell.

## Why

The drivaerml-long advisor stalled because a shell wait used a broad `pgrep -f wandb_sparse_val.py` pattern. With no real target process left, the wait command matched itself and never returned, so the outer advisor loop stopped polling issues, PRs, and idle students.

## Changes

- Add `k8s/advisor-claude-watchdog.sh` with two focused checks:
  - stop self-matching `pgrep -f` wait children when no real target process exists
  - stop stale advisor invocations when the Claude log has not advanced past the configured threshold
- Run both full and heartbeat advisor Claude calls through the watchdog.
- Treat watchdog exit `124` as an immediate re-poll, without advancing the issue watermark.
- Add the same broad-`pgrep` warning to advisor role instructions.

## Validation

- `bash -n k8s/advisor-claude-watchdog.sh k8s/entrypoint-advisor.sh`
- Smoke-tested fake self-matching `pgrep -f` process detection.
- Smoke-tested stale-log watchdog path returning `124`.

Note: `shellcheck` is not installed in this environment, so I could not run it locally.
