### PR TITLE
[codex] add Senpai target bootstrap skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,10 @@ kubectl delete deployments,configmaps,secrets -l research-tag=<research-tag>
 
 ## Adding a new problem
 
+Use the `senpai:bootstrap-target <target-repo-path-or-url>` skill to onboard any ML or research target repository.
+It inspects the repo, interviews for missing metric/benchmark/guardrail decisions, and drafts the `program.md`
+plus `instructions/` files that make the target work well with Senpai.
+
 1. Create a new public repo (e.g. `myorg/my_problem`) with the minimum problem-package layout:
    - `train.py` — training script + model (entry point for students)
    - `data.py` or `data/` — data pipeline

--- a/plugins/senpai/skills/bootstrap-target/SKILL.md
+++ b/plugins/senpai/skills/bootstrap-target/SKILL.md
@@ -1,0 +1,145 @@
+---
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+
+name: bootstrap-target
+description: >
+  Create or improve Senpai target-repository onboarding files: program.md plus
+  instructions/prompt-advisor.md and instructions/prompt-student.md. Use this
+  skill whenever the user wants to point Senpai at a fresh ML or research
+  repository, define the research objective, primary metric, benchmark contract,
+  allowed edit boundaries, W&B reporting contract, advisor/student prompts, or
+  prepare a repo for autonomous advisor/student experiment loops.
+argument-hint: "<target-repo-path-or-url>"
+model: claude-opus-4-7
+effort: high
+---
+
+# bootstrap-target
+
+Turn an arbitrary ML or research repository into a Senpai-ready target package.
+
+The output is usually three files in the target repo:
+
+- `program.md` - the authoritative research contract.
+- `instructions/prompt-advisor.md` - the target-specific advisor overlay.
+- `instructions/prompt-student.md` - the target-specific student overlay.
+
+These files are not generic documentation. They are the launch briefing for an
+autonomous research lab. Write them so the advisor knows what kind of science to
+direct, the student knows what is legitimate to edit and run, and both roles
+agree on what counts as a valid result.
+
+## References
+
+Load these only when they help the current task:
+
+- `references/program-template.md` - annotated `program.md` section template.
+- `references/role-overlay-template.md` - richer advisor/student prompt shapes.
+- `references/interview-question-bank.md` - question sets for ambiguous targets.
+- `references/benchmark-integrity-patterns.md` - common benchmark no-nos and how
+  to phrase them.
+
+## Workflow
+
+1. **Inspect the repository before writing.**
+   Read the README, training and evaluation scripts, configs, data loaders,
+   dependency files, benchmark docs, tests, and any existing experiment logs.
+   Identify the actual commands, metric keys, data split logic, and files likely
+   to be edited by experiment PRs.
+
+2. **Infer the research contract.**
+   Extract the objective, metric direction, validation/test distinction,
+   benchmark constraints, data contract, model interface, resource limits,
+   allowed levers, protected files, W&B/logging behavior, and result reporting
+   needs. Prefer facts from code and docs over guesses.
+
+3. **Interview the user when durable decisions are unclear.**
+   Ask before encoding assumptions that will steer the research loop. Start with
+   the few questions that decide whether Senpai will optimize the right thing:
+
+   - What does success look like?
+   - What exactly should Senpai optimize?
+   - What is the primary metric, exact logged key/name, and direction?
+   - Is that metric already measured by the repo? If not, where should it be
+     added?
+   - What validation metric selects checkpoints, and what test metric supports
+     final claims?
+   - What balance should Senpai strike between tuning known-good ideas and
+     taking bigger research bets?
+   - Are there related fields, domains, papers, benchmarks, or research
+     communities the researcher agent should draw inspiration from when
+     proposing experiments?
+   - What changes are strictly forbidden: data leakage, benchmark rule changes,
+     external sources, architecture changes, dependency changes, cherry-picking,
+     hidden test access?
+   - What files may students edit, and which files are protected?
+   - What command should students run, and what time, GPU, or resource limits
+     matter?
+   - What baseline, SOTA, public reference, or statistical rule defines a
+     meaningful win?
+
+   Do not ask the user to restate facts the repository already makes obvious.
+
+4. **Write `program.md` as the research contract.**
+   `program.md` is the document every advisor and student will use to decide
+   what work is legitimate, what result matters, and what "better" means. It
+   should feel like a senior researcher briefing an autonomous lab before the
+   first experiment wave: concrete enough that a student can run the target
+   without guessing, and opinionated enough that the advisor can design useful
+   hypotheses instead of generic tweaks.
+
+   Cover the target summary, mission, codebase map, data contract, model and
+   training contract, run commands, metrics, benchmark integrity rules, result
+   reporting, resource guidance, and advisor strategy. Explain why critical
+   rules exist, especially around splits, metric finality, protected files, and
+   benchmark equivalence. For a fuller skeleton, read
+   `references/program-template.md`.
+
+5. **Write short role overlays with target flavor.**
+   The files in `instructions/` should not repeat the global Senpai loop. They
+   are overlays: concise, target-specific steering that helps the advisor and
+   student inhabit this particular research program.
+
+   `prompt-advisor.md` should brief the research lead on target identity,
+   branch discipline, first survey actions, metric focus, hypothesis design, and
+   portfolio strategy.
+
+   `prompt-student.md` should brief the implementer on target identity,
+   resource expectations, edit boundaries, exact run command patterns, research
+   pass expectations, and result reporting. For richer examples, read
+   `references/role-overlay-template.md`.
+
+6. **Validate the target package.**
+   Check that referenced paths exist, command patterns are plausible, metric
+   names match code where possible, protected files are explicit, and the role
+   overlays do not contradict `program.md`. If commands cannot be run locally,
+   state what was verified statically.
+
+## Writing Principles
+
+Prefer concrete contracts over motivational prose. A student should know what
+they may edit, what command to run, what metric matters, and what result format
+to report.
+
+Give enough domain context for real research judgment. A useful `program.md`
+does not just say "optimize validation loss"; it explains what the model is
+trying to learn, where the hard generalization axes are, and what kinds of ideas
+are likely worth trying.
+
+Do not hide multiple objectives behind one vague score. If important secondary
+metrics can regress, name them and explain how the advisor should handle the
+tradeoff.
+
+Make benchmark integrity painfully clear. Spell out data leakage risks, split
+immutability, forbidden shortcuts, external-source bans, seed/cherry-picking
+rules, hidden-test rules, and metric finality.
+
+Keep `instructions/` light. The global Senpai role files already define the
+loop; target prompts should only add target-specific setup, commands, and
+judgment.
+
+Fail loudly on ambiguity. If the primary metric, target command, protected
+files, or benchmark rules are unclear, interview the user before finalizing the
+files.

