### PR TITLE
Enable GitHub Pages workflow setup

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Configure Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- Allow actions/configure-pages to enable the repository Pages site during deployment

## Why
The merged Pages workflow failed because the repository did not yet have Pages enabled/configured for GitHub Actions builds.
