### PR TITLE
Harden GitHub workflow reconciliation

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -348,8 +348,10 @@ commit, upserts the typed result, marks the PR ready, reconciles
 `status:review`, and verifies all postconditions. The label itself is the
 cross-node notification. A schema-valid result is immutable for its assignment
 revision and head: canonical-identical duplicates are one idempotent result,
-while different evidence must use a new commit or revision. Distinct valid
-results at the same identity fail closed.
+while different evidence must use a new commit or revision. Result records are
+append-only across revision/head identities, and gates select only the record
+for the live assignment; stale workers therefore cannot rewrite newer evidence.
+Distinct valid results at the same identity fail closed.
 
 Research-base movement is a general property of concurrent research, not a
 target-specific benchmark rule. A changed base does not cancel an in-flight

--- a/senpai_agent/github/mailbox/advisor.py
+++ b/senpai_agent/github/mailbox/advisor.py
@@ -58,21 +58,37 @@ def advisor_events(
             for student in students:
                 active_by_student.setdefault(student, []).append(number)
         payload = pull_payload(pull)
-        if "status:review" in labels:
-            events.append(
-                ControllerEvent(
-                    kind="review_ready",
-                    dedupe_key=f"review_ready:{number}:{head_sha}",
-                    payload=payload,
-                )
-            )
+        assignment = None
         if {"status:wip", "status:review"} & labels:
             try:
-                assignments = parse_assignment_markers(str(pull.get("body") or ""))
+                assignments = parse_assignment_markers(
+                    str(pull.get("body") or "")
+                )
             except ValueError:
                 assignments = []
             if len(assignments) == 1:
-                active_assignments.append((pull, assignments[0]))
+                assignment = assignments[0]
+                active_assignments.append((pull, assignment))
+        if "status:review" in labels:
+            dedupe_key = f"review_ready:{number}:{head_sha}"
+            review_payload = payload
+            if assignment is not None:
+                dedupe_key = (
+                    f"review_ready:{number}:{assignment.assignment_id}:"
+                    f"{assignment.revision_id}:{head_sha}"
+                )
+                review_payload = {
+                    **payload,
+                    "assignment_id": assignment.assignment_id,
+                    "revision_id": assignment.revision_id,
+                }
+            events.append(
+                ControllerEvent(
+                    kind="review_ready",
+                    dedupe_key=dedupe_key,
+                    payload=review_payload,
+                )
+            )
         reasons: list[str] = []
         if "status:blocked" in labels:
             reasons.append("blocked")

--- a/senpai_agent/github/mailbox/advisor.py
+++ b/senpai_agent/github/mailbox/advisor.py
@@ -14,6 +14,7 @@ from senpai_agent.models import (
     AssignmentRecord,
     ResearchBaseAcceptanceRecord,
     ResultMarkerError,
+    authoritative_marker_line,
     experiment_result_digest,
     parse_assignment_markers,
     parse_research_base_acceptance_markers,
@@ -234,22 +235,22 @@ def has_research_base_acceptance(
             continue
         if author.casefold() != actor.casefold():
             continue
-        for line in str(comment.get("body") or "").splitlines():
-            try:
-                results = parse_result_markers(line)
-            except ResultMarkerError:
-                continue
-            result_digests.extend(
-                experiment_result_digest(result)
-                for result in results
-                if result_matches_assignment(
-                    result,
-                    repo=mailbox.repo,
-                    pr_number=int(pull["number"]),
-                    assignment=assignment,
-                    head_sha=head_sha,
-                )
+        first_line = authoritative_marker_line(str(comment.get("body") or ""))
+        try:
+            results = parse_result_markers(first_line)
+        except ResultMarkerError:
+            continue
+        result_digests.extend(
+            experiment_result_digest(result)
+            for result in results
+            if result_matches_assignment(
+                result,
+                repo=mailbox.repo,
+                pr_number=int(pull["number"]),
+                assignment=assignment,
+                head_sha=head_sha,
             )
+        )
     distinct_result_digests = set(result_digests)
     if len(distinct_result_digests) != 1:
         return False
@@ -273,7 +274,7 @@ def has_research_base_acceptance(
             continue
         try:
             acceptances = parse_research_base_acceptance_markers(
-                str(comment.get("body") or "")
+                authoritative_marker_line(str(comment.get("body") or ""))
             )
         except ValueError:
             continue

--- a/senpai_agent/github/tools/runtime.py
+++ b/senpai_agent/github/tools/runtime.py
@@ -165,6 +165,19 @@ class SubmitExperimentResultExecutor(
                     expected_result_head_sha=commit_sha,
                     result=action.result,
                 )
+                git_workflow.require_commit_contains_base(
+                    self.runtime.workspace,
+                    commit_sha=commit_sha,
+                    base_sha=preflight.assignment.base_sha,
+                )
+                git_workflow.push_assignment_branch(
+                    self.runtime.workspace,
+                    branch=action.branch,
+                    expected_remote_sha=action.remote_branch_sha_before_push,
+                    expected_local_sha=commit_sha,
+                    token=self.runtime.git_token,
+                )
+                result = self._submit_after_push(number, action.result)
             except StaleAssignmentRevisionError as error:
                 if conversation is not None:
                     conversation.state.execution_status = (
@@ -174,19 +187,6 @@ class SubmitExperimentResultExecutor(
                     f"{error} Ending this stale turn so the controller can resume "
                     "the current assignment revision."
                 ) from error
-            git_workflow.require_commit_contains_base(
-                self.runtime.workspace,
-                commit_sha=commit_sha,
-                base_sha=preflight.assignment.base_sha,
-            )
-            git_workflow.push_assignment_branch(
-                self.runtime.workspace,
-                branch=action.branch,
-                expected_remote_sha=action.remote_branch_sha_before_push,
-                expected_local_sha=commit_sha,
-                token=self.runtime.git_token,
-            )
-            result = self._submit_after_push(number, action.result)
             return GitHubMutationObservation.from_result(result)
 
     def _submit_after_push(

--- a/senpai_agent/github/tools/runtime.py
+++ b/senpai_agent/github/tools/runtime.py
@@ -110,6 +110,17 @@ class GitHubToolRuntime:
                 f"student {student!r} is outside this launch; choose one of: {allowed}"
             )
 
+    def require_current_student(self, student: str) -> None:
+        """Bind a submitted result to this student runtime."""
+
+        if self.role != "student" or not self.student_name:
+            raise RuntimeError("submit_experiment_result requires a student name")
+        if student != self.student_name:
+            raise PermissionError(
+                f"result student {student!r} does not match this runtime's "
+                f"student {self.student_name!r}"
+            )
+
     def human_issue_audience(self) -> set[str]:
         """Return the only Issue audience labels this role may answer."""
 
@@ -142,6 +153,7 @@ class SubmitExperimentResultExecutor(
         action: SubmitExperimentResultAction,
         conversation: LocalConversation | None = None,
     ) -> GitHubMutationObservation:
+        self.runtime.require_current_student(action.result.assignment.student)
         number = action.result.assignment.pr_number
         commit_sha = action.result.commit_sha
         with self.runtime.workflow.serialized_assignment_mutation():

--- a/senpai_agent/github/workflow/assignments.py
+++ b/senpai_agent/github/workflow/assignments.py
@@ -185,6 +185,7 @@ class AssignmentMixin:
             result = self._require_result(
                 number,
                 assignment_id=assignment_id,
+                revision_id=current_revision_id,
                 expected_head_sha=expected_head_sha,
             )
             require_assignment_result(before, result)

--- a/senpai_agent/github/workflow/comments.py
+++ b/senpai_agent/github/workflow/comments.py
@@ -18,12 +18,15 @@ from senpai_agent.github.workflow.text import role_prefixed_comment
 from senpai_agent.github.workflow.validation import (
     distinct_results,
     positive_number,
+    require_assignment_result,
+    require_open,
     require_result_identity,
 )
 from senpai_agent.models import (
     ExperimentResult,
     ResearchBaseAcceptanceRecord,
     ResultMarkerError,
+    authoritative_marker_line,
     experiment_result_digest,
     parse_research_base_acceptance_markers,
     parse_result_markers,
@@ -57,56 +60,40 @@ class CommentsMixin:
     ) -> tuple[bool, IssueComment]:
         assignment_id = result.assignment.assignment_id
         body = role_prefixed_comment(render_result_comment(result), self._role)
-        existing = self._result_comments(number, assignment_id)
+        existing = tuple(
+            match
+            for match in self._result_comments(number, assignment_id)
+            if _same_result_version(match.result, result)
+        )
+        requested_digest = experiment_result_digest(result)
         distinct = distinct_results(existing)
         if len(distinct) > 1:
             raise ReconciliationError(
-                f"GitHub contains multiple distinct result markers for "
-                f"{assignment_id!r}"
+                "GitHub contains multiple distinct result markers for the "
+                "same assignment revision and head"
             )
-        if distinct:
-            published = distinct[0]
-            if experiment_result_digest(published) == experiment_result_digest(result):
-                comments = {match.comment.id: match.comment for match in existing}
-                changed = False
-                for comment in comments.values():
-                    if comment.body == body:
-                        continue
-                    self._mutate(
-                        "PATCH",
-                        f"/repos/{self._repo}/issues/comments/{comment.id}",
-                        json_body={"body": body},
-                        expected_statuses={200},
-                    )
-                    changed = True
-                if not changed:
-                    return False, existing[0].comment
-                verified = self._result_comments(number, assignment_id)
-                if not verified or any(
-                    match.comment.body != body for match in verified
-                ):
-                    raise ReconciliationError(
-                        "GitHub did not normalize the terminal result comment"
-                    )
-                return True, verified[0].comment
-            if (
-                published.assignment.revision_id == result.assignment.revision_id
-                and published.assignment.expected_head_sha
-                == result.assignment.expected_head_sha
-            ):
-                raise WorkflowPreconditionError(
-                    "a published terminal result is immutable at the same "
-                    "assignment revision and head; use a new revision or head"
-                )
-            comments = {match.comment.id: match.comment for match in existing}
+        if distinct and experiment_result_digest(distinct[0]) != requested_digest:
+            raise WorkflowPreconditionError(
+                "a published terminal result is immutable at the same "
+                "assignment revision and head; use a new revision or head"
+            )
+
+        comments = {match.comment.id: match.comment for match in existing}
+        changed = not comments
+        if comments:
             for comment in comments.values():
+                if comment.body == body:
+                    continue
+                self._require_result_still_current(number, result)
                 self._mutate(
                     "PATCH",
                     f"/repos/{self._repo}/issues/comments/{comment.id}",
                     json_body={"body": body},
                     expected_statuses={200},
                 )
+                changed = True
         else:
+            self._require_result_still_current(number, result)
             self._mutate(
                 "POST",
                 f"/repos/{self._repo}/issues/{number}/comments",
@@ -114,17 +101,33 @@ class CommentsMixin:
                 expected_statuses={201},
             )
 
-        verified = self._result_comments(number, assignment_id)
+        verified = tuple(
+            match
+            for match in self._result_comments(number, assignment_id)
+            if _same_result_version(match.result, result)
+        )
         verified_distinct = distinct_results(verified)
         if (
             len(verified_distinct) != 1
-            or experiment_result_digest(verified_distinct[0])
-            != experiment_result_digest(result)
+            or experiment_result_digest(verified_distinct[0]) != requested_digest
+            or any(match.comment.body != body for match in verified)
         ):
             raise ReconciliationError(
                 "GitHub did not reach the requested terminal result"
             )
-        return True, verified[0].comment
+        return changed, verified[0].comment
+
+    def _require_result_still_current(
+        self,
+        number: int,
+        result: ExperimentResult,
+    ) -> None:
+        current = self._pull_at_head(
+            number,
+            result.assignment.expected_head_sha,
+        )
+        require_open(current)
+        require_assignment_result(current, result)
 
     def _upsert_comment(
         self,
@@ -172,16 +175,17 @@ class CommentsMixin:
         for comment in self._comments(number):
             if comment.author.casefold() != trusted_actor.casefold():
                 continue
-            for line in comment.body.splitlines():
-                try:
-                    results = parse_result_markers(line)
-                except ResultMarkerError:
-                    continue
-                matches.extend(
-                    ResultComment(comment=comment, result=result)
-                    for result in results
-                    if result.assignment.assignment_id == assignment_id
+            try:
+                results = parse_result_markers(
+                    authoritative_marker_line(comment.body)
                 )
+            except ResultMarkerError:
+                continue
+            matches.extend(
+                ResultComment(comment=comment, result=result)
+                for result in results
+                if result.assignment.assignment_id == assignment_id
+            )
         return tuple(matches)
 
     def _research_base_acceptances(
@@ -195,7 +199,9 @@ class CommentsMixin:
                 continue
             try:
                 acceptances.extend(
-                    parse_research_base_acceptance_markers(comment.body)
+                    parse_research_base_acceptance_markers(
+                        authoritative_marker_line(comment.body)
+                    )
                 )
             except ValueError:
                 continue
@@ -217,12 +223,19 @@ class CommentsMixin:
         number: int,
         *,
         assignment_id: str,
+        revision_id: str,
         expected_head_sha: str,
     ) -> ExperimentResult:
-        matches = self._result_comments(number, assignment_id)
+        matches = tuple(
+            match
+            for match in self._result_comments(number, assignment_id)
+            if match.result.assignment.revision_id == revision_id
+            and match.result.assignment.expected_head_sha == expected_head_sha
+        )
         if not matches:
             raise WorkflowPreconditionError(
-                f"schema-valid terminal result for {assignment_id!r} is missing"
+                "schema-valid terminal result for assignment "
+                f"{assignment_id!r} revision {revision_id!r} is missing"
             )
         distinct = distinct_results(matches)
         if len(distinct) > 1:
@@ -249,7 +262,7 @@ class CommentsMixin:
             comment
             for comment in self._comments(number)
             if comment.author.casefold() == trusted_actor.casefold()
-            and marker in comment.body.splitlines()
+            and authoritative_marker_line(comment.body) == marker
         )
 
     def _comments(self, number: int) -> tuple[IssueComment, ...]:
@@ -279,3 +292,9 @@ class CommentsMixin:
                     "GitHub pagination returned an unexpected origin"
                 )
         return tuple(comments)
+
+
+def _same_result_version(first: ExperimentResult, second: ExperimentResult) -> bool:
+    return first.assignment.revision_id == second.assignment.revision_id and (
+        first.assignment.expected_head_sha == second.assignment.expected_head_sha
+    )

--- a/senpai_agent/github/workflow/core.py
+++ b/senpai_agent/github/workflow/core.py
@@ -92,7 +92,6 @@ class WorkflowCore:
     @contextmanager
     def serialized_assignment_mutation(self) -> Iterator[None]:
         """Serialize a coupled local mutation with this workflow's transitions.
-
         This closes races among Senpai operations sharing this workflow instance.
         GitHub's merge API has no base-SHA compare-and-swap; external writers still
         require strict branch protection or a merge queue.
@@ -202,6 +201,10 @@ class WorkflowCore:
             mutation_payload,
             f"GraphQL {mutation} result",
         )
+        if mutation_result.pull_request.id != snapshot.node_id:
+            raise ReconciliationError(
+                f"GitHub GraphQL {mutation} returned the wrong pull request"
+            )
         if mutation_result.pull_request.is_draft is not draft:
             raise ReconciliationError(
                 f"GitHub GraphQL {mutation} returned the wrong draft state"
@@ -276,7 +279,7 @@ class WorkflowCore:
         method: str,
         url: str,
         *,
-        json_body: object,
+        json_body: object | None,
         expected_statuses: set[int],
     ) -> HttpResponse | None:
         """Issue a mutation; an ambiguous transport failure is verified by caller."""

--- a/senpai_agent/github/workflow/issues.py
+++ b/senpai_agent/github/workflow/issues.py
@@ -26,6 +26,24 @@ class HumanIssueMixin:
     ) -> MutationResult:
         """Reply once to one verified human-authored GitHub issue message."""
 
+        with self._assignment_lifecycle_lock:
+            return self._respond_to_issue(
+                number,
+                human_message_id=human_message_id,
+                audience_labels=audience_labels,
+                responder=responder,
+                response=response,
+            )
+
+    def _respond_to_issue(
+        self,
+        number: int,
+        *,
+        human_message_id: int,
+        audience_labels: set[str],
+        responder: str,
+        response: str,
+    ) -> MutationResult:
         number = positive_number(number)
         human_message_id = positive_message_id(human_message_id)
         body = response.strip()
@@ -55,9 +73,7 @@ class HumanIssueMixin:
                 "human message must not be authored by the authenticated actor"
             )
 
-        marker = (
-            f"<!-- senpai-human-response:{responder_key}:{human_message_id} -->"
-        )
+        marker = f"<!-- senpai-human-response:{responder_key}:{human_message_id} -->"
         comment_body = marker_body(marker, body)
         changed, verified = self._upsert_marker_comment(
             number,

--- a/senpai_agent/github/workflow/merge.py
+++ b/senpai_agent/github/workflow/merge.py
@@ -59,6 +59,7 @@ class MergeMixin:
         terminal_result = self._require_result(
             number,
             assignment_id=assignment_id,
+            revision_id=current_revision_id,
             expected_head_sha=expected_head_sha,
         )
         assignment = require_assignment_result(before, terminal_result)
@@ -134,6 +135,7 @@ class MergeMixin:
             self._require_result(
                 number,
                 assignment_id=assignment_id,
+                revision_id=current_revision_id,
                 expected_head_sha=expected_head_sha,
             ),
             phase="immediately before merge",
@@ -153,6 +155,7 @@ class MergeMixin:
             self._require_result(
                 number,
                 assignment_id=assignment_id,
+                revision_id=current_revision_id,
                 expected_head_sha=expected_head_sha,
             ),
             phase="immediately after merge",
@@ -169,6 +172,7 @@ class MergeMixin:
             self._require_result(
                 number,
                 assignment_id=assignment_id,
+                revision_id=current_revision_id,
                 expected_head_sha=expected_head_sha,
             ),
             phase="final merge reconciliation",

--- a/senpai_agent/github/workflow/responses.py
+++ b/senpai_agent/github/workflow/responses.py
@@ -197,6 +197,7 @@ class IssueSearchResponse(NumberedResponse):
 
 
 class DraftPullRequestResponse(GitHubResponse):
+    id: RequiredString
     is_draft: StrictBool = Field(alias="isDraft")
 
 

--- a/senpai_agent/github/workflow/results.py
+++ b/senpai_agent/github/workflow/results.py
@@ -82,17 +82,17 @@ class ResultMixin:
         result_changed, _ = self._upsert_result_comment(number, result=result)
         current = self._pull_at_head(number, expected_head_sha)
         require_open(current)
-        require_assignment_result(current, result)
-        ready_changed = self._set_draft(current, draft=False)
-        labels_changed, desired_labels = self._set_labels(
-            number,
-            current,
-            add={"status:review"},
-            remove={"status:wip"},
-        )
-        after = self._pull_at_head(number, expected_head_sha)
-        require_open(after)
         try:
+            require_assignment_result(current, result)
+            ready_changed = self._set_draft(current, draft=False)
+            labels_changed, desired_labels = self._set_labels(
+                number,
+                current,
+                add={"status:review"},
+                remove={"status:wip"},
+            )
+            after = self._pull_at_head(number, expected_head_sha)
+            require_open(after)
             require_assignment_result(after, result)
         except StaleAssignmentRevisionError:
             self._reconcile_current_result_routing(

--- a/senpai_agent/github/workflow/results.py
+++ b/senpai_agent/github/workflow/results.py
@@ -11,12 +11,13 @@ from senpai_agent.github.workflow.responses import (
     SubmitResultPreflight,
 )
 from senpai_agent.github.workflow.validation import (
+    require_assignment_identity,
     require_assignment_result,
     require_label_update,
     require_open,
     require_result_identity,
 )
-from senpai_agent.models import ExperimentResult
+from senpai_agent.models import AssignmentRecord, ExperimentResult
 
 
 class ResultMixin:
@@ -94,11 +95,10 @@ class ResultMixin:
         try:
             require_assignment_result(after, result)
         except StaleAssignmentRevisionError:
-            self._recover_stale_submit_routing(
+            self._reconcile_current_result_routing(
                 number,
                 assignment_id=result.assignment.assignment_id,
                 expected_head_sha=expected_head_sha,
-                stale_result=result,
             )
             raise
         if after.draft:
@@ -117,16 +117,16 @@ class ResultMixin:
             version=after.head_sha,
         )
 
-    def _recover_stale_submit_routing(
+    def _reconcile_current_result_routing(
         self,
         number: int,
         *,
         assignment_id: str,
         expected_head_sha: str,
-        stale_result: ExperimentResult,
-    ) -> None:
-        """Undo stale review routing without clobbering newer valid evidence."""
+    ) -> tuple[PullRequestSnapshot, AssignmentRecord, bool, bool]:
+        """Route the current assignment from its current durable result."""
 
+        changed = False
         for _attempt in range(3):
             current, assignment = self._assigned_pull_at_head(
                 number,
@@ -134,58 +134,57 @@ class ResultMixin:
                 expected_head_sha=expected_head_sha,
             )
             require_open(current)
-            if assignment.revision_id == stale_result.assignment.revision_id:
-                return
-            if self._has_result_for_snapshot(current, assignment_id):
-                return
-
-            self._set_draft(current, draft=True)
+            has_result = self._has_result_for_snapshot(current, assignment_id)
+            changed |= self._set_draft(current, draft=not has_result)
             current, refreshed = self._assigned_pull_at_head(
                 number,
                 assignment_id=assignment_id,
                 expected_head_sha=expected_head_sha,
             )
+            require_open(current)
             if refreshed != assignment:
                 continue
-            if self._has_result_for_snapshot(current, assignment_id):
-                self._restore_current_result_review(
-                    current,
-                    assignment_id=assignment_id,
-                    expected_head_sha=expected_head_sha,
-                )
-                return
+            if self._has_result_for_snapshot(current, assignment_id) is not has_result:
+                continue
 
-            self._set_labels(
+            labels_changed, _ = self._set_labels(
                 number,
                 current,
-                add={"status:wip"},
-                remove={"status:review"},
+                add={"status:review" if has_result else "status:wip"},
+                remove={"status:wip" if has_result else "status:review"},
             )
+            changed |= labels_changed
             after, verified = self._assigned_pull_at_head(
                 number,
                 assignment_id=assignment_id,
                 expected_head_sha=expected_head_sha,
             )
+            require_open(after)
             if verified != assignment:
                 continue
-            if self._has_result_for_snapshot(after, assignment_id):
-                self._restore_current_result_review(
-                    after,
-                    assignment_id=assignment_id,
-                    expected_head_sha=expected_head_sha,
-                )
-                return
-            if (
+            if self._has_result_for_snapshot(after, assignment_id) is not has_result:
+                continue
+            if has_result:
+                if (
+                    after.draft
+                    or "status:review" not in after.labels
+                    or "status:wip" in after.labels
+                ):
+                    raise ReconciliationError(
+                        "current-revision result did not remain reviewable during "
+                        "current-assignment routing"
+                    )
+            elif not (
                 after.draft
                 and "status:wip" in after.labels
                 and "status:review" not in after.labels
             ):
-                return
-            raise ReconciliationError(
-                "GitHub did not restore the current assignment revision to WIP"
-            )
+                raise ReconciliationError(
+                    "GitHub did not restore the current assignment revision to WIP"
+                )
+            return after, verified, has_result, changed
         raise ReconciliationError(
-            "assignment revision kept changing during stale-submit recovery"
+            "assignment or result kept changing during current-assignment routing"
         )
 
     def _has_result_for_snapshot(
@@ -213,33 +212,30 @@ class ResultMixin:
         *,
         assignment_id: str,
         expected_head_sha: str,
-    ) -> None:
+    ) -> bool:
         """Keep a concurrently submitted current-revision result reviewable."""
 
-        self._set_draft(snapshot, draft=False)
-        current, assignment = self._assigned_pull_at_head(
-            snapshot.number,
+        expected_assignment = require_assignment_identity(
+            snapshot,
+            repo=self._repo,
             assignment_id=assignment_id,
-            expected_head_sha=expected_head_sha,
         )
-        if not self._has_result_for_snapshot(current, assignment_id):
-            raise ReconciliationError(
-                "current-revision result disappeared during stale-submit recovery"
+        after, verified, has_result, changed = (
+            self._reconcile_current_result_routing(
+                snapshot.number,
+                assignment_id=assignment_id,
+                expected_head_sha=expected_head_sha,
             )
-        self._set_labels(
-            snapshot.number,
-            current,
-            add={"status:review"},
-            remove={"status:wip"},
         )
-        after, verified = self._assigned_pull_at_head(
-            snapshot.number,
-            assignment_id=assignment_id,
-            expected_head_sha=expected_head_sha,
-        )
-        if verified != assignment or not self._has_result_for_snapshot(
-            after, assignment_id
+        if (
+            verified != expected_assignment
+            or not has_result
+            or after.draft
+            or "status:review" not in after.labels
+            or "status:wip" in after.labels
         ):
             raise ReconciliationError(
-                "current-revision result changed during stale-submit recovery"
+                "current-revision result did not remain reviewable during "
+                "current-assignment routing"
             )
+        return changed

--- a/senpai_agent/github/workflow/review.py
+++ b/senpai_agent/github/workflow/review.py
@@ -52,6 +52,7 @@ class ReviewMixin:
             result = self._require_result(
                 number,
                 assignment_id=assignment_id,
+                revision_id=current_revision_id,
                 expected_head_sha=expected_head_sha,
             )
             require_assignment_result(before, result)
@@ -88,6 +89,7 @@ class ReviewMixin:
             current_result = self._require_result(
                 number,
                 assignment_id=assignment_id,
+                revision_id=current_revision_id,
                 expected_head_sha=expected_head_sha,
             )
             require_assignment_result(after, current_result)

--- a/senpai_agent/github/workflow/revisions.py
+++ b/senpai_agent/github/workflow/revisions.py
@@ -15,7 +15,6 @@ from senpai_agent.github.workflow.text import (
 from senpai_agent.github.workflow.validation import (
     require_active_assignment_routing,
     require_current_revision,
-    require_label_update,
     require_open,
 )
 from senpai_agent.models import (
@@ -78,6 +77,7 @@ class RevisionMixin:
                     f"required research base {assignment.base_ref}@"
                     f"{required_base_sha} does not match live {live_base_sha}"
                 )
+            applied_revision = False
         elif not (
             assignment.revision_id == new_revision_id
             and assignment.base_sha == required_base_sha
@@ -85,6 +85,21 @@ class RevisionMixin:
             raise StaleAssignmentRevisionError(
                 f"assignment revision is {assignment.revision_id!r}, expected "
                 f"current {current_revision_id!r} or applied {new_revision_id!r}"
+            )
+        else:
+            applied_revision = True
+
+        if applied_revision and self._has_result_for_snapshot(before, assignment_id):
+            routing_changed = self._restore_current_result_review(
+                before,
+                assignment_id=assignment_id,
+                expected_head_sha=expected_head_sha,
+            )
+            return MutationResult(
+                changed=routing_changed,
+                resource_url=before.url,
+                state="revision_requested",
+                version=before.head_sha,
             )
         conflicts = tuple(
             active_number
@@ -137,29 +152,19 @@ class RevisionMixin:
             marker=marker,
             body=rendered_comment,
         )
-        draft_changed = self._set_draft(current, draft=True)
-        labels_changed, desired_labels = self._set_labels(
-            number,
-            current,
-            add={"status:wip"},
-            remove={"status:review"},
-        )
-        after = self._pull_at_head(number, expected_head_sha)
-        require_open(after)
-        if not after.draft:
-            raise ReconciliationError(
-                "GitHub did not convert the pull request to draft"
+        after, current_assignment, _has_result, routing_changed = (
+            self._reconcile_current_result_routing(
+                number,
+                assignment_id=assignment_id,
+                expected_head_sha=expected_head_sha,
             )
-        require_label_update(
-            after,
-            required=desired_labels,
-            forbidden={"status:review"},
         )
+        if current_assignment != revised_assignment:
+            raise ReconciliationError(
+                "assignment revision changed while routing the revision request"
+            )
         return MutationResult(
-            changed=assignment_changed
-            or marker_changed
-            or draft_changed
-            or labels_changed,
+            changed=assignment_changed or marker_changed or routing_changed,
             resource_url=after.url,
             state="revision_requested",
             version=after.head_sha,

--- a/senpai_agent/github/workflow/revisions.py
+++ b/senpai_agent/github/workflow/revisions.py
@@ -89,14 +89,34 @@ class RevisionMixin:
         else:
             applied_revision = True
 
+        marker = render_revision_marker(
+            RevisionRecord(
+                repo=self._repo,
+                pr_number=number,
+                assignment_id=assignment.assignment_id,
+                revision_id=new_revision_id,
+                requested_head_sha=expected_head_sha,
+            )
+        )
+        rendered_comment = marker_body(marker, comment)
+        marker_comments = self._marker_comments(number, marker)
+        if len(marker_comments) > 1:
+            raise ReconciliationError(
+                f"GitHub contains multiple comments for marker {marker!r}"
+            )
         if applied_revision and self._has_result_for_snapshot(before, assignment_id):
+            marker_changed, _ = self._upsert_marker_comment(
+                number,
+                marker=marker,
+                body=rendered_comment,
+            )
             routing_changed = self._restore_current_result_review(
                 before,
                 assignment_id=assignment_id,
                 expected_head_sha=expected_head_sha,
             )
             return MutationResult(
-                changed=routing_changed,
+                changed=marker_changed or routing_changed,
                 resource_url=before.url,
                 state="revision_requested",
                 version=before.head_sha,
@@ -112,21 +132,6 @@ class RevisionMixin:
             raise WorkflowPreconditionError(
                 f"student:{assignment.student} already has active assignment "
                 f"PR(s): {', '.join(f'#{active_number}' for active_number in conflicts)}"
-            )
-        marker = render_revision_marker(
-            RevisionRecord(
-                repo=self._repo,
-                pr_number=number,
-                assignment_id=assignment.assignment_id,
-                revision_id=new_revision_id,
-                requested_head_sha=expected_head_sha,
-            )
-        )
-        rendered_comment = marker_body(marker, comment)
-        marker_comments = self._marker_comments(number, marker)
-        if len(marker_comments) > 1:
-            raise ReconciliationError(
-                f"GitHub contains multiple comments for marker {marker!r}"
             )
         revised_assignment = assignment.model_copy(
             update={

--- a/senpai_agent/github/workflow/text.py
+++ b/senpai_agent/github/workflow/text.py
@@ -21,7 +21,7 @@ def marker_body(marker: str, content: str) -> str:
 
 def _quote_senpai_marker_lines(content: str) -> str:
     return "\n".join(
-        f"> {line}" if line.startswith("<!-- senpai-") else line
+        f"> {line}" if line.lstrip().startswith("<!-- senpai-") else line
         for line in content.splitlines()
     )
 
@@ -65,7 +65,9 @@ def _validate_marker(marker: str, body: str) -> None:
     ):
         raise ValueError("marker must be one hidden Senpai marker")
     protocol_lines = [
-        line for line in body.splitlines() if line.startswith("<!-- senpai-")
+        line
+        for line in body.splitlines()
+        if line.lstrip().startswith("<!-- senpai-")
     ]
     if protocol_lines != [marker]:
         raise ValueError("comment body must contain exactly its intended marker")

--- a/senpai_agent/github/workflow/text.py
+++ b/senpai_agent/github/workflow/text.py
@@ -64,5 +64,8 @@ def _validate_marker(marker: str, body: str) -> None:
         or not marker.endswith("-->")
     ):
         raise ValueError("marker must be one hidden Senpai marker")
-    if body.splitlines().count(marker) != 1:
-        raise ValueError("comment body must contain the marker exactly once")
+    protocol_lines = [
+        line for line in body.splitlines() if line.startswith("<!-- senpai-")
+    ]
+    if protocol_lines != [marker]:
+        raise ValueError("comment body must contain exactly its intended marker")

--- a/senpai_agent/models.py
+++ b/senpai_agent/models.py
@@ -369,7 +369,7 @@ def render_result_marker(result: ExperimentResult) -> str:
 
 def _quote_senpai_marker_lines(value: str) -> str:
     return "\n".join(
-        f"> {line}" if line.startswith("<!-- senpai-") else line
+        f"> {line}" if line.lstrip().startswith("<!-- senpai-") else line
         for line in value.splitlines()
     )
 

--- a/senpai_agent/models.py
+++ b/senpai_agent/models.py
@@ -263,6 +263,12 @@ def render_assignment_marker(assignment: AssignmentRecord) -> str:
     return f"<!-- senpai-assignment:v1 {_marker_payload(assignment)} -->"
 
 
+def authoritative_marker_line(comment_body: str) -> str:
+    """Return the only logical line eligible to carry a trusted marker."""
+
+    return next(iter(comment_body.splitlines()), "")
+
+
 def render_revision_marker(revision: RevisionRecord) -> str:
     return f"<!-- senpai-revision:v1 {_marker_payload(revision)} -->"
 

--- a/tests/github_workflow_support.py
+++ b/tests/github_workflow_support.py
@@ -179,14 +179,18 @@ class FakeGitHub:
         issue: dict[str, object] | None = None,
         comment_page_size: int = 100,
         ignore_label_mutations: bool = False,
+        ignore_draft_mutations: bool = False,
         branch_heads: dict[str, str] | None = None,
+        actor_login: str = "senpai-bot",
     ):
         self.pr = pr
         self.comments = list(comments or [])
         self.issue = issue
         self.comment_page_size = comment_page_size
         self.ignore_label_mutations = ignore_label_mutations
+        self.ignore_draft_mutations = ignore_draft_mutations
         self.branch_heads = branch_heads or {str(pr["base_ref"]): BASE_SHA}
+        self.actor_login = actor_login
         self.requests: list[tuple[str, str, object | None, dict[str, str]]] = []
 
     @property
@@ -215,6 +219,9 @@ class FakeGitHub:
         issue_path = f"/repos/{REPO}/issues/7"
         comments_path = f"/repos/{REPO}/issues/7/comments"
         labels_path = f"/repos/{REPO}/issues/7/labels"
+
+        if method == "GET" and path == "/user":
+            return HttpResponse(200, {"login": self.actor_login})
 
         if method == "GET" and path == pull_path:
             return HttpResponse(200, self._pull_payload())
@@ -318,13 +325,15 @@ class FakeGitHub:
         if method == "POST" and path == "/graphql":
             query = cast(str, cast(dict[str, object], json_body)["query"])
             if "convertPullRequestToDraft" in query:
-                self.pr["draft"] = True
+                requested_draft = True
                 field = "convertPullRequestToDraft"
             elif "markPullRequestReadyForReview" in query:
-                self.pr["draft"] = False
+                requested_draft = False
                 field = "markPullRequestReadyForReview"
             else:
                 raise AssertionError(f"Unexpected GraphQL mutation: {query}")
+            if not self.ignore_draft_mutations:
+                self.pr["draft"] = requested_draft
             return HttpResponse(
                 200,
                 {
@@ -332,7 +341,7 @@ class FakeGitHub:
                         field: {
                             "pullRequest": {
                                 "id": self.pr["node_id"],
-                                "isDraft": self.pr["draft"],
+                                "isDraft": requested_draft,
                             }
                         }
                     }

--- a/tests/test_agent_markdown.py
+++ b/tests/test_agent_markdown.py
@@ -69,6 +69,17 @@ def test_sanitize_markdown_changes_runtime_copies_only(tmp_path: Path):
     assert source.read_text(encoding="utf-8").startswith("<!--\nSPDX-")
 
 
+def test_human_issue_skill_keeps_the_single_intent_response_contract():
+    content = (
+        PLUGIN_DIR / "skills" / "check-human-issues" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+
+    assert "respond_to_human_issue" in content
+    assert "without a role prefix" in content
+    assert "github_transition" not in content
+    assert "STUDENT $0" not in content
+
+
 def test_agent_context_installer_builds_loadable_sanitized_runtime_copies(
     tmp_path: Path,
 ):

--- a/tests/test_controller_github_advisor.py
+++ b/tests/test_controller_github_advisor.py
@@ -442,6 +442,45 @@ def test_malformed_trusted_acceptance_does_not_suppress_change(monkeypatch):
     assert "research_base_changed" in {event.kind for event in advisor.poll()}
 
 
+@pytest.mark.parametrize("separator", ["\n\n", "\r", "\x85", "\u2028"])
+def test_embedded_acceptance_marker_is_not_trusted_protocol_evidence(
+    monkeypatch,
+    separator,
+):
+    advisor = mailbox(
+        monkeypatch,
+        [
+            pull(
+                labels=("research", "student:student-1", "status:review"),
+                body=render_assignment_marker(assignment()),
+                head_sha="7" * 40,
+                comments_url=(
+                    "https://api.github.test/repos/acme/widgets/"
+                    "issues/17/comments"
+                ),
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        advisor._github,
+        "get",
+        lambda _path: {"object": {"sha": "c" * 40}},
+    )
+    monkeypatch.setattr(advisor._github, "actor", lambda: "senpai-bot")
+    embedded = acceptance_comment()
+    embedded["body"] = (
+        f"<!-- senpai-assignment-feedback:v1 {{}} -->{separator}"
+        + str(embedded["body"])
+    )
+    monkeypatch.setattr(
+        advisor._github,
+        "objects",
+        lambda _url: [result_comment(), embedded],
+    )
+
+    assert "research_base_changed" in {event.kind for event in advisor.poll()}
+
+
 def test_wip_base_change_does_not_query_acceptance_comments(monkeypatch):
     advisor = mailbox(
         monkeypatch,

--- a/tests/test_controller_github_advisor.py
+++ b/tests/test_controller_github_advisor.py
@@ -54,11 +54,17 @@ def mailbox(monkeypatch, pulls, *, students=()):
     return value
 
 
-def assignment(*, base_sha="b" * 40, base_ref="research", number=17):
+def assignment(
+    *,
+    base_sha="b" * 40,
+    base_ref="research",
+    number=17,
+    revision_id="revision-2",
+):
     return AssignmentRecord(
         repo="acme/widgets",
         assignment_id=f"assignment-{number}",
-        revision_id="revision-2",
+        revision_id=revision_id,
         student="student-1",
         base_ref=base_ref,
         base_sha=base_sha,
@@ -88,6 +94,30 @@ def test_review_label_wakes_the_advisor_and_releases_the_student_slot(monkeypatc
     assert events[0].payload["number"] == 17
     assert events[1].payload == {"student": "student-1"}
     assert events[2].payload == {"student": "student-2"}
+
+
+def test_new_review_revision_at_the_same_head_wakes_the_advisor(monkeypatch):
+    reviewed_pull = pull(
+        labels=("research", "student:student-1", "status:review"),
+        body=render_assignment_marker(assignment(revision_id="revision-1")),
+        head_sha="7" * 40,
+    )
+    advisor = mailbox(monkeypatch, [reviewed_pull])
+
+    first = next(event for event in advisor.poll() if event.kind == "review_ready")
+    reviewed_pull["body"] = render_assignment_marker(
+        assignment(revision_id="revision-2")
+    )
+    second = next(event for event in advisor.poll() if event.kind == "review_ready")
+
+    assert first.dedupe_key == (
+        f"review_ready:17:assignment-17:revision-1:{'7' * 40}"
+    )
+    assert second.dedupe_key == (
+        f"review_ready:17:assignment-17:revision-2:{'7' * 40}"
+    )
+    assert first.payload["revision_id"] == "revision-1"
+    assert second.payload["revision_id"] == "revision-2"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_github_workflow_assignment_messages.py
+++ b/tests/test_github_workflow_assignment_messages.py
@@ -13,7 +13,10 @@ from senpai_agent.models import (
     AssignmentFeedbackRecord,
     RevisionRecord,
     parse_assignment_markers,
+    render_assignment_marker,
     render_assignment_feedback_marker,
+    render_result_comment,
+    render_result_marker,
     render_revision_marker,
 )
 from github_workflow_support import (
@@ -22,7 +25,9 @@ from github_workflow_support import (
     HEAD_SHA,
     REPO,
     FakeGitHub,
+    assignment_record,
     comment,
+    experiment_result,
     pull_request,
     workflow,
 )
@@ -85,6 +90,257 @@ def test_request_revision_converges_marker_assignment_state_and_replays():
     assert fake.mutations == mutations_after_first
 
 
+def test_applied_revision_replay_preserves_a_submitted_current_result():
+    current = experiment_result()
+    current = current.model_copy(
+        update={
+            "assignment": current.assignment.model_copy(
+                update={"revision_id": "revision-2"}
+            )
+        }
+    )
+    fake = FakeGitHub(
+        pull_request(
+            labels={"student:one", "status:review"},
+            draft=False,
+            body=render_assignment_marker(
+                assignment_record(revision_id="revision-2")
+            ),
+        ),
+        comments=[comment(1, render_result_comment(current))],
+    )
+
+    replayed = request_revision(workflow(fake))
+
+    assert replayed.changed is False
+    assert fake.pr["draft"] is False
+    assert fake.pr["labels"] == {"student:one", "status:review"}
+    assert fake.mutations == []
+
+
+def test_applied_revision_replay_restores_drifted_result_routing():
+    current = experiment_result()
+    current = current.model_copy(
+        update={
+            "assignment": current.assignment.model_copy(
+                update={"revision_id": "revision-2"}
+            )
+        }
+    )
+    fake = FakeGitHub(
+        pull_request(
+            labels={"student:one", "status:wip"},
+            draft=True,
+            body=render_assignment_marker(
+                assignment_record(revision_id="revision-2")
+            ),
+        ),
+        comments=[comment(1, render_result_comment(current))],
+    )
+
+    replayed = request_revision(workflow(fake))
+
+    assert replayed.changed is True
+    assert fake.pr["draft"] is False
+    assert fake.pr["labels"] == {"student:one", "status:review"}
+
+
+def test_applied_revision_replay_repairs_a_newer_revision_before_failing():
+    current = experiment_result()
+    current = current.model_copy(
+        update={
+            "assignment": current.assignment.model_copy(
+                update={"revision_id": "revision-2"}
+            )
+        }
+    )
+
+    class AdvanceBeforeRestoreReady(FakeGitHub):
+        advanced = False
+
+        def request(self, method, url, *, headers, json_body=None):
+            if (
+                not self.advanced
+                and method == "POST"
+                and url.endswith("/graphql")
+                and "markPullRequestReadyForReview" in str(json_body)
+            ):
+                self.pr["body"] = render_assignment_marker(
+                    assignment_record(revision_id="revision-3")
+                )
+                self.advanced = True
+            return super().request(
+                method,
+                url,
+                headers=headers,
+                json_body=json_body,
+            )
+
+    fake = AdvanceBeforeRestoreReady(
+        pull_request(
+            labels={"student:one", "status:wip", "status:hold"},
+            draft=True,
+            body=render_assignment_marker(
+                assignment_record(revision_id="revision-2")
+            ),
+        ),
+        comments=[comment(1, render_result_comment(current))],
+    )
+
+    with pytest.raises(ReconciliationError, match="did not remain reviewable"):
+        request_revision(workflow(fake))
+
+    assert fake.pr["draft"] is True
+    assert fake.pr["labels"] == {
+        "student:one",
+        "status:wip",
+        "status:hold",
+    }
+    assert parse_assignment_markers(cast(str, fake.pr["body"]))[0].revision_id == (
+        "revision-3"
+    )
+
+
+def test_first_revision_request_preserves_a_result_arriving_after_assignment_patch():
+    current = experiment_result()
+    current = current.model_copy(
+        update={
+            "assignment": current.assignment.model_copy(
+                update={"revision_id": "revision-2"}
+            )
+        }
+    )
+
+    class ResultAfterAssignmentPatch(FakeGitHub):
+        published = False
+
+        def request(self, method, url, *, headers, json_body=None):
+            response = super().request(
+                method,
+                url,
+                headers=headers,
+                json_body=json_body,
+            )
+            if (
+                not self.published
+                and method == "PATCH"
+                and url.endswith("/pulls/7")
+            ):
+                self.comments.append(comment(2, render_result_comment(current)))
+                self.published = True
+            return response
+
+    fake = ResultAfterAssignmentPatch(
+        pull_request(labels={"student:one", "status:review"}, draft=False)
+    )
+
+    revised = request_revision(workflow(fake))
+
+    assert revised.changed is True
+    assert fake.pr["draft"] is False
+    assert fake.pr["labels"] == {"student:one", "status:review"}
+    assert parse_assignment_markers(cast(str, fake.pr["body"]))[0].revision_id == (
+        "revision-2"
+    )
+
+
+def test_applied_revision_replay_preserves_a_result_arriving_with_its_comment():
+    current = experiment_result()
+    current = current.model_copy(
+        update={
+            "assignment": current.assignment.model_copy(
+                update={"revision_id": "revision-2"}
+            )
+        }
+    )
+
+    class ResultDuringRevisionCommentGitHub(FakeGitHub):
+        published = False
+
+        def request(self, method, url, *, headers, json_body=None):
+            response = super().request(
+                method,
+                url,
+                headers=headers,
+                json_body=json_body,
+            )
+            if (
+                not self.published
+                and method == "POST"
+                and url.endswith("/issues/7/comments")
+            ):
+                self.comments.append(comment(2, render_result_comment(current)))
+                self.published = True
+            return response
+
+    fake = ResultDuringRevisionCommentGitHub(
+        pull_request(
+            labels={"student:one", "status:review"},
+            draft=False,
+            body=render_assignment_marker(
+                assignment_record(revision_id="revision-2")
+            ),
+        )
+    )
+
+    replayed = request_revision(workflow(fake))
+
+    assert replayed.changed is True
+    assert fake.pr["draft"] is False
+    assert fake.pr["labels"] == {"student:one", "status:review"}
+    assert len(fake.comments) == 2
+
+
+def test_applied_revision_replay_restores_a_result_arriving_during_demotion():
+    current = experiment_result()
+    current = current.model_copy(
+        update={
+            "assignment": current.assignment.model_copy(
+                update={"revision_id": "revision-2"}
+            )
+        }
+    )
+
+    class ResultDuringDemotionGitHub(FakeGitHub):
+        published = False
+
+        def request(self, method, url, *, headers, json_body=None):
+            response = super().request(
+                method,
+                url,
+                headers=headers,
+                json_body=json_body,
+            )
+            if (
+                not self.published
+                and method == "DELETE"
+                and url.endswith("/labels/status%3Areview")
+            ):
+                self.comments.append(comment(2, render_result_comment(current)))
+                self.published = True
+            return response
+
+    marker = revision_marker()
+    fake = ResultDuringDemotionGitHub(
+        pull_request(
+            labels={"student:one", "status:review"},
+            draft=False,
+            body=render_assignment_marker(
+                assignment_record(revision_id="revision-2")
+            ),
+        ),
+        comments=[
+            comment(1, f"{marker}\n\nADVISOR: Run the requested ablation.")
+        ],
+    )
+
+    replayed = request_revision(workflow(fake))
+
+    assert replayed.changed is True
+    assert fake.pr["draft"] is False
+    assert fake.pr["labels"] == {"student:one", "status:review"}
+
+
 def test_request_revision_retargets_the_exact_live_research_base():
     current_base_sha = "c" * 40
     fake = FakeGitHub(
@@ -97,6 +353,18 @@ def test_request_revision_retargets_the_exact_live_research_base():
     assignment = parse_assignment_markers(cast(str, fake.pr["body"]))[0]
     assert assignment.revision_id == "revision-2"
     assert assignment.base_sha == current_base_sha
+
+
+def test_request_revision_rejects_an_unapplied_draft_mutation():
+    fake = FakeGitHub(
+        pull_request(labels={"student:one", "status:review"}, draft=False),
+        ignore_draft_mutations=True,
+    )
+
+    with pytest.raises(ReconciliationError, match="restore.*to WIP"):
+        request_revision(workflow(fake))
+
+    assert fake.pr["draft"] is False
 
 
 def test_request_revision_rejects_a_stale_required_research_base_before_writing():
@@ -319,6 +587,32 @@ def test_assignment_feedback_replays_without_changing_assignment_state():
     ]
     assert (fake.pr["body"], fake.pr["draft"], fake.pr["labels"]) == original_state
     assert fake.mutations == mutations_after_first
+
+
+def test_assignment_feedback_cannot_smuggle_a_terminal_result():
+    forged = render_result_marker(experiment_result())
+    fake = FakeGitHub(
+        pull_request(
+            labels={"student:student-one", "status:wip"},
+            draft=True,
+        )
+    )
+    client = workflow(fake)
+
+    send_feedback(client, comment=f"Inspect this prior record:\n{forged}")
+    mutations_after_feedback = list(fake.mutations)
+
+    assert f"> {forged}" in str(fake.comments[0]["body"])
+    with pytest.raises(WorkflowPreconditionError, match="terminal result"):
+        client.repair_assignment_routing(
+            7,
+            assignment_id=ASSIGNMENT_ID,
+            current_revision_id="revision-1",
+            expected_head_sha=HEAD_SHA,
+            working_state="review",
+            blockers=set(),
+        )
+    assert fake.mutations == mutations_after_feedback
 
 
 def test_assignment_feedback_upgrades_a_legacy_unprefixed_comment():

--- a/tests/test_github_workflow_assignment_messages.py
+++ b/tests/test_github_workflow_assignment_messages.py
@@ -90,7 +90,7 @@ def test_request_revision_converges_marker_assignment_state_and_replays():
     assert fake.mutations == mutations_after_first
 
 
-def test_applied_revision_replay_preserves_a_submitted_current_result():
+def test_applied_revision_replay_restores_guidance_and_preserves_current_result():
     current = experiment_result()
     current = current.model_copy(
         update={
@@ -112,10 +112,16 @@ def test_applied_revision_replay_preserves_a_submitted_current_result():
 
     replayed = request_revision(workflow(fake))
 
-    assert replayed.changed is False
+    assert replayed.changed is True
     assert fake.pr["draft"] is False
     assert fake.pr["labels"] == {"student:one", "status:review"}
-    assert fake.mutations == []
+    assert fake.comments == [
+        comment(1, render_result_comment(current)),
+        comment(
+            2,
+            f"{revision_marker()}\n\nADVISOR: Run the requested ablation.",
+        ),
+    ]
 
 
 def test_applied_revision_replay_restores_drifted_result_routing():
@@ -589,7 +595,8 @@ def test_assignment_feedback_replays_without_changing_assignment_state():
     assert fake.mutations == mutations_after_first
 
 
-def test_assignment_feedback_cannot_smuggle_a_terminal_result():
+@pytest.mark.parametrize("indent", ["", "  "])
+def test_assignment_feedback_cannot_smuggle_a_terminal_result(indent):
     forged = render_result_marker(experiment_result())
     fake = FakeGitHub(
         pull_request(
@@ -599,10 +606,10 @@ def test_assignment_feedback_cannot_smuggle_a_terminal_result():
     )
     client = workflow(fake)
 
-    send_feedback(client, comment=f"Inspect this prior record:\n{forged}")
+    send_feedback(client, comment=f"Inspect this prior record:\n{indent}{forged}")
     mutations_after_feedback = list(fake.mutations)
 
-    assert f"> {forged}" in str(fake.comments[0]["body"])
+    assert f"> {indent}{forged}" in str(fake.comments[0]["body"])
     with pytest.raises(WorkflowPreconditionError, match="terminal result"):
         client.repair_assignment_routing(
             7,

--- a/tests/test_github_workflow_assignments.py
+++ b/tests/test_github_workflow_assignments.py
@@ -55,6 +55,26 @@ def test_create_assignment_converges_one_draft_pull_request_and_replays():
     assert fake.mutations == mutations_after_first
 
 
+def test_create_assignment_rejects_an_unapplied_draft_mutation():
+    assignment = assignment_record()
+    visible_body = "Run the bounded learning-rate experiment."
+    fake = FakeGitHub(
+        pull_request(
+            labels={"schmidhuber", "student:student-one", "status:wip"},
+            draft=False,
+            body=f"{render_assignment_marker(assignment)}\n\n{visible_body}",
+        ),
+        ignore_draft_mutations=True,
+    )
+
+    with pytest.raises(ReconciliationError, match="not draft"):
+        workflow(fake).create_assignment(
+            assignment,
+            title="Try lower learning rate",
+            body=visible_body,
+        )
+
+
 def test_create_assignment_does_not_repurpose_a_foreign_pull_request():
     foreign_body = render_assignment_marker(
         assignment_record(assignment_id="someone-elses-assignment")
@@ -284,6 +304,26 @@ def test_repair_routing_restores_wip_draft_state_without_label_changes():
 
     assert result.changed is True
     assert fake.pr["draft"] is True
+
+
+def test_repair_routing_rejects_an_unapplied_draft_mutation():
+    fake = FakeGitHub(
+        pull_request(
+            labels={"schmidhuber", "student:student-one", "status:wip"},
+            draft=False,
+        ),
+        ignore_draft_mutations=True,
+    )
+
+    with pytest.raises(ReconciliationError, match="draft state"):
+        workflow(fake).repair_assignment_routing(
+            7,
+            assignment_id=ASSIGNMENT_ID,
+            current_revision_id="revision-1",
+            expected_head_sha=HEAD_SHA,
+            working_state="wip",
+            blockers=set(),
+        )
 
 
 def test_repair_routing_rejects_a_stale_head_before_writing():

--- a/tests/test_github_workflow_contracts.py
+++ b/tests/test_github_workflow_contracts.py
@@ -18,6 +18,7 @@ from github_workflow_support import (
     API_URL,
     HEAD_SHA,
     REPO,
+    AmbiguousMutationGitHub,
     FakeGitHub,
     pull_request,
     workflow,
@@ -123,3 +124,64 @@ def test_network_failure_raises_a_token_safe_transport_error(monkeypatch):
 
     assert "never-show-this" not in str(raised.value)
     assert "never-show-this" not in repr(raised.value)
+
+
+def test_draft_mutation_recovers_an_ambiguous_response_after_application():
+    fake = AmbiguousMutationGitHub(
+        pull_request(draft=False),
+        fail_method="POST",
+        fail_path="/graphql",
+    )
+    client = workflow(fake)
+
+    changed = client._set_draft(client.pull_request(7), draft=True)
+
+    assert changed is True
+    assert fake.pr["draft"] is True
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ({"errors": [{"message": "denied"}]}, "returned errors"),
+        ({"data": {"convertPullRequestToDraft": {}}}, "invalid GraphQL"),
+        (
+            {
+                "data": {
+                    "convertPullRequestToDraft": {
+                        "pullRequest": {"id": "other", "isDraft": True}
+                    }
+                }
+            },
+            "wrong pull request",
+        ),
+        (
+            {
+                "data": {
+                    "convertPullRequestToDraft": {
+                        "pullRequest": {"id": "PR_node_7", "isDraft": False}
+                    }
+                }
+            },
+            "wrong draft state",
+        ),
+    ],
+    ids=("errors", "malformed", "wrong-pull", "wrong-state"),
+)
+def test_draft_mutation_rejects_invalid_graphql_results(payload, message):
+    class GraphQLResultGitHub(FakeGitHub):
+        def request(self, method, url, *, headers, json_body=None):
+            if method == "POST" and url.endswith("/graphql"):
+                return HttpResponse(200, payload)
+            return super().request(
+                method,
+                url,
+                headers=headers,
+                json_body=json_body,
+            )
+
+    fake = GraphQLResultGitHub(pull_request(draft=False))
+    client = workflow(fake)
+
+    with pytest.raises(ReconciliationError, match=message):
+        client._set_draft(client.pull_request(7), draft=True)

--- a/tests/test_github_workflow_issue_messages.py
+++ b/tests/test_github_workflow_issue_messages.py
@@ -1,9 +1,11 @@
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event
 from typing import cast
 from urllib.parse import urlsplit
 
 import pytest
 
-from senpai_agent.github.workflow import WorkflowPreconditionError
+from senpai_agent.github.workflow import MutationResult, WorkflowPreconditionError
 from github_workflow_support import (
     REPO,
     FakeGitHub,
@@ -64,6 +66,9 @@ def test_respond_to_issue_accepts_a_specific_human_comment():
 
     assert result.changed is True
     assert len(fake.comments) == 2
+    assert cast(str, fake.comments[-1]["body"]).startswith(
+        "<!-- senpai-human-response:student:fern:42 -->"
+    )
     assert cast(str, fake.comments[-1]["body"]).endswith(
         "\n\nSTUDENT: I included memory in the comparison."
     )
@@ -125,6 +130,49 @@ def test_advisor_and_two_student_replies_to_one_human_message_coexist():
         "<!-- senpai-human-response:student:sage:700 -->",
     ]
     assert fake.mutations == mutations_after_replies
+
+
+def test_human_issue_responses_share_the_workflow_mutation_lock(monkeypatch):
+    client = workflow(FakeGitHub(pull_request(), issue=human_issue()))
+    first_entered = Event()
+    second_entered = Event()
+    release_first = Event()
+
+    def hold_response(*_args, **_kwargs):
+        if not first_entered.is_set():
+            first_entered.set()
+            assert release_first.wait(1)
+        else:
+            second_entered.set()
+        return MutationResult(False, "https://github.test/issues/7", "test")
+
+    monkeypatch.setattr(type(client), "_respond_to_issue", hold_response)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(
+            client.respond_to_issue,
+            7,
+            human_message_id=700,
+            audience_labels={"team"},
+            responder="advisor",
+            response="First response.",
+        )
+        assert first_entered.wait(1)
+        second = executor.submit(
+            client.respond_to_issue,
+            7,
+            human_message_id=700,
+            audience_labels={"team"},
+            responder="advisor",
+            response="Second response.",
+        )
+        overlapped = second_entered.wait(0.1)
+        release_first.set()
+        first.result(timeout=1)
+        second.result(timeout=1)
+
+    assert not overlapped
+    assert second_entered.is_set()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_github_workflow_merge.py
+++ b/tests/test_github_workflow_merge.py
@@ -8,7 +8,11 @@ from senpai_agent.github.workflow import (
     StaleResearchBaseError,
     WorkflowPreconditionError,
 )
-from senpai_agent.models import render_assignment_marker, render_result_comment
+from senpai_agent.models import (
+    render_assignment_marker,
+    render_result_comment,
+    render_result_marker,
+)
 from github_workflow_support import (
     ASSIGNMENT_ID,
     BASE_SHA,
@@ -259,6 +263,58 @@ def test_merge_consumes_exact_durable_research_base_acceptance():
 
     assert result.state == "experiment_merged"
     assert fake.pr["merged"] is True
+
+
+@pytest.mark.parametrize("separator", ["\n\n", "\r", "\x85", "\u2028"])
+def test_merge_rejects_an_acceptance_below_another_protocol_marker(separator):
+    current_base_sha = "c" * 40
+    fake = FakeGitHub(
+        mergeable_pull(),
+        comments=[result_comment()],
+        branch_heads={"schmidhuber": current_base_sha},
+    )
+    client = workflow(fake)
+    accept_result(client, expected_current_base_sha=current_base_sha)
+    acceptance = fake.comments[-1]
+    acceptance["body"] = (
+        f"<!-- senpai-assignment-feedback:v1 {{}} -->{separator}"
+        + str(acceptance["body"])
+    )
+
+    with pytest.raises(StaleResearchBaseError, match="no durable acceptance"):
+        merge_experiment(client, expected_current_base_sha=current_base_sha)
+
+    assert fake.pr["merged"] is False
+
+
+def test_result_replay_preserves_a_durable_acceptance_with_legacy_marker_prose():
+    current_base_sha = "c" * 40
+    fake = FakeGitHub(
+        mergeable_pull(),
+        comments=[result_comment()],
+        branch_heads={"schmidhuber": current_base_sha},
+    )
+    advisor = workflow(fake)
+    accept_result(advisor, expected_current_base_sha=current_base_sha)
+    acceptance = fake.comments[-1]
+    acceptance["body"] = (
+        str(acceptance["body"])
+        + "\n\nLegacy quoted evidence:\n"
+        + render_result_marker(experiment_result())
+    )
+    acceptance_body = acceptance["body"]
+
+    workflow(fake, role="student").submit_result(
+        7,
+        expected_head_sha=HEAD_SHA,
+        result=experiment_result(),
+    )
+
+    assert acceptance["body"] == acceptance_body
+    assert merge_experiment(
+        advisor,
+        expected_current_base_sha=current_base_sha,
+    ).state == "experiment_merged"
 
 
 def test_merge_treats_identical_duplicate_results_as_one():

--- a/tests/test_github_workflow_results.py
+++ b/tests/test_github_workflow_results.py
@@ -518,6 +518,44 @@ def test_submit_result_stops_if_assignment_revision_changes_after_comment():
     assert len(fake.comments) == 1
 
 
+def test_submit_result_restores_wip_if_revision_changes_after_comment():
+    class RevisingGitHub(FakeGitHub):
+        def request(self, method, url, *, headers, json_body=None):
+            response = super().request(
+                method,
+                url,
+                headers=headers,
+                json_body=json_body,
+            )
+            if (
+                method == "POST"
+                and urlsplit(url).path == f"/repos/{REPO}/issues/7/comments"
+            ):
+                self.pr["body"] = render_assignment_marker(
+                    assignment_record(revision_id="revision-2")
+                )
+            return response
+
+    fake = RevisingGitHub(
+        pull_request(
+            labels={"student:one", "status:review", "status:hold", "keep"},
+            draft=False,
+        )
+    )
+
+    with pytest.raises(StaleAssignmentRevisionError, match="revision_id"):
+        submit_result(workflow(fake))
+
+    assert fake.pr["draft"] is True
+    assert fake.pr["labels"] == {
+        "student:one",
+        "status:wip",
+        "status:hold",
+        "keep",
+    }
+    assert len(fake.comments) == 1
+
+
 def test_submit_result_restores_new_revision_to_wip_after_ready_race():
     class RevisionDuringReadyGitHub(FakeGitHub):
         def request(self, method, url, *, headers, json_body=None):

--- a/tests/test_github_workflow_results.py
+++ b/tests/test_github_workflow_results.py
@@ -1,14 +1,26 @@
 from urllib.parse import urlsplit
 
 import pytest
+from pydantic import SecretStr
 
 from senpai_agent.github.workflow import (
+    GitHubAPIError,
+    GitHubTransportError,
+    HttpResponse,
+    GitHubWorkflow,
+    ReconciliationError,
     StaleAssignmentRevisionError,
     WorkflowPreconditionError,
 )
-from senpai_agent.models import render_assignment_marker, render_result_comment
+from senpai_agent.models import (
+    parse_result_markers,
+    render_assignment_marker,
+    render_result_comment,
+    render_result_marker,
+)
 from github_workflow_support import (
     ASSIGNMENT_ID,
+    API_URL,
     BASE_SHA,
     HEAD_SHA,
     REPO,
@@ -65,6 +77,53 @@ def test_submit_result_converges_review_state_and_replays_without_writes():
     assert len(fake.comments) == 1
     assert "\n\nSTUDENT: Status: succeeded" in str(fake.comments[0]["body"])
     assert fake.mutations == mutations_after_first
+
+
+def test_result_replay_resolves_and_caches_the_authenticated_actor():
+    fake = FakeGitHub(
+        pull_request(labels={"student:one", "status:wip"}, draft=True),
+        actor_login="SENPAI-BOT",
+    )
+    client = GitHubWorkflow(
+        REPO,
+        SecretStr("github-secret"),
+        role="student",
+        transport=fake,
+        api_url=API_URL,
+    )
+
+    submit_result(client)
+    submit_result(client)
+
+    assert sum(
+        method == "GET" and path == "/user"
+        for method, path, _body, _headers in fake.requests
+    ) == 1
+
+
+@pytest.mark.parametrize("separator", ["\n", "\r", "\x85", "\u2028"])
+def test_result_marker_below_visible_prose_is_not_protocol_evidence(separator):
+    fake = FakeGitHub(
+        pull_request(labels={"student:one", "status:wip"}, draft=True),
+        comments=[
+            comment(
+                1,
+                f"Visible prose{separator}{render_result_marker(experiment_result())}",
+            )
+        ],
+    )
+
+    with pytest.raises(WorkflowPreconditionError, match="terminal result"):
+        workflow(fake).repair_assignment_routing(
+            7,
+            assignment_id=ASSIGNMENT_ID,
+            current_revision_id="revision-1",
+            expected_head_sha=HEAD_SHA,
+            working_state="review",
+            blockers=set(),
+        )
+
+    assert fake.mutations == []
 
 
 def test_published_result_is_immutable_at_the_same_revision_and_head():
@@ -127,7 +186,17 @@ def test_changed_result_is_allowed_on_a_new_revision_or_head(advance):
     expected = render_result_comment(changed).replace(
         "\n\n", "\n\nSTUDENT: ", 1
     )
-    assert fake.comments == [comment(1, expected)]
+    assert fake.comments == [
+        comment(1, render_result_comment(original)),
+        comment(2, expected),
+    ]
+    assert workflow(fake).merge_experiment(
+        7,
+        expected_head_sha=pr_head,
+        assignment_id=ASSIGNMENT_ID,
+        current_revision_id=changed.assignment.revision_id,
+        expected_current_base_sha=BASE_SHA,
+    ).state == "experiment_merged"
 
 
 def test_identical_duplicate_result_replay_upgrades_legacy_role_prefix_once():
@@ -245,6 +314,178 @@ def test_submit_result_recovers_when_the_comment_response_is_lost():
     assert len(fake.comments) == 1
     assert fake.pr["draft"] is False
     assert fake.pr["labels"] == {"student:one", "status:review"}
+
+
+def test_submit_result_rejects_an_ambiguous_unapplied_draft_mutation():
+    class DroppedDraftMutation(FakeGitHub):
+        dropped = False
+
+        def request(self, method, url, *, headers, json_body=None):
+            if not self.dropped and method == "POST" and urlsplit(url).path == "/graphql":
+                self.dropped = True
+                raise GitHubTransportError(method, url)
+            return super().request(
+                method,
+                url,
+                headers=headers,
+                json_body=json_body,
+            )
+
+    fake = DroppedDraftMutation(
+        pull_request(labels={"student:one", "status:wip"}, draft=True)
+    )
+
+    with pytest.raises(ReconciliationError, match="ready for review"):
+        submit_result(workflow(fake, role="student"))
+
+    assert fake.pr["draft"] is True
+
+
+@pytest.mark.parametrize("failure_mode", ["api", "transport"])
+def test_submit_result_retry_repairs_a_partial_multi_comment_update(failure_mode):
+    current = experiment_result()
+
+    class SecondPatchFailsOnce(FakeGitHub):
+        patch_count = 0
+
+        def request(self, method, url, *, headers, json_body=None):
+            if method == "PATCH" and "/issues/comments/" in urlsplit(url).path:
+                self.patch_count += 1
+                if self.patch_count == 2:
+                    if failure_mode == "api":
+                        return HttpResponse(500, {"message": "temporary failure"})
+                    raise GitHubTransportError(method, url)
+            return super().request(
+                method,
+                url,
+                headers=headers,
+                json_body=json_body,
+            )
+
+    fake = SecondPatchFailsOnce(
+        pull_request(labels={"student:one", "status:wip"}, draft=True),
+        comments=[
+            comment(1, render_result_comment(current)),
+            comment(2, render_result_comment(current)),
+        ],
+    )
+    client = workflow(fake, role="student")
+
+    error_type = GitHubAPIError if failure_mode == "api" else ReconciliationError
+    with pytest.raises(error_type):
+        submit_result(client, current)
+
+    assert all(
+        parse_result_markers(str(item["body"])) == (current,)
+        for item in fake.comments
+    )
+    assert len({str(item["body"]) for item in fake.comments}) == 2
+
+    submitted = submit_result(client, current)
+
+    assert submitted.state == "result_submitted"
+    assert all(
+        parse_result_markers(str(item["body"])) == (current,)
+        for item in fake.comments
+    )
+
+
+def test_stale_submit_cannot_overwrite_a_newer_result_before_upsert():
+    current = experiment_result().model_copy(
+        update={
+            "assignment": experiment_result().assignment.model_copy(
+                update={"revision_id": "revision-2"}
+            ),
+            "summary": "The current revision has durable evidence.",
+        }
+    )
+
+    class CurrentResultBeforeStaleUpsert(FakeGitHub):
+        advanced = False
+
+        def request(self, method, url, *, headers, json_body=None):
+            if (
+                not self.advanced
+                and method == "GET"
+                and urlsplit(url).path == f"/repos/{REPO}/issues/7/comments"
+            ):
+                self.pr["body"] = render_assignment_marker(
+                    assignment_record(revision_id="revision-2")
+                )
+                self.pr["draft"] = False
+                self.pr["labels"] = {"student:one", "status:review"}
+                self.comments = [comment(1, render_result_comment(current))]
+                self.advanced = True
+            return super().request(
+                method,
+                url,
+                headers=headers,
+                json_body=json_body,
+            )
+
+    fake = CurrentResultBeforeStaleUpsert(
+        pull_request(labels={"student:one", "status:wip"}, draft=True)
+    )
+
+    with pytest.raises(StaleAssignmentRevisionError, match="revision_id"):
+        submit_result(workflow(fake, role="student"))
+
+    assert fake.pr["draft"] is False
+    assert fake.pr["labels"] == {"student:one", "status:review"}
+    assert parse_result_markers(str(fake.comments[0]["body"])) == (current,)
+    assert fake.mutations == []
+
+
+def test_submit_result_fails_closed_on_unexplained_distinct_results():
+    first = experiment_result().model_copy(
+        update={"summary": "First conflicting result."}
+    )
+    second = first.model_copy(
+        update={"summary": "Second conflicting result."}
+    )
+    requested = second.model_copy(
+        update={"summary": "Requested current result."}
+    )
+    fake = FakeGitHub(
+        pull_request(),
+        comments=[
+            comment(1, render_result_comment(first)),
+            comment(2, render_result_comment(second)),
+        ],
+    )
+
+    with pytest.raises(ReconciliationError, match="multiple distinct"):
+        submit_result(workflow(fake, role="student"), requested)
+
+    assert fake.mutations == []
+
+
+def test_submit_result_quotes_a_valid_prior_marker_in_its_summary():
+    prior = experiment_result().model_copy(
+        update={"summary": "Prior evidence quoted by the student."}
+    )
+    current = experiment_result().model_copy(
+        update={
+            "summary": (
+                "The new evidence supersedes this prior marker:\n"
+                f"{render_result_marker(prior)}"
+            )
+        }
+    )
+    fake = FakeGitHub(
+        pull_request(labels={"student:one", "status:wip"}, draft=True)
+    )
+    client = workflow(fake, role="student")
+
+    first = submit_result(client, current)
+    mutations_after_first = list(fake.mutations)
+    second = submit_result(client, current)
+
+    assert first.changed is True
+    assert second.changed is False
+    assert parse_result_markers(str(fake.comments[0]["body"])) == (current,)
+    assert f"> {render_result_marker(prior)}" in str(fake.comments[0]["body"])
+    assert fake.mutations == mutations_after_first
 
 
 def test_submit_result_stops_if_assignment_revision_changes_after_comment():
@@ -477,6 +718,246 @@ def test_submit_result_preserves_a_hold_added_during_label_transition():
         )
 
     assert fake.mutations == mutations_before_merge
+
+
+def test_stale_submit_restores_a_current_result_arriving_after_draft_recovery():
+    current = experiment_result()
+    current = current.model_copy(
+        update={
+            "assignment": current.assignment.model_copy(
+                update={"revision_id": "revision-2"}
+            ),
+            "summary": "Current evidence arrived during recovery.",
+        }
+    )
+
+    class CurrentResultAfterDraftGitHub(FakeGitHub):
+        revision_changed = False
+        result_published = False
+
+        def request(self, method, url, *, headers, json_body=None):
+            response = super().request(
+                method,
+                url,
+                headers=headers,
+                json_body=json_body,
+            )
+            if method != "POST" or urlsplit(url).path != "/graphql":
+                return response
+            query = str(json_body)
+            if "markPullRequestReadyForReview" in query and not self.revision_changed:
+                self.pr["body"] = render_assignment_marker(
+                    assignment_record(revision_id="revision-2")
+                )
+                self.revision_changed = True
+            elif "convertPullRequestToDraft" in query and not self.result_published:
+                self.comments = [comment(1, render_result_comment(current))]
+                self.result_published = True
+            return response
+
+    fake = CurrentResultAfterDraftGitHub(
+        pull_request(labels={"student:one", "status:wip"}, draft=True)
+    )
+
+    with pytest.raises(StaleAssignmentRevisionError, match="revision_id"):
+        submit_result(workflow(fake, role="student"))
+
+    assert fake.pr["draft"] is False
+    assert fake.pr["labels"] == {"student:one", "status:review"}
+    assert fake.comments == [comment(1, render_result_comment(current))]
+
+
+def test_stale_submit_restores_a_current_result_arriving_after_wip_recovery():
+    current = experiment_result()
+    current = current.model_copy(
+        update={
+            "assignment": current.assignment.model_copy(
+                update={"revision_id": "revision-2"}
+            ),
+            "summary": "Current evidence arrived after label recovery.",
+        }
+    )
+
+    class CurrentResultAfterLabelsGitHub(FakeGitHub):
+        revision_changed = False
+        result_published = False
+
+        def request(self, method, url, *, headers, json_body=None):
+            response = super().request(
+                method,
+                url,
+                headers=headers,
+                json_body=json_body,
+            )
+            path = urlsplit(url).path
+            if method == "POST" and path == "/graphql" and not self.revision_changed:
+                if "markPullRequestReadyForReview" in str(json_body):
+                    self.pr["body"] = render_assignment_marker(
+                        assignment_record(revision_id="revision-2")
+                    )
+                    self.revision_changed = True
+            elif (
+                method == "DELETE"
+                and path.endswith("/labels/status%3Areview")
+                and not self.result_published
+            ):
+                self.comments = [comment(1, render_result_comment(current))]
+                self.result_published = True
+            return response
+
+    fake = CurrentResultAfterLabelsGitHub(
+        pull_request(labels={"student:one", "status:wip"}, draft=True)
+    )
+
+    with pytest.raises(StaleAssignmentRevisionError, match="revision_id"):
+        submit_result(workflow(fake, role="student"))
+
+    assert fake.pr["draft"] is False
+    assert fake.pr["labels"] == {"student:one", "status:review"}
+    assert fake.comments == [comment(1, render_result_comment(current))]
+
+
+def test_stale_submit_recovery_stops_after_three_assignment_changes():
+    class RepeatedRevisionGitHub(FakeGitHub):
+        revision = 1
+
+        def request(self, method, url, *, headers, json_body=None):
+            response = super().request(
+                method,
+                url,
+                headers=headers,
+                json_body=json_body,
+            )
+            if method != "POST" or urlsplit(url).path != "/graphql":
+                return response
+            query = str(json_body)
+            if "markPullRequestReadyForReview" in query and self.revision == 1:
+                self.revision = 2
+            elif "convertPullRequestToDraft" in query:
+                self.revision += 1
+                self.pr["draft"] = False
+            else:
+                return response
+            self.pr["body"] = render_assignment_marker(
+                assignment_record(revision_id=f"revision-{self.revision}")
+            )
+            return response
+
+    fake = RepeatedRevisionGitHub(
+        pull_request(labels={"student:one", "status:wip"}, draft=True)
+    )
+
+    with pytest.raises(ReconciliationError, match="kept changing"):
+        submit_result(workflow(fake, role="student"))
+
+
+def test_stale_submit_retries_when_assignment_changes_after_label_recovery():
+    class RevisionAfterLabelsGitHub(FakeGitHub):
+        initial_revision_changed = False
+        recovery_revision_changed = False
+
+        def request(self, method, url, *, headers, json_body=None):
+            response = super().request(
+                method,
+                url,
+                headers=headers,
+                json_body=json_body,
+            )
+            path = urlsplit(url).path
+            if (
+                method == "POST"
+                and path == "/graphql"
+                and "markPullRequestReadyForReview" in str(json_body)
+                and not self.initial_revision_changed
+            ):
+                self.pr["body"] = render_assignment_marker(
+                    assignment_record(revision_id="revision-2")
+                )
+                self.initial_revision_changed = True
+            elif (
+                method == "DELETE"
+                and path.endswith("/labels/status%3Areview")
+                and not self.recovery_revision_changed
+            ):
+                self.pr["body"] = render_assignment_marker(
+                    assignment_record(revision_id="revision-3")
+                )
+                self.recovery_revision_changed = True
+            return response
+
+    fake = RevisionAfterLabelsGitHub(
+        pull_request(labels={"student:one", "status:wip"}, draft=True)
+    )
+
+    with pytest.raises(StaleAssignmentRevisionError, match="revision_id"):
+        submit_result(workflow(fake, role="student"))
+
+    assert fake.pr["draft"] is True
+    assert fake.pr["labels"] == {"student:one", "status:wip"}
+    assert "revision-3" in str(fake.pr["body"])
+
+
+@pytest.mark.parametrize(
+    "ignored_mutation",
+    ["draft", "labels"],
+)
+def test_current_result_restore_rejects_unapplied_routing_mutations(
+    ignored_mutation,
+):
+    current = experiment_result()
+    fake = FakeGitHub(
+        pull_request(labels={"student:one", "status:wip"}, draft=True),
+        comments=[comment(1, render_result_comment(current))],
+        ignore_draft_mutations=ignored_mutation == "draft",
+        ignore_label_mutations=ignored_mutation == "labels",
+    )
+    client = workflow(fake, role="student")
+
+    with pytest.raises(ReconciliationError, match="did not remain reviewable"):
+        client._restore_current_result_review(
+            client.pull_request(7),
+            assignment_id=ASSIGNMENT_ID,
+            expected_head_sha=HEAD_SHA,
+        )
+
+
+def test_stale_recovery_restores_a_result_when_the_revision_reverts():
+    fake = FakeGitHub(
+        pull_request(labels={"student:one", "status:wip"}, draft=True),
+        comments=[comment(1, render_result_comment(experiment_result()))],
+    )
+    client = workflow(fake, role="student")
+
+    client._reconcile_current_result_routing(
+        7,
+        assignment_id=ASSIGNMENT_ID,
+        expected_head_sha=HEAD_SHA,
+    )
+
+    assert fake.pr["draft"] is False
+    assert fake.pr["labels"] == {"student:one", "status:review"}
+
+
+def test_stale_recovery_rejects_an_unapplied_wip_label_rollback():
+    fake = FakeGitHub(
+        pull_request(
+            labels={"student:one", "status:review"},
+            draft=False,
+            body=render_assignment_marker(
+                assignment_record(revision_id="revision-2")
+            ),
+        ),
+        comments=[comment(1, render_result_comment(experiment_result()))],
+        ignore_label_mutations=True,
+    )
+    client = workflow(fake, role="student")
+
+    with pytest.raises(ReconciliationError, match="restore.*to WIP"):
+        client._reconcile_current_result_routing(
+            7,
+            assignment_id=ASSIGNMENT_ID,
+            expected_head_sha=HEAD_SHA,
+        )
 
 
 def test_submit_result_does_not_treat_the_initial_assignment_head_as_a_lease():

--- a/tests/test_model_markers.py
+++ b/tests/test_model_markers.py
@@ -158,8 +158,8 @@ def test_visible_result_comment_contains_status_commit_summary_and_runs():
 
 
 def test_result_comment_quotes_protocol_marker_lines_from_visible_fields():
-    result_marker = "<!-- senpai-result:v2 {} -->"
-    response_marker = "<!-- senpai-human-response:student:fern:700 -->"
+    result_marker = "  <!-- senpai-result:v2 {} -->"
+    response_marker = "\t<!-- senpai-human-response:student:fern:700 -->"
     runs = (
         WandbRunRef(
             run_id="run-123",

--- a/tests/test_model_markers.py
+++ b/tests/test_model_markers.py
@@ -12,6 +12,7 @@ from senpai_agent.models import (
     ResultMarkerError,
     ResultStatus,
     WandbRunRef,
+    authoritative_marker_line,
     experiment_result_digest,
     parse_assignment_markers,
     parse_research_base_acceptance_markers,
@@ -21,6 +22,15 @@ from senpai_agent.models import (
     render_result_comment,
     render_result_marker,
 )
+
+
+@pytest.mark.parametrize("separator", ["\n", "\r", "\x85", "\u2028"])
+def test_authoritative_marker_line_uses_parser_line_boundaries(separator: str):
+    marker = render_result_marker(result())
+
+    assert authoritative_marker_line(f"Visible prose{separator}{marker}") == (
+        "Visible prose"
+    )
 
 
 def test_assignment_marker_round_trips_as_one_line():
@@ -167,6 +177,30 @@ def test_result_comment_quotes_protocol_marker_lines_from_visible_fields():
     assert f"> {result_marker}" in body.splitlines()
     assert f"> {response_marker}" in body.splitlines()
     assert parse_result_markers(body) == (experiment_result,)
+
+
+def test_result_comment_quotes_protocol_markers_in_visible_fields():
+    prior_marker = render_result_marker(
+        result(
+            assignment_id="assignment-prior",
+            summary="Prior terminal evidence.",
+        )
+    )
+    current = result(
+        summary=f"Compare against the prior record.\n{prior_marker}",
+        runs=(
+            WandbRunRef(
+                run_id="run-123",
+                url=f"https://wandb.ai/acme/widgets/runs/run-123\n{prior_marker}",
+                state="finished",
+            ),
+        ),
+    )
+
+    body = render_result_comment(current)
+
+    assert body.splitlines().count(f"> {prior_marker}") == 2
+    assert parse_result_markers(body) == (current,)
 
 
 def test_result_parser_preserves_marker_order_and_duplicates():

--- a/tests/test_tools_github_access.py
+++ b/tests/test_tools_github_access.py
@@ -13,6 +13,7 @@ from senpai_agent.github.tools import (
     GetPRsAction,
     GetPRsTool,
     GitHubToolRuntime,
+    GitHubWorkflowToolSet,
     RespondToHumanIssueAction,
     RespondToHumanIssueTool,
     clear_github_credentials,
@@ -92,6 +93,17 @@ def test_registered_github_toolset_exposes_only_role_owned_tools(
     assert "github_transition" not in expected
     assert "github-secret" not in json.dumps(spec.model_dump())
     assert all("github-secret" not in repr(tool.executor) for tool in resolved)
+
+
+def test_toolset_rejects_a_runtime_role_mismatch(tmp_path: Path):
+    with pytest.raises(ValueError, match="workflow role"):
+        GitHubWorkflowToolSet.create(
+            workflow=workflow(FakeGitHub(pull_request())),
+            role="student",
+            student_name="student-one",
+            state_dir=tmp_path / "state",
+            workspace=tmp_path,
+        )
 
 
 @pytest.mark.parametrize("role", ["advisor", "student"])

--- a/tests/test_tools_github_submission.py
+++ b/tests/test_tools_github_submission.py
@@ -184,6 +184,39 @@ def test_stale_submission_finishes_the_obsolete_conversation_without_pushing(
     assert pushes == []
 
 
+def test_stale_submission_after_push_finishes_the_obsolete_conversation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    class StaleWorkflow(RecordingWorkflow):
+        def submit_result(self, number, **kwargs):
+            self.events.append(("submit", number, kwargs))
+            raise StaleAssignmentRevisionError(
+                "revision='revision-2'; result revision='revision-1'. Refresh PR #17."
+            )
+
+    workflow = StaleWorkflow()
+    pushes = []
+    monkeypatch.setattr(
+        "senpai_agent.github.tools.runtime.git_workflow.push_assignment_branch",
+        lambda *args, **kwargs: pushes.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        "senpai_agent.github.tools.runtime.git_workflow.require_commit_contains_base",
+        lambda *args, **kwargs: None,
+    )
+    conversation = SimpleNamespace(
+        state=SimpleNamespace(execution_status=ConversationExecutionStatus.RUNNING)
+    )
+
+    with pytest.raises(ValueError, match="controller can resume"):
+        student_tool(workflow, tmp_path)(submit_action(), conversation)
+
+    assert conversation.state.execution_status is ConversationExecutionStatus.FINISHED
+    assert [event[0] for event in workflow.events] == ["preflight", "submit"]
+    assert len(pushes) == 1
+
+
 def test_submit_result_pushes_the_validated_local_head_before_github_mutation(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_tools_github_submission.py
+++ b/tests/test_tools_github_submission.py
@@ -119,6 +119,38 @@ def test_submit_result_preflights_before_any_git_mutation(
     assert pushes == []
 
 
+def test_submit_result_rejects_another_students_assignment_before_preflight(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    workflow = RecordingWorkflow()
+    action = submit_action()
+    action = action.model_copy(
+        update={
+            "result": action.result.model_copy(
+                update={
+                    "assignment": action.result.assignment.model_copy(
+                        update={"student": "student-two"}
+                    )
+                }
+            )
+        }
+    )
+    monkeypatch.setattr(
+        "senpai_agent.github.tools.runtime.git_workflow.push_assignment_branch",
+        lambda *_args, **_kwargs: pytest.fail("git push reached"),
+    )
+    monkeypatch.setattr(
+        "senpai_agent.github.tools.runtime.git_workflow.require_commit_contains_base",
+        lambda *_args, **_kwargs: pytest.fail("ancestry check reached"),
+    )
+
+    with pytest.raises(PermissionError, match="does not match this runtime"):
+        student_tool(workflow, tmp_path)(action)
+
+    assert workflow.events == []
+
+
 def test_stale_submission_finishes_the_obsolete_conversation_without_pushing(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_tools_github_transitions.py
+++ b/tests/test_tools_github_transitions.py
@@ -25,6 +25,7 @@ from senpai_agent.github.tools import (
     SendAssignmentFeedbackTool,
 )
 from senpai_agent.github.workflow import MutationResult
+from senpai_agent.models import DispositionRecord, render_disposition_marker
 
 
 class RecordingWorkflow:
@@ -267,7 +268,17 @@ def test_publish_advisor_branch_uses_configured_branch_and_distinct_shas(
                 reason="The hypothesis was falsified.",
             ),
             "close_experiment",
-            {"reason": "The hypothesis was falsified."},
+            {
+                "marker": render_disposition_marker(
+                    DispositionRecord(
+                        repo="acme/widgets",
+                        pr_number=17,
+                        assignment_id="assignment-17",
+                        head_sha="a" * 40,
+                    )
+                ),
+                "reason": "The hypothesis was falsified.",
+            },
         ),
     ],
 )


### PR DESCRIPTION
## Summary

- trust Senpai protocol markers only at an authoritative logical line and quote marker-looking model prose, including indented forms
- keep result records append-only across revision/head identities while preserving retry convergence and same-version immutability
- scope and serialize human responses, preserve concurrent labels, and bind student submissions to the runtime identity
- reconcile revision/result routing through bounded evidence-driven recovery and verify mutations target the expected pull request
- wake the advisor for a new assignment revision even when the PR head SHA is unchanged
- handle stale revisions found after branch push and restore WIP routing after result-publication races

## Validation

- `uv run pytest` — 801 passed, 6 skipped
- focused workflow suite — 140 passed
- independent review — no findings
- `git diff --check`