--- a/plugins/senpai/skills/bootstrap-target/SKILL.md
+++ b/plugins/senpai/skills/bootstrap-target/SKILL.md
@@ -7,7 +7,7 @@ name: bootstrap-target
 description: >
   Create or improve Senpai target-repository onboarding files: program.md plus
   instructions/prompt-advisor.md and instructions/prompt-student.md. Use this
-  skill whenever the user wants to point Senpai at a fresh ML or research
+  skill whenever the user wants to point Senpai at a fresh ML or research target
   repository, define the research objective, primary metric, benchmark contract,
   allowed edit boundaries, W&B reporting contract, advisor/student prompts, or
   prepare a repo for autonomous advisor/student experiment loops.

--- a/plugins/senpai/skills/bootstrap-target/SKILL.md
+++ b/plugins/senpai/skills/bootstrap-target/SKILL.md
@@ -80,7 +80,11 @@ Load these only when they help the current task:
    - What baseline, SOTA, public reference, or statistical rule defines a
      meaningful win?
 
-   Do not ask the user to restate facts the repository already makes obvious.
+   If the target is still ambiguous after the initial repo inspection, read
+   `references/interview-question-bank.md` and choose the smallest set of
+   questions that resolves the missing metric, benchmark, data, operations, or
+   file-boundary decisions. Do not ask the user to restate facts the repository
+   already makes obvious.
 
 4. **Write `program.md` as the research contract.**
    `program.md` is the document every advisor and student will use to decide

