### PR TITLE
[codex] Make polling responsiveness configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,17 @@ wandb_entity: wandb-applied-ai-team
 wandb_project: senpai-v1
 timeout_minutes: 30.0
 max_epochs: 50
+poll_interval_s: 600
+poll_jitter_s: 120
+stale_wip_seconds: 7200
+advisor_claude_watchdog_interval_s: 60
+advisor_claude_min_runtime_s: 600
+advisor_claude_stale_log_s: 1200
+student_claude_watchdog_interval_s: 300
+student_claude_watchdog_jitter_s: 60
+student_claude_min_runtime_s: 600
+student_claude_stale_log_s: 1200
+student_assignment_drift_grace_s: 1800
 n_students: 4
 student_prefix: ""
 gpus_per_student: 8
@@ -113,6 +124,37 @@ preflight_only: false
 ```
 
 `launch.py` reads this via `simple_parsing` — every field can be overridden on the CLI.
+
+### Responsiveness knobs
+
+Advisor and student entrypoints poll GitHub before invoking Claude Code. By
+default they sleep for 10 minutes plus jitter between idle checks, which is
+appropriate for long training loops but too slow for short-budget targets. Use
+the polling and watchdog launch fields to make the loop more responsive without
+editing manifests by hand.
+
+`poll_interval_s` and `poll_jitter_s` are shared by both advisor and student
+outer loops. The watchdog fields tune role-specific checks while Claude is
+already running.
+
+For short, interactive experiments, lower `poll_interval_s` and
+`poll_jitter_s` so idle students and review-ready PRs are picked up quickly.
+For long training runs, keep those defaults or use larger values to reduce
+GitHub/API churn. Lower `*_claude_watchdog_interval_s` and
+`student_assignment_drift_grace_s` only when you want the outer loop to reclaim
+stale or reassigned work aggressively.
+
+```bash
+python k8s/launch.py \
+  --tag inferencebench-a-r1 \
+  --advisor \
+  --poll_interval_s 30 \
+  --poll_jitter_s 5 \
+  --stale_wip_seconds 600 \
+  --student_claude_watchdog_interval_s 30 \
+  --student_claude_watchdog_jitter_s 5 \
+  --student_assignment_drift_grace_s 120
+```
 
 ### Image rebuilds
 

--- a/k8s/launch.py
+++ b/k8s/launch.py
@@ -66,9 +66,44 @@ class Args:
     extra_instructions: str = ""  # extra prompt text for the advisor: a .md file path or a literal string
     timeout_minutes: float = 30.0  # training run wall-clock limit (SENPAI_TIMEOUT_MINUTES)
     max_epochs: int = 50  # maximum training epochs (SENPAI_MAX_EPOCHS)
+    poll_interval_s: int = 600  # default advisor/student outer-loop sleep between GitHub polls
+    poll_jitter_s: int = 120  # max random jitter added to outer-loop sleeps
+    stale_wip_seconds: int = 7200  # advisor-action threshold for stale WIP PRs
+    advisor_claude_watchdog_interval_s: int = 60  # how often advisor watchdog checks active Claude
+    advisor_claude_min_runtime_s: int = 600  # minimum advisor runtime before stale-log intervention
+    advisor_claude_stale_log_s: int = 1200  # advisor stale-log intervention threshold
+    student_claude_watchdog_interval_s: int = 300  # how often student watchdog checks active Claude
+    student_claude_watchdog_jitter_s: int = 60  # max jitter added to student watchdog checks
+    student_claude_min_runtime_s: int = 600  # minimum student runtime before stale-log intervention
+    student_claude_stale_log_s: int = 1200  # student stale-log intervention threshold
+    student_assignment_drift_grace_s: int = 1800  # grace before stopping active work after assignment changes
     start_gate_path: str = ""  # optional shared file path that must exist before advisor/student loops begin
     dry_run: bool = False  # render manifests only: do not apply them or validate credentials
     preflight_only: bool = False  # validate credentials/access only: do not render or apply manifests
+
+
+def validate_timing_args(args: Args) -> None:
+    positive = [
+        "poll_interval_s",
+        "advisor_claude_watchdog_interval_s",
+        "advisor_claude_min_runtime_s",
+        "advisor_claude_stale_log_s",
+        "student_claude_watchdog_interval_s",
+        "student_claude_min_runtime_s",
+        "student_claude_stale_log_s",
+    ]
+    non_negative = [
+        "poll_jitter_s",
+        "stale_wip_seconds",
+        "student_claude_watchdog_jitter_s",
+        "student_assignment_drift_grace_s",
+    ]
+    for name in positive:
+        if getattr(args, name) < 1:
+            sys.exit(f"ERROR: --{name} must be at least 1")
+    for name in non_negative:
+        if getattr(args, name) < 0:
+            sys.exit(f"ERROR: --{name} must be non-negative")
 
 
 def load_extra_instructions(extra_instructions: str) -> str:
@@ -123,6 +158,13 @@ def render_student(template: str, student_name: str, tag: str, secret_name: str,
             "SENPAI_ENABLE_HUMAN_ISSUES": "true" if args.human_issues else "false",
             "SENPAI_TIMEOUT_MINUTES": str(args.timeout_minutes),
             "SENPAI_MAX_EPOCHS": str(args.max_epochs),
+            "SENPAI_POLL_INTERVAL_S": str(args.poll_interval_s),
+            "SENPAI_POLL_JITTER_S": str(args.poll_jitter_s),
+            "STUDENT_CLAUDE_WATCHDOG_INTERVAL_S": str(args.student_claude_watchdog_interval_s),
+            "STUDENT_CLAUDE_WATCHDOG_JITTER_S": str(args.student_claude_watchdog_jitter_s),
+            "STUDENT_CLAUDE_MIN_RUNTIME_S": str(args.student_claude_min_runtime_s),
+            "STUDENT_CLAUDE_STALE_LOG_S": str(args.student_claude_stale_log_s),
+            "STUDENT_ASSIGNMENT_DRIFT_GRACE_S": str(args.student_assignment_drift_grace_s),
             "EXTRA_INSTRUCTIONS_B64": encoded_extra_instructions(args, tag, [student_name]),
             "PROBLEM_DIR": args.problem_dir,
             "PVC_MOUNT_PATH": args.pvc_mount_path,
@@ -164,6 +206,12 @@ def render_advisor(template: str, tag: str, student_list: list[str], secret_name
         "ADVISOR_BRANCH": args.advisor_branch,
         "GH_HISTORY_SCOPE": args.gh_history_scope,
         "SENPAI_ENABLE_HUMAN_ISSUES": "true" if args.human_issues else "false",
+        "SENPAI_POLL_INTERVAL_S": str(args.poll_interval_s),
+        "SENPAI_POLL_JITTER_S": str(args.poll_jitter_s),
+        "SENPAI_STALE_WIP_SECONDS": str(args.stale_wip_seconds),
+        "ADVISOR_CLAUDE_WATCHDOG_INTERVAL_S": str(args.advisor_claude_watchdog_interval_s),
+        "ADVISOR_CLAUDE_MIN_RUNTIME_S": str(args.advisor_claude_min_runtime_s),
+        "ADVISOR_CLAUDE_STALE_LOG_S": str(args.advisor_claude_stale_log_s),
         "PROBLEM_DIR": args.problem_dir,
         "PVC_MOUNT_PATH": args.pvc_mount_path,
         "SENPAI_START_GATE_PATH": args.start_gate_path,
@@ -190,6 +238,7 @@ def main():
     args = sp.parse(Args, config_path=str(SENPAI_CONFIG))
     if min(args.gpus_per_student, args.cpu_per_gpu, args.memory_gi_per_gpu) < 1:
         sys.exit("ERROR: --gpus_per_student, --cpu_per_gpu, and --memory_gi_per_gpu must all be at least 1")
+    validate_timing_args(args)
     if args.gh_history_scope not in {"branch", "repo", "fresh"}:
         sys.exit("ERROR: --gh_history_scope must be one of: branch, repo, fresh")
     if target_repo_slug(args.target_repo_url) == target_repo_slug(args.repo_url):

--- a/senpai.yaml
+++ b/senpai.yaml
@@ -35,6 +35,19 @@ gh_history_scope: branch
 timeout_minutes: 30.0
 max_epochs: 50
 
+# responsiveness / polling
+poll_interval_s: 600
+poll_jitter_s: 120
+stale_wip_seconds: 7200
+advisor_claude_watchdog_interval_s: 60
+advisor_claude_min_runtime_s: 600
+advisor_claude_stale_log_s: 1200
+student_claude_watchdog_interval_s: 300
+student_claude_watchdog_jitter_s: 60
+student_claude_min_runtime_s: 600
+student_claude_stale_log_s: 1200
+student_assignment_drift_grace_s: 1800
+
 # students
 n_students: 4
 student_prefix: ""


### PR DESCRIPTION
## Summary

Adds launch-time responsiveness controls so short-budget targets can run faster advisor/student feedback loops without hand-editing Kubernetes manifests.

- Exposes shared advisor/student GitHub poll interval and jitter as `launch.py` / `senpai.yaml` fields.
- Exposes stale-WIP and Claude watchdog timing knobs for faster short-budget recovery.
- Passes those values through the advisor and student ConfigMaps to the existing entrypoint/watchdog environment variables.
- Documents a rapid profile example in `README.md`.

## Why

For InferenceBench-style 2 hour runs, the default 10 minute idle polling loop is too slow. The entrypoints already support env vars such as `SENPAI_POLL_INTERVAL_S`, `SENPAI_POLL_JITTER_S`, `SENPAI_STALE_WIP_SECONDS`, and `STUDENT_ASSIGNMENT_DRIFT_GRACE_S`; this makes them configurable at launch time.

Generic advisor/student behavior instructions are intentionally unchanged. Target-specific mini-search guidance belongs in the problem package, not the generic Senpai runner prompts.

## Validation

- `python3 -m py_compile k8s/launch.py k8s/launch_helpers.py`
- `git diff --check`
- Rendered a dry-run launch with a 30s rapid profile after installing `simple-parsing` and `PyYAML` into a temporary local venv; confirmed the generated ConfigMaps include:
  - `SENPAI_POLL_INTERVAL_S: "30"`
  - `SENPAI_POLL_JITTER_S: "5"`
  - `SENPAI_STALE_WIP_SECONDS: "600"`
  - `STUDENT_CLAUDE_WATCHDOG_INTERVAL_S: "30"`
  - `STUDENT_ASSIGNMENT_DRIFT_GRACE_S: "120"`

## Follow-up

This does not yet interrupt an actively running student Claude invocation when the same assigned PR receives a new advisor comment. The current student watchdog polls assignment numbers, so same-PR comment updates are best handled by target-specific instructions that ask students to check comments between local arms. A future watchdog enhancement could track assigned PR `updatedAt` or latest advisor-comment timestamp for true mid-run interruptibility.
