### PR TITLE
[codex] Replace Claude headless with SDK runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SPDX-PackageName: senpai
 
 # senpai
 
-Autonomous ML research loop powered by Claude Code agents coordinated through GitHub PRs. Point it at a problem, deploy advisor + student agents on k8s, and let them iterate.
+Autonomous ML research loop powered by Claude Code Agent SDK agents coordinated through GitHub PRs. Point it at a problem, deploy advisor + student agents on k8s, and let them iterate.
 
 ## How it works
 
@@ -31,7 +31,7 @@ An **advisor** pod creates experiment PRs and assigns them to **student** GPU po
 ```mermaid
 graph TD
     subgraph K8s["Kubernetes Cluster"]
-        A["Advisor Pod<br/>(Claude Code, no GPU)<br/>Creates hypothesis PRs<br/>Reviews results, merges/closes"]
+        A["Advisor Pod<br/>(Claude Code SDK, no GPU)<br/>Creates hypothesis PRs<br/>Reviews results, merges/closes"]
         subgraph Students["Student Deployments (one per GPU node)"]
             S1["frieren<br/>8x GPU"]
             S2["fern<br/>8x GPU"]
@@ -74,6 +74,7 @@ senpai/
 │   └── CLAUDE-STUDENT.md
 ├── k8s/                           # Kubernetes deployment (problem-agnostic)
 │   ├── launch.py                  #   Deploy advisor + student pods
+│   ├── run_senpai_claude_sdk.py   #   Claude Agent SDK bridge
 │   ├── advisor-deployment.yaml
 │   ├── student-deployment.yaml
 │   ├── entrypoint-advisor.sh
@@ -117,6 +118,12 @@ preflight_only: false
 ### Image rebuilds
 
 The published runner image is `ghcr.io/wandb/senpai:latest`. It is built by `.github/workflows/build.yaml` on pushes to `main` or `docker` when `Dockerfile`, `pyproject.toml`, `uv.lock`, or the workflow changes. It can also be rebuilt manually from the GitHub Actions `workflow_dispatch` button.
+
+### Claude Agent SDK runtime
+
+Advisor and student loops invoke Claude through `k8s/run_senpai_claude_sdk.py`, a Python Agent SDK bridge. The outer shell loops still own GitHub polling, assignment checkout, idle skipping, and watchdog termination; the SDK bridge owns the model session itself.
+
+The bridge uses the Claude Code preset, model `claude-opus-4-7`, max effort, bypass permissions inside the pod sandbox, checked-in project settings, the local `plugins/senpai` plugin, all discovered skills, strict Exa MCP config from `.mcp.json`, and SDK hook telemetry for prompts and tool use.
 
 ### Launch credentials
 

--- a/k8s/run-senpai-claude.sh
+++ b/k8s/run-senpai-claude.sh
@@ -2,22 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-PackageName: senpai
 #
-# Shared Claude Code invocation for Senpai advisor/student entrypoints.
+# Shared Claude Agent SDK invocation for Senpai advisor/student entrypoints.
 # Each loop iteration must set LOGFILE before calling.
 #
-# Usage: run_senpai_claude <max_turns> <user_prompt> [extra claude argv before -p, e.g. -c]
+# Usage: run_senpai_claude <max_turns> <user_prompt> [extra argv, currently -c]
 
 run_senpai_claude() {
     local max_turns=$1 user_prompt=$2
     shift 2
     export CLAUDE_PLUGIN_ROOT="$SENPAI_PLUGIN"
-    local claude_cmd=(claude "$@" -p -
-        --model "claude-opus-4-7[1m]"
-        --effort "max"
+    local claude_cmd=(python3 "$WORKDIR/k8s/run_senpai_claude_sdk.py"
         --max-turns "$max_turns"
-        --output-format stream-json --verbose
         --plugin-dir "$SENPAI_PLUGIN"
-        --dangerously-skip-permissions)
+        "$@")
     if [ -n "${SENPAI_CLAUDE_TIMEOUT_SECONDS:-}" ] && command -v timeout >/dev/null 2>&1; then
         local kill_after="${SENPAI_CLAUDE_TIMEOUT_KILL_AFTER_SECONDS:-30}"
         claude_cmd=(timeout -k "$kill_after" "$SENPAI_CLAUDE_TIMEOUT_SECONDS" "${claude_cmd[@]}")

--- a/k8s/run_senpai_claude_sdk.py
+++ b/k8s/run_senpai_claude_sdk.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+
+"""Run one Senpai Claude Code turn through the Python Agent SDK."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import dataclasses
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from claude_agent_sdk import ClaudeAgentOptions, HookMatcher, query
+
+MODEL = "claude-opus-4-7"
+EFFORT = "max"
+SETTING_SOURCES = ["project"]
+REQUIRED_PLUGIN = "senpai"
+REQUIRED_SLASH_COMMANDS = {
+    "alphaxiv-paper-lookup",
+    "list-experiments",
+    "senpai-status-check",
+    "wandb-primary",
+    "web-search-advanced-research-paper",
+    "senpai:assign-experiment",
+    "senpai:bootstrap-target",
+    "senpai:check-human-issues",
+    "senpai:merge-winner",
+    "senpai:poll-for-work",
+    "senpai:submit-experiment-results",
+    "senpai:survey-prs",
+}
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--max-turns", required=True, type=int)
+    parser.add_argument("--plugin-dir", required=True, type=Path)
+    parser.add_argument("-c", "--continue", dest="continue_conversation", action="store_true")
+    return parser.parse_args(argv)
+
+
+def repo_root(plugin_dir: Path) -> Path:
+    return plugin_dir.resolve().parents[1]
+
+
+def mcp_config_path(plugin_dir: Path) -> Path:
+    return repo_root(plugin_dir) / ".mcp.json"
+
+
+def jsonable(value: Any) -> Any:
+    if dataclasses.is_dataclass(value):
+        return {key: jsonable(item) for key, item in dataclasses.asdict(value).items()}
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, dict):
+        return {str(key): jsonable(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [jsonable(item) for item in value]
+    if isinstance(value, tuple):
+        return [jsonable(item) for item in value]
+    return value
+
+
+def emit(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload, separators=(",", ":"), default=str), flush=True)
+
+
+def message_payload(message: Any) -> dict[str, Any]:
+    name = type(message).__name__
+    data = jsonable(message)
+
+    if name == "SystemMessage":
+        return data["data"]
+    if name == "AssistantMessage":
+        return {"type": "assistant", **data}
+    if name == "UserMessage":
+        return {"type": "user", **data}
+    if name == "ResultMessage":
+        data["modelUsage"] = data.pop("model_usage")
+        return {"type": "result", **data}
+    if name == "RateLimitEvent":
+        return {"type": "system", "subtype": "rate_limit", **data}
+    return {"type": name, **data}
+
+
+def validate_init_event(payload: dict[str, Any]) -> None:
+    plugins = {item.get("name") for item in payload.get("plugins", [])}
+    if REQUIRED_PLUGIN not in plugins:
+        raise RuntimeError(f"Claude SDK did not load required plugin: {REQUIRED_PLUGIN}")
+
+    commands = set(payload.get("slash_commands", []))
+    missing = sorted(REQUIRED_SLASH_COMMANDS - commands)
+    if missing:
+        raise RuntimeError(f"Claude SDK missing required skills: {', '.join(missing)}")
+
+
+async def user_prompt_hook(
+    input_data: dict[str, Any],
+    _tool_use_id: str | None,
+    _context: Any,
+) -> dict[str, Any]:
+    emit({
+        "type": "senpai_hook",
+        "hook_event_name": input_data["hook_event_name"],
+        "prompt_chars": len(input_data.get("prompt", "")),
+    })
+    return {}
+
+
+async def tool_hook(input_data: dict[str, Any], _tool_use_id: str | None, _context: Any) -> dict[str, Any]:
+    payload = {
+        "type": "senpai_hook",
+        "hook_event_name": input_data["hook_event_name"],
+        "tool_name": input_data.get("tool_name"),
+    }
+    command = input_data.get("tool_input", {}).get("command")
+    if command:
+        payload["command"] = command
+    emit(payload)
+    return {}
+
+
+def build_options(args: argparse.Namespace) -> ClaudeAgentOptions:
+    plugin_dir = args.plugin_dir.resolve()
+    root = repo_root(plugin_dir)
+    mcp_config = mcp_config_path(plugin_dir)
+
+    env = dict(os.environ)
+    env["CLAUDE_PLUGIN_ROOT"] = str(plugin_dir)
+    env["CLAUDE_CODE_ALLOW_ROOT"] = "1"
+
+    return ClaudeAgentOptions(
+        cli_path=Path.home() / ".local/bin/claude",
+        cwd=Path.cwd(),
+        continue_conversation=args.continue_conversation,
+        max_turns=args.max_turns,
+        model=MODEL,
+        effort=EFFORT,
+        permission_mode="bypassPermissions",
+        system_prompt={"type": "preset", "preset": "claude_code"},
+        tools={"type": "preset", "preset": "claude_code"},
+        add_dirs=[root],
+        plugins=[{"type": "local", "path": str(plugin_dir)}],
+        mcp_servers=mcp_config,
+        strict_mcp_config=True,
+        setting_sources=SETTING_SOURCES,
+        skills="all",
+        include_hook_events=True,
+        env=env,
+        hooks={
+            "UserPromptSubmit": [HookMatcher(hooks=[user_prompt_hook])],
+            "PreToolUse": [HookMatcher(hooks=[tool_hook])],
+            "PostToolUse": [HookMatcher(hooks=[tool_hook])],
+            "PostToolUseFailure": [HookMatcher(hooks=[tool_hook])],
+        },
+    )
+
+
+async def run(prompt: str, args: argparse.Namespace) -> int:
+    saw_init = False
+    async for message in query(prompt=prompt, options=build_options(args)):
+        payload = message_payload(message)
+        if payload.get("type") == "system" and payload.get("subtype") == "init":
+            validate_init_event(payload)
+            saw_init = True
+        emit(payload)
+
+    if not saw_init:
+        raise RuntimeError("Claude SDK session ended before init")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    prompt = sys.stdin.read()
+    return asyncio.run(run(prompt, args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "senpai"
 version = "0.1.0"
 requires-python = ">=3.10"
 dependencies = [
+    "claude-agent-sdk",
     "numpy",
     "PyYAML",
     "torch",
@@ -29,4 +30,5 @@ exclude = ["k8s*", "target*", "tests*"]
 dev = [
     "ipython",
     "jupyter",
+    "pytest",
 ]

--- a/tests/test_docker_image.py
+++ b/tests/test_docker_image.py
@@ -4,9 +4,10 @@ Deploys a test pod, verifies the weave plugin works, checks that a
 claude session produces a trace in Weave, then tears down the pod.
 
 Usage:
-    uv run pytest tests/test_docker_image.py -v -s
+    uv run --extra dev pytest tests/test_docker_image.py -v -s
 """
 
+import shlex
 import subprocess
 import time
 import uuid
@@ -109,6 +110,7 @@ def test_python_deps_and_icml_target_import(test_pod):
     """The image has the Python deps needed by the new ICML target."""
     cmd = (
         "python - <<'PY'\n"
+        "import claude_agent_sdk\n"
         "import numpy\n"
         "import torch\n"
         "import torch_geometric\n"
@@ -127,16 +129,21 @@ def test_weave_plugin_ready(test_pod):
 
 
 def test_claude_creates_trace(test_pod):
-    """Running claude with a unique prompt produces a matching Weave trace."""
+    """Running the SDK bridge with a unique prompt produces a matching Weave trace."""
     marker = f"senpai-test-{uuid.uuid4().hex[:8]}"
     prompt = f"Reply with exactly this string and nothing else: {marker}"
+    quoted_prompt = shlex.quote(prompt)
 
     out = kubectl_check(
         "exec", test_pod, "--",
-        "bash", "-c", f'CLAUDE_CODE_ALLOW_ROOT=1 claude -p "{prompt}"',
+        "bash", "-c",
+        "cd /workspaces/senpai && "
+        f"printf %s {quoted_prompt} | "
+        "python3 k8s/run_senpai_claude_sdk.py --max-turns 1 --plugin-dir plugins/senpai",
         timeout=CLAUDE_TIMEOUT,
     )
     assert marker in out, f"Expected {marker!r} in output, got: {out!r}"
+    assert "senpai_hook" in out, f"Expected SDK hook telemetry in output, got: {out!r}"
 
     # Give the daemon a moment to flush the trace
     time.sleep(10)

--- a/tests/test_sdk_runner.py
+++ b/tests/test_sdk_runner.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+
+import argparse
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNNER_PATH = ROOT / "k8s" / "run_senpai_claude_sdk.py"
+
+spec = importlib.util.spec_from_file_location("run_senpai_claude_sdk", RUNNER_PATH)
+runner = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(runner)
+
+
+def test_parse_args_accepts_continue_flag():
+    args = runner.parse_args(["--max-turns", "7", "--plugin-dir", "plugins/senpai", "-c"])
+
+    assert args.max_turns == 7
+    assert args.plugin_dir == Path("plugins/senpai")
+    assert args.continue_conversation is True
+
+
+def test_parse_args_rejects_old_cli_flags():
+    with pytest.raises(SystemExit):
+        runner.parse_args(["--max-turns", "7", "--plugin-dir", "plugins/senpai", "--model", "opus"])
+
+
+def test_mcp_config_path_is_repo_root_relative():
+    assert runner.mcp_config_path(ROOT / "plugins" / "senpai") == ROOT / ".mcp.json"
+
+
+def test_build_options_adds_runner_root_for_nested_target_repos():
+    args = argparse.Namespace(
+        max_turns=3,
+        plugin_dir=ROOT / "plugins" / "senpai",
+        continue_conversation=False,
+    )
+
+    options = runner.build_options(args)
+
+    assert options.add_dirs == [ROOT]
+    assert options.model == "claude-opus-4-7"
+    assert options.betas == []
+    assert options.setting_sources == ["project"]
+
+
+def test_validate_init_event_requires_senpai_surface():
+    payload = {
+        "plugins": [{"name": "senpai"}],
+        "slash_commands": sorted(runner.REQUIRED_SLASH_COMMANDS),
+    }
+
+    runner.validate_init_event(payload)
+
+
+def test_validate_init_event_fails_when_skill_missing():
+    payload = {
+        "plugins": [{"name": "senpai"}],
+        "slash_commands": [],
+    }
+
+    with pytest.raises(RuntimeError, match="missing required skills"):
+        runner.validate_init_event(payload)

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "2026-05-21T10:31:37.961549Z"
+exclude-newer-span = "P2D"
+
 [[package]]
 name = "abnf"
 version = "2.2.0"
@@ -605,6 +609,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3e/c8/3ae22fa142be0bf9eee856e90c314f4144dfae376cc5e3e55b9a169670fb/cint-1.0.0.tar.gz", hash = "sha256:66f026d28c46ef9ea9635be5cb342506c6a1af80d11cb1c881a8898ca429fc91", size = 4641, upload-time = "2019-03-19T01:07:48.723Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/91/c2/898e59963084e1e2cbd4aad1dee92c5bd7a79d121dcff1e659c2a0c2174e/cint-1.0.0-py3-none-any.whl", hash = "sha256:8aa33028e04015711c0305f918cb278f1dc8c5c9997acdc45efad2c7cb1abf50", size = 5573, upload-time = "2019-03-19T01:07:46.496Z" },
+]
+
+[[package]]
+name = "claude-agent-sdk"
+version = "0.2.83"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "mcp" },
+    { name = "sniffio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/4a/2dd1079d9ecee35cd7cfb7299675297a2d9067a08c6f949c0ba8d9604d1a/claude_agent_sdk-0.2.83.tar.gz", hash = "sha256:c333bbecfab24a2bcc8b385e46c5fa9930ca5c2ffcd4f334a871902cdeb3ba2d", size = 252059, upload-time = "2026-05-21T02:07:12.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/1d/8703cd5636176480da7f1f33c4740a25d27cab8ed4f6467da7d30cdc126d/claude_agent_sdk-0.2.83-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4445196e98a50cfbda69d5d66b1a500dfdd384f0440e5cdd2b51e3afbd862fa5", size = 62555640, upload-time = "2026-05-21T02:07:17.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/bf/16be259af88b199faa827630ffe3933e397e8f881111e64b0506e1ddfbbd/claude_agent_sdk-0.2.83-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:26823090fc0a84d1aacaec9a36e3a54a20980660ee002af044d8cd213f19092d", size = 64608755, upload-time = "2026-05-21T02:07:21.917Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b1/d1c005c827a9c8b8fe14e9772c7e697b319b3c1a5fd251c3e89cdae8b257/claude_agent_sdk-0.2.83-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:044c90af795430882707a00bcbbf417fe37db84a3a36ebef56098f50d400272c", size = 72245617, upload-time = "2026-05-21T02:07:27.526Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/e5/56bfa415697bc6b4a077c00cfc38e8120d01eece0c456f5ec7fbbace20ea/claude_agent_sdk-0.2.83-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:147f824c55079d63dd67a64b6f8f7d53e6a2e0e54f89f5e37b1741b4543971b5", size = 72419743, upload-time = "2026-05-21T02:07:32.246Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/fd/45fe8c8e586571ccb0a04a0a4bee6de84d81684d961e3d3a6ce2b7b1ce4a/claude_agent_sdk-0.2.83-py3-none-win_amd64.whl", hash = "sha256:f8730b651933232297739c0c47810954ae4457c0c73b1d3615ada15c7058d6c0", size = 73059300, upload-time = "2026-05-21T02:07:36.986Z" },
 ]
 
 [[package]]
@@ -1397,6 +1420,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "huggingface-hub"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1435,6 +1467,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -2174,6 +2215,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/bd/c0/9f7c9a46090390368a4d7bcb76bb87a4a36c421e4c0792cdb53486ffac7a/matplotlib_inline-0.2.2.tar.gz", hash = "sha256:72f3fe8fce36b70d4a5b612f899090cd0401deddc4ea90e1572b9f4bfb058c79", size = 8150, upload-time = "2026-05-08T17:33:33.49Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/09/5b161152e2d90f7b87f781c2e1267494aef9c32498df793f73ad0a0a494a/matplotlib_inline-0.2.2-py3-none-any.whl", hash = "sha256:3c821cf1c209f59fb2d2d64abbf5b23b67bcb2210d663f9918dd851c6da1fcf6", size = 9534, upload-time = "2026-05-08T17:33:32.055Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.27.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458, upload-time = "2026-05-08T16:50:12.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/73/42d9596facebdb533b7f0b86c1b0364ef350d1f8ba78b1052e8a58b48b65/mcp-1.27.1-py3-none-any.whl", hash = "sha256:1af3c4203b329430fde7a87b4fcb6392a041f5cb851fd68fc674016ab4e7c06f", size = 216260, upload-time = "2026-05-08T16:50:10.547Z" },
 ]
 
 [[package]]
@@ -2996,6 +3062,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "polyfile-weave"
 version = "0.5.9"
 source = { registry = "https://pypi.org/simple" }
@@ -3372,12 +3447,43 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -3396,6 +3502,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/49/4cea918a08f02817aabae639e3d0ac046fef9f9180518a3ad394e22da148/pyreadline3-3.5.4.tar.gz", hash = "sha256:8d57d53039a1c75adba8e50dd3d992b28143480816187ea5efbd5c78e6c885b7", size = 99839, upload-time = "2024-09-19T02:40:10.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl", hash = "sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6", size = 83178, upload-time = "2024-09-19T02:40:08.598Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -3426,6 +3550,37 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f7/ff/3cc9165fd44106973cd7ac9facb674a65ed853494592541d339bdc9a30eb/python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195", size = 17573, upload-time = "2026-03-29T04:39:56.805Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2", size = 15021, upload-time = "2026-03-29T04:39:55.266Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.29"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/fe/70bd71a6738b09a0bdf6480ca6436b167469ca4578b2a0efbe390b4b0e70/python_multipart-0.0.29.tar.gz", hash = "sha256:643e93849196645e2dbdd81a0f8829a23123ad7f797a84a364c6fb3563f18904", size = 45678, upload-time = "2026-05-17T17:29:47.654Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/cb/769cfc37177252872a45a71f3fbdde9d51b471a3f3c14bfe95dde3407386/python_multipart-0.0.29-py3-none-any.whl", hash = "sha256:2ddcc971cef266225f54f552d8fa10bcfbb1f14446caec199060daac59ff2d69", size = 29640, upload-time = "2026-05-17T17:29:45.69Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/40/44efbb0dfbd33aca6a6483191dae0716070ed99e2ecb0c53683f400a0b4f/pywin32-311-cp310-cp310-win32.whl", hash = "sha256:d03ff496d2a0cd4a5893504789d4a15399133fe82517455e78bad62efbb7f0a3", size = 8760432, upload-time = "2025-07-14T20:13:05.9Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/bf/360243b1e953bd254a82f12653974be395ba880e7ec23e3731d9f73921cc/pywin32-311-cp310-cp310-win_amd64.whl", hash = "sha256:797c2772017851984b97180b0bebe4b620bb86328e8a884bb626156295a63b3b", size = 9590103, upload-time = "2025-07-14T20:13:07.698Z" },
+    { url = "https://files.pythonhosted.org/packages/57/38/d290720e6f138086fb3d5ffe0b6caa019a791dd57866940c82e4eeaf2012/pywin32-311-cp310-cp310-win_arm64.whl", hash = "sha256:0502d1facf1fed4839a9a51ccbcc63d952cf318f78ffc00a7e78528ac27d7a2b", size = 8778557, upload-time = "2025-07-14T20:13:11.11Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/af/449a6a91e5d6db51420875c54f6aff7c97a86a3b13a0b4f1a5c13b988de3/pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151", size = 8697031, upload-time = "2025-07-14T20:13:13.266Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8f/9bb81dd5bb77d22243d33c8397f09377056d5c687aa6d4042bea7fbf8364/pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503", size = 9508308, upload-time = "2025-07-14T20:13:15.147Z" },
+    { url = "https://files.pythonhosted.org/packages/44/7b/9c2ab54f74a138c491aba1b1cd0795ba61f144c711daea84a88b63dc0f6c/pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2", size = 8703930, upload-time = "2025-07-14T20:13:16.945Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
 ]
 
 [[package]]
@@ -3824,6 +3979,7 @@ name = "senpai"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "claude-agent-sdk" },
     { name = "einops" },
     { name = "matplotlib" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -3845,15 +4001,18 @@ dev = [
     { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "ipython", version = "9.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "jupyter" },
+    { name = "pytest" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "claude-agent-sdk" },
     { name = "einops" },
     { name = "ipython", marker = "extra == 'dev'" },
     { name = "jupyter", marker = "extra == 'dev'" },
     { name = "matplotlib" },
     { name = "numpy" },
+    { name = "pytest", marker = "extra == 'dev'" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "rich" },
@@ -3930,6 +4089,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
 name = "sortedcontainers"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3948,6 +4116,19 @@ wheels = [
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/2b/58abc2d1fd397e7dde08e947e05c884d8ef2f78d5e2588c17a12d42d6994/sse_starlette-3.4.4.tar.gz", hash = "sha256:07e0fa0460138baf25cdd5fb28683472c3995dc1642225191b3832d62526bcb0", size = 31819, upload-time = "2026-05-12T17:37:17.019Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/67/805710444ea8cc75fbf70b920ed431a560c4bf9c57f7d5a3117213189399/sse_starlette-3.4.4-py3-none-any.whl", hash = "sha256:3f4dd50d8aed2771a091f3a83000323fc3844541c16b4fe585ae2420cc6df973", size = 16514, upload-time = "2026-05-12T17:37:15.601Z" },
+]
+
+[[package]]
 name = "stack-data"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3959,6 +4140,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
 ]
 
 [[package]]
@@ -4312,6 +4506,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.47.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/b1/8e7077a8641086aea449e1b5752a570f1b5906c64e0a33cd6d93b63a066b/uvicorn-0.47.0.tar.gz", hash = "sha256:7c9a0ea1a9414106bbab7324609c162d8fa0cdcdcb703060987269d77c7bb533", size = 90582, upload-time = "2026-05-14T18:16:54.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/41/ac2dfdbc1f60c7af4f994c7a335cfa7040c01642b605d65f611cecc2a1e4/uvicorn-0.47.0-py3-none-any.whl", hash = "sha256:2c5715bc12d1892d84752049f400cd1c3cb018514967fdfeb97640443a6a9432", size = 71301, upload-time = "2026-05-14T18:16:51.762Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Replace the shared `claude -p` invocation with a Python Claude Agent SDK bridge.
- Load the Senpai plugin, runner-root skills, strict Exa MCP config, Claude Code preset, and SDK hook telemetry explicitly.
- Update dependencies, Docker smoke coverage, focused runner tests, and README runtime docs.

## Validation

- `uv run --extra dev pytest tests/test_sdk_runner.py -q`
- `uv lock --check`
- `git diff --check --cached`
- Live SDK runner smoke locally
- Shell bridge smoke locally
- Nested target-repo simulation for runner-root skill discovery
- `bash k8s/test-entrypoint-advisor.sh`
- `uv run python -m compileall k8s/run_senpai_claude_sdk.py tests/test_sdk_runner.py tests/test_docker_image.py`

## Notes

This is a clean break: there is no headless fallback path and no rollback env var. The model is set to `claude-opus-4-7` without the old `[1m]` shorthand or beta flag.