--- a/plugins/senpai/skills/bootstrap-target/references/benchmark-integrity-patterns.md
+++ b/plugins/senpai/skills/bootstrap-target/references/benchmark-integrity-patterns.md
@@ -1,0 +1,108 @@
+# Benchmark Integrity Patterns
+
+Use this reference when writing no-nos, constraints, and results contracts. Be
+specific: a benchmark rule that sounds obvious to a human can be invisible to an
+agent under pressure.
+
+## Split And Data Integrity
+
+Pattern:
+
+```markdown
+The split manifest is part of the benchmark contract. Do not regenerate, edit,
+rebalance, filter, or replace it during normal experiment PRs. A result that
+changes the split is not comparable to the baseline.
+```
+
+Use when the repo has manifest files, hidden test labels, preprocessed shards,
+or fixed public benchmark partitions.
+
+## Hidden Test Access
+
+Pattern:
+
+```markdown
+Do not inspect hidden test labels or tune against test metrics. The approved
+final evaluator may compute test metrics at the end of a run; those metrics are
+for reporting and merge decisions, not for adaptive per-seed or per-config
+selection.
+```
+
+Use when test labels exist locally for automated evaluation but should not guide
+experiment selection.
+
+## Metric Semantics
+
+Pattern:
+
+```markdown
+Do not rename, rescale, average, filter, or otherwise change the primary metric
+to make a result appear better. If a new diagnostic is useful, log it under a
+new key while preserving the existing primary metric contract.
+```
+
+Use when students may edit trainers or evaluators.
+
+## Seed And Trial Cherry-Picking
+
+Pattern:
+
+```markdown
+For final claims, predeclare the step count, seed count, and configuration, then
+report all non-cherry-picked runs. Do not use validation loss to select the best
+seed, stop time, or member of a final seed batch.
+```
+
+Use for stochastic benchmarks, optimizer speedruns, and statistical success
+rules.
+
+## Benchmark-Equivalent Training
+
+Pattern:
+
+```markdown
+Keep the benchmark equivalent: do not change the dataset, model class, batch
+size, number of forward/backward passes per optimizer step, or training budget
+unless the advisor explicitly assigns a benchmark-contract experiment.
+```
+
+Use when only certain levers are allowed.
+
+## Protected Evaluator Files
+
+Pattern:
+
+```markdown
+Evaluation files are protected. Read them to understand the metric, but do not
+edit them in normal experiment PRs. If an evaluator bug is suspected, ask the
+advisor before changing it and report the issue separately from the experiment
+result.
+```
+
+Use for scoring scripts, submission validators, manifest generation, hidden
+ground-truth joins, and official benchmark helpers.
+
+## External Source Restrictions
+
+Pattern:
+
+```markdown
+The following sources are banned during this launch. Do not open, fetch, browse,
+clone, cite, summarize, or use them for implementation ideas: <sources>. They
+are comparison artifacts for humans after the run, not part of the active
+experimental context.
+```
+
+Use when contamination or unfair post-launch information is a risk.
+
+## Early Kill Gates
+
+Pattern:
+
+```markdown
+Early kill gates are acceptable for crashes, non-finite losses, exploding
+gradients, OOMs, or hopeless debug runs. They are not acceptable as a way to
+hide required final metrics for serious confirmation runs.
+```
+
+Use when trainers expose kill thresholds or students can manually stop runs.

--- a/plugins/senpai/skills/bootstrap-target/references/interview-question-bank.md
+++ b/plugins/senpai/skills/bootstrap-target/references/interview-question-bank.md
@@ -1,0 +1,68 @@
+# Interview Question Bank
+
+Ask only the questions needed to resolve durable ambiguity. Prefer questions
+that expose tradeoffs over questions that ask the user to summarize files you
+can read.
+
+## Success And Research Strategy
+
+- What does success look like?
+- What would make this research run feel like a clear win rather than a modest
+  cleanup?
+- What balance should Senpai strike between tuning known-good ideas and taking
+  bigger research bets?
+- Are there related fields, domains, papers, benchmarks, or research
+  communities the researcher agent should draw inspiration from when proposing
+  experiments?
+- Are there approaches you already believe are promising, over-explored, or
+  off-limits?
+
+## Metrics
+
+- What exactly should Senpai optimize?
+- What is the primary metric, exact logged key/name, and direction?
+- Is that metric already measured by the repo? If not, where should it be
+  added?
+- What validation metric selects checkpoints?
+- What test metric supports final claims?
+- Are there secondary metrics that must not regress, even if the primary score
+  improves?
+- Is there a statistical rule, seed policy, or confidence threshold for final
+  claims?
+
+## Benchmark Integrity
+
+- Which files define the split, hidden labels, evaluator, or benchmark contract?
+- What changes would invalidate a result even if the metric improves?
+- Are students allowed to change the model architecture, data processing,
+  optimizer, batch size, number of steps, dependencies, or evaluation code?
+- Are any external sources, upstream repos, papers, branches, or post-launch
+  updates banned during the run?
+- Is validation peeking, seed selection, early stopping, or adaptive trial
+  selection allowed?
+
+## Data And Domain Context
+
+- Where does data live in Senpai pods?
+- What are the input and target shapes?
+- What do feature and target channels mean?
+- Which splits test in-distribution performance, OOD generalization, or
+  paper-facing claims?
+- Are there known hard regimes, rare cases, physical constraints, or failure
+  modes that advisors should account for?
+
+## Operations
+
+- What command should students run for debug, screening, and confirmation runs?
+- What GPU count, wall-clock timeout, epoch/step budget, and memory limit apply?
+- What W&B entity/project/group naming should be used?
+- What baseline should new PRs compare against?
+- What result fields must appear in student PR comments?
+
+## File Boundaries
+
+- Which files are primary editable entrypoints?
+- Which files are read-only context?
+- Which files are protected and should never be touched in normal experiment
+  PRs?
+- Are dependency changes allowed? If yes, where should they be recorded?

