### PR TITLE
Prefix advisor and student GitHub comments by role

### DIFF
--- a/senpai_agent/github_workflow.py
+++ b/senpai_agent/github_workflow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Callable
 from dataclasses import dataclass
 from threading import Lock
@@ -329,6 +330,7 @@ class GitHubWorkflow:
         "_api_url",
         "_assignment_lifecycle_lock",
         "_repo",
+        "_role",
         "_token",
         "_transport",
         "_trusted_actor",
@@ -339,6 +341,7 @@ class GitHubWorkflow:
         repo: str,
         token: SecretStr,
         *,
+        role: Literal["advisor", "student"],
         transport: HttpTransport | None = None,
         api_url: str = "https://api.github.com",
         trusted_actor: str | None = None,
@@ -349,10 +352,13 @@ class GitHubWorkflow:
             raise TypeError("token must be a SecretStr")
         if not token.get_secret_value().strip():
             raise ValueError("token must not be empty")
+        if role not in {"advisor", "student"}:
+            raise ValueError("role must be advisor or student")
         if trusted_actor is not None and not trusted_actor.strip():
             raise ValueError("trusted actor must not be empty")
 
         self._repo = repo
+        self._role = role
         self._token = token
         self._transport = transport or _UrllibTransport()
         self._api_url = api_url.rstrip("/")
@@ -367,6 +373,10 @@ class GitHubWorkflow:
     @property
     def repo(self) -> str:
         return self._repo
+
+    @property
+    def role(self) -> Literal["advisor", "student"]:
+        return self._role
 
     def __getstate__(self) -> None:
         raise TypeError("GitHubWorkflow cannot be serialized")
@@ -724,7 +734,11 @@ class GitHubWorkflow:
             raise ReconciliationError(
                 f"GitHub contains multiple comments for marker {marker!r}"
             )
-        if existing and existing[0].body != marker_body:
+        desired_body = _role_prefixed_comment(marker_body, self._role)
+        if existing and _role_prefixed_comment(
+            existing[0].body,
+            self._role,
+        ) != desired_body:
             raise WorkflowPreconditionError(
                 "feedback_id already identifies different guidance; "
                 "use a new feedback_id"
@@ -1119,6 +1133,7 @@ class GitHubWorkflow:
         subject: str,
         desired_state: str,
     ) -> tuple[bool, _IssueComment]:
+        body = _role_prefixed_comment(body, self._role)
         existing = matches()
         if len(existing) > 1:
             raise ReconciliationError(f"GitHub contains multiple {subject}")
@@ -1678,6 +1693,20 @@ def _marker_body(marker: str, content: str) -> str:
     body = f"{marker}\n\n{content}"
     _validate_marker(marker, body)
     return body
