### PR TITLE
Reject legacy reasoning input and preserve training sidecars

### DIFF
--- a/k8s/launch.py
+++ b/k8s/launch.py
@@ -181,12 +181,6 @@ def _supports_openai_pro(model: str) -> bool:
     return normalized == "openai/gpt-5.6" or normalized.startswith("openai/gpt-5.6-")
 
 
-def _canonical_reasoning_effort(model: str, effort: str) -> str:
-    """Normalize the retired spelling only for its original GPT-5.6 scope."""
-
-    return "max" if effort == "ultra" and _supports_openai_pro(model) else effort
-
-
 def validate_model_config(args: Args) -> None:
     profiles = {
         "student": (args.student_model, args.student_reasoning_effort),
@@ -201,23 +195,18 @@ def validate_model_config(args: Args) -> None:
         )
     for name, (model, effort) in profiles.items():
         model_provider(model)
-        canonical_effort = _canonical_reasoning_effort(model, effort)
-        if effort == "ultra" and canonical_effort == "ultra":
-            sys.exit(
-                f"ERROR: --{name}_reasoning_effort={effort} is unsupported for {model}"
-            )
-        if canonical_effort not in REASONING_EFFORTS:
+        if effort not in REASONING_EFFORTS:
             choices = ", ".join(sorted(REASONING_EFFORTS))
             sys.exit(f"ERROR: --{name}_reasoning_effort must be one of: {choices}")
         normalized_model = model.lower()
         if normalized_model == "wandb/zai-org/glm-5.2":
-            if canonical_effort not in {"high", "max"}:
+            if effort not in {"high", "max"}:
                 sys.exit(
                     f"ERROR: --{name}_reasoning_effort={effort} is "
                     f"unsupported for {model}"
                 )
             continue
-        if canonical_effort == "max" and not _supports_openai_pro(model):
+        if effort == "max" and not _supports_openai_pro(model):
             sys.exit(
                 f"ERROR: --{name}_reasoning_effort={effort} is unsupported for {model}"
             )
@@ -232,25 +221,13 @@ def role_model_config(args: Args, role: str) -> dict[str, str]:
     )
     return {
         "SENPAI_OPENHANDS_MODEL": model,
-        "SENPAI_OPENHANDS_REASONING_EFFORT": _canonical_reasoning_effort(
-            model,
-            reasoning_effort,
-        ),
+        "SENPAI_OPENHANDS_REASONING_EFFORT": reasoning_effort,
         "SENPAI_OPENHANDS_SMART_MODEL": args.smart_model,
-        "SENPAI_OPENHANDS_SMART_REASONING_EFFORT": _canonical_reasoning_effort(
-            args.smart_model,
-            args.smart_reasoning_effort,
-        ),
+        "SENPAI_OPENHANDS_SMART_REASONING_EFFORT": args.smart_reasoning_effort,
         "SENPAI_OPENHANDS_FAST_MODEL": args.fast_model,
-        "SENPAI_OPENHANDS_FAST_REASONING_EFFORT": _canonical_reasoning_effort(
-            args.fast_model,
-            args.fast_reasoning_effort,
-        ),
+        "SENPAI_OPENHANDS_FAST_REASONING_EFFORT": args.fast_reasoning_effort,
         "SENPAI_OPENHANDS_FRONTIER_MODEL": args.frontier_model,
-        "SENPAI_OPENHANDS_FRONTIER_REASONING_EFFORT": _canonical_reasoning_effort(
-            args.frontier_model,
-            args.frontier_reasoning_effort,
-        ),
+        "SENPAI_OPENHANDS_FRONTIER_REASONING_EFFORT": args.frontier_reasoning_effort,
     }
 
 

--- a/senpai_agent/hooks.py
+++ b/senpai_agent/hooks.py
@@ -10,6 +10,8 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
+from senpai_agent.training import training_result_paths
+
 
 @dataclass(frozen=True, slots=True)
 class PolicyDecision:
@@ -587,7 +589,7 @@ def _stop_policy(
     if state_dir is not None:
         running = {
             path.stem
-            for path in (state_dir / "training").glob("*.json")
+            for path in training_result_paths(state_dir / "training")
             if json.loads(path.read_text()).get("state") == "running"
         }
         monitored = {

--- a/senpai_agent/openhands_runner.py
+++ b/senpai_agent/openhands_runner.py
@@ -92,8 +92,6 @@ REASONING_EFFORTS = (
     "max",
     "none",
 )
-# Input-only compatibility for live configs; RunnerConfig stores max.
-_REASONING_EFFORT_INPUTS = (*REASONING_EFFORTS, "ultra")
 SENPAI_AGENT_NAMES = ("bash-runner", "general-purpose", "explore", "search")
 SENPAI_AGENT_DIR = Path(__file__).resolve().parents[1] / ".agents" / "agents"
 PROVIDER_API_KEY_ENVS = {
@@ -116,25 +114,25 @@ class RunnerArgs:
     reasoning_effort: str | None = field(
         default=None,
         alias="--reasoning-effort",
-        choices=_REASONING_EFFORT_INPUTS,
+        choices=REASONING_EFFORTS,
     )
     smart_model: str | None = field(default=None, alias="--smart-model")
     smart_reasoning_effort: str | None = field(
         default=None,
         alias="--smart-reasoning-effort",
-        choices=_REASONING_EFFORT_INPUTS,
+        choices=REASONING_EFFORTS,
     )
     fast_model: str | None = field(default=None, alias="--fast-model")
     fast_reasoning_effort: str | None = field(
         default=None,
         alias="--fast-reasoning-effort",
-        choices=_REASONING_EFFORT_INPUTS,
+        choices=REASONING_EFFORTS,
     )
     frontier_model: str | None = field(default=None, alias="--frontier-model")
     frontier_reasoning_effort: str | None = field(
         default=None,
         alias="--frontier-reasoning-effort",
-        choices=_REASONING_EFFORT_INPUTS,
+        choices=REASONING_EFFORTS,
     )
     workspace: str | None = field(default=None, alias="--workspace")
     state_dir: str | None = field(default=None, alias="--state-dir")
@@ -211,13 +209,6 @@ def openhands_reasoning_effort(reasoning_effort: str, model: str) -> str:
     supports_openai_pro = provider == "openai" and (
         model_name == "gpt-5.6" or model_name.startswith("gpt-5.6-")
     )
-    if reasoning_effort == "ultra":
-        if not supports_openai_pro:
-            raise ValueError(
-                f"reasoning effort {reasoning_effort!r} is unsupported for "
-                f"model {model!r}; use 'max' with an openai/gpt-5.6 model"
-            )
-        reasoning_effort = "max"
     if reasoning_effort not in REASONING_EFFORTS:
         choices = ", ".join(REASONING_EFFORTS)
         raise ValueError(
@@ -263,7 +254,7 @@ def _openai_pro_reasoning(
 
 
 def apply_reasoning_profile(llm: LLM) -> LLM:
-    """Canonicalize effort and replace only Senpai's reasoning request body."""
+    """Validate effort and replace only Senpai's reasoning request body."""
 
     reasoning_effort = openhands_reasoning_effort(
         llm.reasoning_effort,

--- a/senpai_agent/training.py
+++ b/senpai_agent/training.py
@@ -5,6 +5,7 @@ import subprocess
 import threading
 import time
 import uuid
+from collections.abc import Iterator
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
@@ -57,6 +58,18 @@ class TrainingResult(BaseModel):
     error_tail: str = ""
 
 
+def training_result_paths(state_dir: Path) -> Iterator[Path]:
+    """Yield only process records owned by the training supervisor."""
+
+    for path in state_dir.glob("*.json"):
+        try:
+            training_id = uuid.UUID(path.stem)
+        except ValueError:
+            continue
+        if path.name == f"{training_id}.json":
+            yield path
+
+
 @dataclass
 class _ActiveTraining:
     process: subprocess.Popen[bytes]
@@ -90,7 +103,7 @@ class TrainingSupervisor:
         self._cancel_orphaned_runs()
 
     def _cancel_orphaned_runs(self) -> None:
-        for path in self.state_dir.glob("*.json"):
+        for path in training_result_paths(self.state_dir):
             result = TrainingResult.model_validate_json(path.read_text())
             if result.state is TrainingState.RUNNING:
                 process_was_terminated = self._terminate_recovered_process(result)

--- a/tests/test_hooks_lifecycle.py
+++ b/tests/test_hooks_lifecycle.py
@@ -12,7 +12,7 @@ from openhands.sdk.plugin import Plugin
 from senpai_agent.hooks import hook_main
 
 PLUGIN_DIR = Path(__file__).parents[1] / "plugins" / "senpai"
-TRAINING_ID = "training-1"
+TRAINING_ID = "b81440b1-b803-471e-9fe0-6dcabd756b83"
 
 
 def invoke_hook(
@@ -116,6 +116,37 @@ def test_student_stop_allows_durable_monitored_training(
 ):
     state_dir = tmp_path / "state"
     write_running_training(state_dir, monitored=True)
+    monkeypatch.setattr(
+        "senpai_agent.hooks.subprocess.run",
+        lambda *args, **kwargs: SimpleNamespace(stdout=""),
+    )
+
+    exit_code, output = invoke_hook(
+        "stop",
+        {"working_dir": str(assignment_workspace)},
+        monkeypatch,
+        capsys,
+        {
+            "SENPAI_ROLE": "student",
+            "SENPAI_OPENHANDS_STATE_DIR": str(state_dir),
+        },
+    )
+
+    assert (exit_code, output["decision"]) == (0, "allow")
+
+
+def test_student_stop_ignores_non_training_json_sidecars(
+    assignment_workspace: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    state_dir = tmp_path / "state"
+    training_dir = state_dir / "training"
+    training_dir.mkdir(parents=True)
+    (training_dir / f"{TRAINING_ID}.score.json").write_text(
+        '{"metrics": {}, "passed": true, "score": 1.0}'
+    )
     monkeypatch.setattr(
         "senpai_agent.hooks.subprocess.run",
         lambda *args, **kwargs: SimpleNamespace(stdout=""),

--- a/tests/test_launch_images_and_rendering.py
+++ b/tests/test_launch_images_and_rendering.py
@@ -245,19 +245,14 @@ def test_role_model_configuration_preserves_the_configured_efforts():
         assert config["SENPAI_OPENHANDS_FRONTIER_REASONING_EFFORT"] == "max"
 
 
-def test_legacy_openai_ultra_launch_value_is_rendered_as_max():
+def test_openai_ultra_launch_value_is_rejected():
     args = launch_args(
         frontier_model="openai/gpt-5.6-sol",
         frontier_reasoning_effort="ultra",
     )
 
-    launch.validate_model_config(args)
-    configmap, _deployment, _secret = render_role("student", args)
-
-    assert (
-        yaml.safe_load(configmap)["data"]["SENPAI_OPENHANDS_FRONTIER_REASONING_EFFORT"]
-        == "max"
-    )
+    with pytest.raises(SystemExit, match="must be one of"):
+        launch.validate_model_config(args)
 
 
 def test_wandb_gateway_is_rendered_for_every_role():
@@ -296,7 +291,7 @@ def test_wandb_gateway_is_rendered_for_every_role():
                 "advisor_model": "anthropic/claude-opus-4-8",
                 "advisor_reasoning_effort": "ultra",
             },
-            "unsupported for",
+            "must be one of",
         ),
         (
             {

--- a/tests/test_openhands_config.py
+++ b/tests/test_openhands_config.py
@@ -175,43 +175,12 @@ def test_default_model_profiles_are_explicit_and_provider_credentials_are_inferr
     ) == ("openai/gpt-5.6-sol", "OPENAI_API_KEY", "max")
 
 
-def test_legacy_ultra_environment_values_normalize_to_max(tmp_path: Path):
+def test_ultra_environment_value_is_rejected(tmp_path: Path):
     env = runtime_env(tmp_path)
-    env.update(
-        {
-            "SENPAI_OPENHANDS_REASONING_EFFORT": "ultra",
-            "SENPAI_OPENHANDS_SMART_REASONING_EFFORT": "ultra",
-            "SENPAI_OPENHANDS_FAST_MODEL": "openai/gpt-5.6-luna",
-            "SENPAI_OPENHANDS_FAST_REASONING_EFFORT": "ultra",
-            "SENPAI_OPENHANDS_FRONTIER_REASONING_EFFORT": "ultra",
-        }
-    )
+    env["SENPAI_OPENHANDS_REASONING_EFFORT"] = "ultra"
 
-    config = resolve_config(parse_runner_args(["--max-turns", "1"]), env)
-
-    assert {
-        config.reasoning_effort,
-        config.smart_reasoning_effort,
-        config.fast_reasoning_effort,
-        config.frontier_reasoning_effort,
-    } == {"max"}
-
-
-def test_legacy_ultra_cli_value_normalizes_to_max(tmp_path: Path):
-    args = parse_runner_args(
-        [
-            "--max-turns",
-            "1",
-            "--model",
-            "openai/gpt-5.6-sol",
-            "--reasoning-effort",
-            "ultra",
-        ]
-    )
-
-    config = resolve_config(args, runtime_env(tmp_path))
-
-    assert config.reasoning_effort == "max"
+    with pytest.raises(ValueError, match="unsupported reasoning effort"):
+        resolve_config(parse_runner_args(["--max-turns", "1"]), env)
 
 
 def test_wandb_gateway_configuration_is_explicit_and_uses_max_glm_reasoning(
@@ -333,7 +302,7 @@ def test_all_model_profiles_accept_independent_cli_model_and_effort_settings(
                 "SENPAI_OPENHANDS_MODEL": "anthropic/claude-opus-4-8",
                 "SENPAI_OPENHANDS_REASONING_EFFORT": "ultra",
             },
-            "unsupported for",
+            "unsupported",
         ),
         (
             {"SENPAI_OPENHANDS_FRONTIER_MODEL": "anthropic/claude-opus-4-8"},

--- a/tests/test_openhands_sdk.py
+++ b/tests/test_openhands_sdk.py
@@ -109,6 +109,7 @@ def test_supported_reasoning_effort_is_preserved(
         ("max", "openai/gpt-5.60"),
         ("medium", "wandb/zai-org/GLM-5.2"),
         ("extreme", "openai/gpt-5.6-sol"),
+        ("ultra", "openai/gpt-5.6-sol"),
     ],
 )
 def test_unsupported_reasoning_effort_fails_instead_of_being_rewritten(
@@ -231,7 +232,6 @@ def test_openai_max_uses_pro_mode_on_the_wire():
     [
         ("xhigh", "max", "max", True),
         ("max", "xhigh", "xhigh", False),
-        ("xhigh", "ultra", "max", True),
     ],
 )
 def test_file_agent_reasoning_override_replaces_the_parent_request_profile(

--- a/tests/test_training_lifecycle.py
+++ b/tests/test_training_lifecycle.py
@@ -35,6 +35,33 @@ def test_finished_training_persists_its_result_and_log(tmp_path: Path):
     assert reopened == terminal
 
 
+def test_recovery_ignores_non_training_json_sidecars(tmp_path: Path):
+    workspace = tmp_path / "workspace"
+    state_dir = tmp_path / "state"
+    workspace.mkdir()
+    state_dir.mkdir()
+    sidecar = state_dir / "b81440b1-b803-471e-9fe0-6dcabd756b83.score.json"
+    contents = '{"metrics": {}, "passed": true, "score": 1.0}'
+    sidecar.write_text(contents)
+
+    supervisor = TrainingSupervisor(workspace=workspace, state_dir=state_dir)
+
+    assert sidecar.read_text() == contents
+    supervisor.close()
+
+
+def test_recovery_rejects_a_corrupt_training_result(tmp_path: Path):
+    workspace = tmp_path / "workspace"
+    state_dir = tmp_path / "state"
+    workspace.mkdir()
+    state_dir.mkdir()
+    result = state_dir / "b81440b1-b803-471e-9fe0-6dcabd756b83.json"
+    result.write_text('{"state": "running"}')
+
+    with pytest.raises(ValueError):
+        TrainingSupervisor(workspace=workspace, state_dir=state_dir)
+
+
 def test_training_passes_shell_metacharacters_as_a_literal_argument(tmp_path: Path):
     workspace, supervisor = make_supervisor(tmp_path)
     literal = "result; $(echo not-a-shell)"

--- a/tests/test_training_processes.py
+++ b/tests/test_training_processes.py
@@ -151,6 +151,8 @@ def test_restart_stops_a_verified_orphaned_process_group(tmp_path: Path):
         log_path=str(state_dir / "orphan.log"),
     )
     (state_dir / f"{orphan.training_id}.json").write_text(orphan.model_dump_json())
+    sidecar = state_dir / f"{orphan.training_id}.score.json"
+    sidecar.write_text('{"metrics": {}, "passed": true, "score": 1.0}')
 
     try:
         supervisor = TrainingSupervisor(
@@ -162,6 +164,7 @@ def test_restart_stops_a_verified_orphaned_process_group(tmp_path: Path):
         recovered = supervisor.get_training_status(orphan.training_id)
         assert recovered.state is TrainingState.CANCELLED
         assert "supervisor restarted" in recovered.error_tail
+        assert sidecar.exists()
         assert process.wait(timeout=3) is not None
         assert_process_stopped(int(child_pid_path.read_text()))
     finally:


### PR DESCRIPTION
## Summary

- reject the retired `ultra` reasoning-effort spelling instead of silently rewriting it
- retain GPT-5.6 Pro as the explicit Responses API request `reasoning.mode: "pro"` with `effort: "max"`
- recover only exact canonical `<uuid>.json` training process records so benchmark sidecars remain untouched
- keep malformed canonical process records fail-loud

## Validation

- `uv run pytest tests/test_openhands_config.py tests/test_openhands_sdk.py tests/test_launch_images_and_rendering.py tests/test_hooks_lifecycle.py tests/test_training_lifecycle.py tests/test_training_processes.py` — 122 passed
- `uv run pytest` — 747 passed, 6 skipped
- independent diff review — no findings
- `git diff --check`