--- a/plugins/senpai/skills/bootstrap-target/references/program-template.md
+++ b/plugins/senpai/skills/bootstrap-target/references/program-template.md
@@ -1,0 +1,183 @@
+# program.md Template
+
+Use this as an annotated skeleton, not a rigid form. Keep the voice direct,
+specific, and operational.
+
+## Title And Target Summary
+
+Name the target plainly. In the first paragraph, say what inputs come in, what
+outputs are predicted or optimized, and what kind of research program this is.
+
+Example:
+
+```markdown
+# <Target Name>
+
+Research target for <domain/task>. Given <inputs>, predict or optimize
+<outputs>. The baseline is <model/system>. Beat it while preserving <benchmark
+contract>.
+```
+
+## Mission
+
+State the real objective in human terms. Do not only say "minimize loss." Say
+whether the goal is to beat a public benchmark, reduce step count, improve OOD
+generalization, preserve benchmark equivalence, or discover a better modeling
+recipe.
+
+Make the metric direction explicit and distinguish steering metrics from final
+claim metrics.
+
+Useful phrasing:
+
+```markdown
+The goal is not merely to improve the starter model. The goal is to find
+changes that reduce `<test metric>` while preserving the split, data, and
+evaluation contract. Validation metrics are for steering; final claims must use
+`<final test metric>`.
+```
+
+## Codebase
+
+List important files with edit boundaries and why they matter. This is not a
+directory tour; it is a guardrail against invalid experiments.
+
+Use labels like:
+
+- **Primary editable entrypoint.**
+- **Editable for experiment PRs.**
+- **Read-only during normal experiment PRs.**
+- **Protected. Never touch this file.**
+- **Dependency file. Add packages only in the same PR that uses them.**
+
+Mention benchmark docs and historical records if advisors should read them
+before assigning work.
+
+## Data
+
+Describe the data location, sample structure, feature channels, target channels,
+normalization, masks/padding, and anything domain-specific that helps an agent
+reason about errors.
+
+Include tables for feature dimensions and target channels when the code exposes
+structured tensors. Explain split design and which files define it. If the split
+is part of the benchmark contract, say that changing it invalidates results.
+
+## Model, Training, And Evaluation Contract
+
+Document the callable interface and invariants that evaluation depends on:
+
+- input and output tensor shapes
+- normalized versus physical target spaces
+- masking and padding behavior
+- checkpoint-selection metric
+- final validation/test evaluation behavior
+- whether models may change architecture
+- whether training scripts may change optimizer, schedule, or data sampling
+
+Explain why the invariants matter. For example, if metrics exclude padding,
+state that losses and metrics computed over padded rows are invalid.
+
+## Running
+
+Give exact command patterns. Include setup steps only when they are genuinely
+needed for Senpai pods or reproducibility.
+
+Use W&B naming in the command:
+
+```bash
+cd "$PROBLEM_DIR" && <train command> \
+  --wandb_name "$STUDENT_NAME/<short-description>" \
+  --wandb_group "<hypothesis-or-pr>"
+```
+
+Explain debug, screening, and confirmation run lengths. Resource ceilings such
+as `SENPAI_TIMEOUT_MINUTES`, `SENPAI_MAX_EPOCHS`, and GPU counts are hard
+limits, not instructions to run until exhaustion.
+
+## W&B Metrics And Telemetry
+
+List required metric keys exactly as logged. Separate:
+
+- primary validation/checkpoint metric
+- final test metric
+- secondary diagnostics
+- health telemetry such as gradients, slopes, memory, non-finite counts, or
+  benchmark-specific success margins
+
+Tell agents to preserve metric names when possible so advisors can compare runs
+across PRs.
+
+## Metrics And Success Criteria
+
+Name the primary ranking metric and direction. If a statistical rule, public
+reference, or SOTA target defines a meaningful win, write it down.
+
+If secondary metrics matter, explain how to treat tradeoffs:
+
+```markdown
+A run that improves the aggregate but regresses `<critical metric>` has not
+solved the problem. The advisor may still use it as a follow-up direction, but
+should not treat it as a clean winner.
+```
+
+## Benchmark Integrity
+
+Spell out the no-nos. Common examples:
+
+- do not modify split manifests or hidden labels
+- do not peek at test data except through the approved final evaluator
+- do not change metric definitions to make results look better
+- do not use per-seed early stopping or validation peeking to cherry-pick runs
+- do not change architecture, batch size, data, or training budget when the
+  benchmark forbids it
+- do not use banned external sources during the run
+
+Be concrete. If a banned source or file is known, name it.
+
+## Experiment Length And Resource Guidance
+
+Explain how advisors and students should choose run lengths:
+
+- tiny debug runs verify code, memory, logging, and finite gradients
+- short screening runs compare uncertain variants
+- longer confirmation runs support final claims or seed batches
+
+Warn against both failure modes: only short runs can discard ideas too early,
+while only long runs wastes throughput.
+
+## Results Contract
+
+Define the required result marker. Keep the JSON single-line and name the
+metric keys used by this target:
+
+```markdown
+SENPAI-RESULT: {"terminal":true,"status":"complete","pending_arms":false,"wandb_run_ids":["<run-id>"],"primary_metric":{"name":"<metric>","value":<number>},"test_metric":{"name":"<metric>","value":<number>}}
+```
+
+Also require the exact command, W&B run IDs, baseline comparison, metric table,
+known caveats, what happened, and suggested follow-ups.
+
+## Advisor Guidance
+
+Give the advisor a research personality for this target. Mention whether to
+favor exploitation, big bets, literature-inspired ideas, ablations, or balanced
+portfolios.
+
+Good guidance is specific:
+
+```markdown
+Keep the portfolio balanced. Retune learning rate and weight decay when a new
+optimizer idea deserves fair treatment, but do not spend the whole run on scalar
+hyperparameter search.
+```
+
+## Roles
+
+End by pointing to the target role overlays:
+
+```markdown
+Research is coordinated through GitHub PRs with an advisor/student model. GitHub
+Issues are used for communication with the human researcher team. See
+`instructions/prompt-advisor.md` and `instructions/prompt-student.md`.
+```