+
+
+_ROLE_COMMENT_PREFIX = re.compile(r"^(?:ADVISOR|STUDENT(?: [^:\s]+)?):[ \t]*")
+
+
+def _role_prefixed_comment(
+    body: str,
+    role: Literal["advisor", "student"],
+) -> str:
+    marker, separator, content = body.partition("\n\n")
+    if not (separator and marker.startswith("<!-- senpai-")):
+        marker, separator, content = "", "", body
+    content = _ROLE_COMMENT_PREFIX.sub("", content)
+    return f"{marker}{separator}{role.upper()}: {content}"
 
 
 def _replace_assignment_marker(

--- a/senpai_agent/tools.py
+++ b/senpai_agent/tools.py
@@ -757,7 +757,7 @@ class RespondToIssueTransition(_Transition):
     response: str = Field(
         min_length=1,
         max_length=50_000,
-        description="Response including the role prefix required by the skill.",
+        description="Response text; the runtime adds the authenticated role prefix.",
     )
 
 
@@ -1121,9 +1121,12 @@ class GitHubTransitionTool(
             workflow = GitHubWorkflow(
                 credentials.repo,
                 credentials.token,
+                role=role,
                 trusted_actor=credentials.trusted_actor,
             )
             git_token = credentials.token
+        elif isinstance(workflow, GitHubWorkflow) and workflow.role != role:
+            raise ValueError("workflow role must match the GitHub tool role")
         if workspace is None:
             if conv_state is None:
                 raise ValueError("github_transition requires its OpenHands workspace")

--- a/tests/github_workflow_support.py
+++ b/tests/github_workflow_support.py
@@ -1,6 +1,6 @@
 """Stateful GitHub transport used by the workflow transition tests."""
 
-from typing import cast
+from typing import Literal, cast
 from urllib.parse import parse_qs, unquote, urlsplit
 
 from pydantic import SecretStr
@@ -378,10 +378,15 @@ class AmbiguousMutationGitHub(FakeGitHub):
         return response
 
 
-def workflow(fake: FakeGitHub) -> GitHubWorkflow:
+def workflow(
+    fake: FakeGitHub,
+    *,
+    role: Literal["advisor", "student"] = "advisor",
+) -> GitHubWorkflow:
     return GitHubWorkflow(
         REPO,
         SecretStr("github-secret"),
+        role=role,
         transport=fake,
         api_url=API_URL,
         trusted_actor="senpai-bot",

--- a/tests/test_github_workflow_assignment_messages.py
+++ b/tests/test_github_workflow_assignment_messages.py
@@ -69,7 +69,9 @@ def test_request_revision_converges_marker_assignment_state_and_replays():
     assert parse_assignment_markers(cast(str, fake.pr["body"]))[0].revision_id == (
         "revision-2"
     )
-    assert fake.comments == [comment(1, f"{marker}\n\nRun the requested ablation.")]
+    assert fake.comments == [
+        comment(1, f"{marker}\n\nADVISOR: Run the requested ablation.")
+    ]
     assert fake.pr["draft"] is True
     assert fake.pr["labels"] == {"student:one", "status:wip"}
     assert fake.mutations == mutations_after_first
@@ -90,7 +92,7 @@ def test_request_revision_updates_a_trusted_marker_on_the_final_comment_page():
 
     assert [item["body"] for item in fake.comments] == [
         "unrelated",
-        f"{marker}\n\nRun the requested ablation.",
+        f"{marker}\n\nADVISOR: Run the requested ablation.",
     ]
 
 
@@ -112,7 +114,7 @@ def test_request_revision_does_not_trust_spoofed_or_embedded_markers():
         spoofed,
         f"Documentation example: {marker}",
         f"> {marker}",
-        f"{marker}\n\nUse the trusted revision.",
+        f"{marker}\n\nADVISOR: Use the trusted revision.",
     ]
 
 
@@ -224,11 +226,29 @@ def test_assignment_feedback_replays_without_changing_assignment_state():
         comment(
             1,
             f"{feedback_marker()}\n\n"
-            "Check the cruise split before choosing a default.",
+            "ADVISOR: Check the cruise split before choosing a default.",
         )
     ]
     assert (fake.pr["body"], fake.pr["draft"], fake.pr["labels"]) == original_state
     assert fake.mutations == mutations_after_first
+
+
+def test_assignment_feedback_upgrades_a_legacy_unprefixed_comment():
+    marker = feedback_marker()
+    guidance = "Check the cruise split before choosing a default."
+    fake = FakeGitHub(
+        pull_request(labels={"student:student-one", "status:wip"}, draft=True),
+        comments=[comment(1, f"{marker}\n\n{guidance}")],
+    )
+
+    result = send_feedback(
+        workflow(fake),
+        feedback_id="check-cruise-split",
+        comment=f"ADVISOR: {guidance}",
+    )
+
+    assert result.changed is True
+    assert fake.comments == [comment(1, f"{marker}\n\nADVISOR: {guidance}")]
 
 
 def test_assignment_feedback_id_cannot_be_reused_for_different_guidance():

--- a/tests/test_github_workflow_contracts.py
+++ b/tests/test_github_workflow_contracts.py
@@ -74,6 +74,7 @@ def test_api_errors_do_not_expose_the_token():
     client = GitHubWorkflow(
         REPO,
         SecretStr("never-show-this"),
+        role="advisor",
         transport=FailingTransport(),
         api_url=API_URL,
     )
@@ -93,6 +94,7 @@ def test_network_failure_raises_a_token_safe_transport_error(monkeypatch):
     client = GitHubWorkflow(
         REPO,
         SecretStr("never-show-this"),
+        role="advisor",
         api_url=API_URL,
     )
 

--- a/tests/test_github_workflow_issue_messages.py
+++ b/tests/test_github_workflow_issue_messages.py
@@ -20,13 +20,13 @@ def test_respond_to_issue_writes_one_verified_idempotent_reply():
     first = client.respond_to_issue(
         7,
         human_message_id=700,
-        response="ADVISOR: I will investigate this now.",
+        response="I will investigate this now.",
     )
     mutations_after_first = list(fake.mutations)
     second = client.respond_to_issue(
         7,
         human_message_id=700,
-        response="ADVISOR: I will investigate this now.",
+        response="I will investigate this now.",
     )
 
     assert first.changed is True
@@ -49,7 +49,7 @@ def test_respond_to_issue_accepts_a_specific_human_comment():
         comments=[comment(42, "Please also compare memory use.", author="ada")],
     )
 