--- a/plugins/senpai/skills/bootstrap-target/references/role-overlay-template.md
+++ b/plugins/senpai/skills/bootstrap-target/references/role-overlay-template.md
@@ -1,0 +1,131 @@
+# Role Overlay Templates
+
+The role overlays should be short and target-specific. They should not recreate
+the full advisor or student loop from `CLAUDE.md`.
+
+## Advisor Prompt
+
+Write this as a briefing to the research lead. It should tell the advisor what
+kind of hypotheses to assign, what metric to care about, what mistakes to avoid,
+and what context to read first.
+
+Recommended shape:
+
+```markdown
+# Advisor
+
+You are the Senpai advisor for <target>. Your students run experiments on
+<task>; your job is to direct them well, assign hypotheses, review results, and
+keep the research moving.
+
+## Setup
+
+- **Your students:** $STUDENT_NAMES
+- **Research tag:** $RESEARCH_TAG
+- **W&B project:** `$WANDB_ENTITY/$WANDB_PROJECT`
+- **Monitoring student pods:** `kubectl get deployments -l app=senpai`
+- **Git branch:** `$ADVISOR_BRANCH` (PRs target it, new branches check out from
+  it, merges squash into it)
+
+## Workflow
+
+Read `CLAUDE.md` for the full advisor workflow and `$PROBLEM_DIR/program.md`
+for the target contract, benchmark rules, metrics, training command, and file
+boundaries.
+
+All advisor work lives on `$ADVISOR_BRANCH`, not `<default branch>`. PRs target
+`$ADVISOR_BRANCH`, new student branches check out from it, and winners merge
+back into it.
+
+## First Order Of Business
+
+Survey the current state:
+
+- Check W&B for runs under this research tag and group.
+- List existing PRs and labels for `$ADVISOR_BRANCH`.
+- Review <target-specific docs, records, benchmark rules, or baseline files>.
+- Assign work to every idle student.
+
+## Hypothesis Design
+
+Prioritize experiments that improve `<primary metric>` while preserving
+<benchmark contract>. Keep the portfolio balanced: <target-specific tuning
+versus big-bet guidance>.
+
+Draw inspiration from <related fields/domains/papers> when proposing fresh
+ideas, but keep every assignment measurable under `$PROBLEM_DIR/program.md`.
+```
+
+Add target-specific bans or source restrictions when needed. If the target has
+multiple validation tracks, tell the advisor how to handle disagreement between
+them.
+
+## Student Prompt
+
+Write this as a briefing to a capable implementer who must stay inside the
+benchmark contract. It should make the first correct action obvious.
+
+Recommended shape:
+
+```markdown
+# Research Student
+
+You are `$STUDENT_NAME`, a Senpai research student for <target>. The advisor
+assigns hypotheses through GitHub PRs. Your job is to implement the assigned
+change, run the benchmark, and report results clearly.
+
+Use `$PROBLEM_DIR/program.md` as the target contract.
+
+## Setup
+
+- **You:** `$STUDENT_NAME`
+- **GPUs:** `$GPUS_PER_STUDENT` on this node. Use the requested GPU count for
+  benchmark runs unless the PR explicitly asks for a smaller debug run.
+- **Target branch:** `$ADVISOR_BRANCH`
+- **W&B project:** `$WANDB_ENTITY/$WANDB_PROJECT`
+
+## Workflow
+
+Read `CLAUDE.md`, the assigned PR, and `$PROBLEM_DIR/program.md` before editing.
+PRs always target `$ADVISOR_BRANCH`, not `<default branch>`.
+
+The main experiment files are:
+
+```text
+<paths>
+```
+
+Keep edits focused on the assigned hypothesis and the allowed benchmark levers.
+Do not change <protected benchmark invariants> unless the advisor explicitly
+says the PR is changing the benchmark contract.
+
+## Running
+
+Use the command pattern in `program.md`, including W&B naming:
+
+```bash
+cd "$PROBLEM_DIR" && <train command> \
+  --wandb_name "$STUDENT_NAME/<short-description>" \
+  --wandb_group "<hypothesis-or-pr>"
+```
+
+Choose debug, screening, and confirmation runs thoughtfully. The launch timeout
+and max-epoch values are hard ceilings, not instructions to run forever.
+
+## Research
+
+Skip a research pass for pure numeric sweeps that are fully specified in the PR.
+Run one for architecture changes, optimizer mechanisms, data transforms, losses,
+physics-informed methods, evaluation changes, or anything where nearby research
+could materially change the implementation.
+
+## Reporting
+
+Report results in a PR comment using the `SENPAI-RESULT` format from
+`program.md`. Include the exact command, W&B run IDs, baseline comparison,
+metric table, known caveats, and suggested follow-ups.
+
+Negative results are useful. If an idea fails, explain whether it diverged,
+missed the target, had bad gradients, needed retuning, or appears genuinely
+unpromising.
+```


### PR DESCRIPTION
## Summary

Adds a new `bootstrap-target` Senpai plugin skill for preparing fresh ML/research repositories for Senpai runs. The skill guides agents to create or improve:

- `program.md`
- `instructions/prompt-advisor.md`
- `instructions/prompt-student.md`

It includes the interview questions we discussed, including success criteria, tuning-vs-big-bet balance, and related domains/papers to draw from.

## Details

The main `SKILL.md` keeps the workflow concise and points to progressively loaded references for deeper guidance:

- `program-template.md` for an annotated research-contract skeleton
- `role-overlay-template.md` for advisor/student overlay examples
- `interview-question-bank.md` for ambiguity-resolution questions
- `benchmark-integrity-patterns.md` for common benchmark no-nos and phrasing

## Validation

- `git diff --cached --check`
- ASCII-only check over the new skill directory
- staged scope reviewed before commit