-    result = workflow(fake).respond_to_issue(
+    result = workflow(fake, role="student").respond_to_issue(
         7,
         human_message_id=42,
         response="STUDENT fern: I included memory in the comparison.",
@@ -57,7 +57,9 @@ def test_respond_to_issue_accepts_a_specific_human_comment():
 
     assert result.changed is True
     assert len(fake.comments) == 2
-    assert "<!-- senpai-human-response:42 -->" in cast(str, fake.comments[-1]["body"])
+    assert cast(str, fake.comments[-1]["body"]).endswith(
+        "\n\nSTUDENT: I included memory in the comparison."
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_github_workflow_results.py
+++ b/tests/test_github_workflow_results.py
@@ -44,7 +44,7 @@ def test_submit_result_converges_review_state_and_replays_without_writes():
         pull_request(labels={"student:one", "status:wip"}, draft=True)
     )
     result = experiment_result()
-    client = workflow(fake)
+    client = workflow(fake, role="student")
 
     first = submit_result(client, result)
     mutations_after_first = list(fake.mutations)
@@ -55,7 +55,7 @@ def test_submit_result_converges_review_state_and_replays_without_writes():
     assert fake.pr["draft"] is False
     assert fake.pr["labels"] == {"student:one", "status:review"}
     assert len(fake.comments) == 1
-    assert "<!-- senpai-result:v1 " in str(fake.comments[0]["body"])
+    assert "\n\nSTUDENT: Status: succeeded" in str(fake.comments[0]["body"])
     assert fake.mutations == mutations_after_first
 
 
@@ -141,7 +141,7 @@ def test_submit_result_recovers_when_the_comment_response_is_lost():
         fail_path=f"/repos/{REPO}/issues/7/comments",
     )
 
-    result = submit_result(workflow(fake))
+    result = submit_result(workflow(fake, role="student"))
 
     assert result.state == "result_submitted"
     assert fake.failed is True
@@ -160,7 +160,7 @@ def test_submit_result_does_not_treat_the_initial_assignment_head_as_a_lease():
         )
     )
 
-    submitted = submit_result(workflow(fake))
+    submitted = submit_result(workflow(fake, role="student"))
 
     assert submitted.state == "result_submitted"
 
@@ -181,7 +181,7 @@ def test_submit_result_rejects_mismatched_result_location(result):
     )
 
     with pytest.raises(WorkflowPreconditionError, match="result"):
-        submit_result(workflow(fake), result)
+        submit_result(workflow(fake, role="student"), result)
 
     assert fake.mutations == []
 
@@ -202,7 +202,7 @@ def test_close_experiment_writes_one_reason_and_replays_without_writes():
             "id": 1,
             "body": (
                 "<!-- senpai-disposition:v1 dead-end-7 -->\n\n"
-                "The hypothesis was falsified."
+                "ADVISOR: The hypothesis was falsified."
             ),
             "user": {"login": "senpai-bot"},
             "html_url": f"https://github.com/{REPO}/pull/7#issuecomment-1",

--- a/tests/test_tools_github_access.py
+++ b/tests/test_tools_github_access.py
@@ -6,6 +6,7 @@ import pytest
 from openhands.sdk.tool import Tool, resolve_tool
 from pydantic import SecretStr
 
+from github_workflow_support import FakeGitHub, pull_request, workflow
 from senpai_agent.github import PRManifestEntry, PRRetrievalResult
 from senpai_agent.github_workflow import MutationResult
 from senpai_agent.tools import (
@@ -116,6 +117,17 @@ ADVISOR_TRANSITIONS = [
         id="merge-experiment",
     ),
 ]
+
+
+def test_transition_rejects_a_workflow_bound_to_another_role(tmp_path: Path):
+    student_workflow = workflow(FakeGitHub(pull_request()), role="student")
+
+    with pytest.raises(ValueError, match="workflow role"):
+        GitHubTransitionTool.create(
+            workflow=student_workflow,
+            role="advisor",
+            workspace=tmp_path,
+        )
 
 
 @pytest.mark.parametrize("transition", ADVISOR_TRANSITIONS)


### PR DESCRIPTION
## Summary

- bind the GitHub comment writer to the authenticated advisor or student role
- prefix the first visible line of every PR and issue comment with `ADVISOR: ` or `STUDENT: ` while preserving Senpai protocol markers
- normalize legacy caller prefixes and safely migrate existing unprefixed feedback comments
- reject mismatches between an injected workflow role and the runtime tool role

## Why

Advisor and student comments share a GitHub identity, so their role should be unambiguous and enforced by tooling rather than prompt compliance.

## Validation

- `uv lock --check`
- `uv run --extra dev pytest -q` — 643 passed, 6 skipped