### PR TITLE
Improve delegated tool ergonomics and telemetry

### DIFF
--- a/.agents/agents/search.md
+++ b/.agents/agents/search.md
@@ -1,8 +1,8 @@
 ---
 name: search
 description: |
-  Use for external research in one explicit mode: general-web for current
-  documentation and public web sources, or research-publications for scholarly
+  Use for external research through the explicit search_general_web task form
+  for current public sources, or search_research_publications for scholarly
   literature through Exa and primary papers.
 
   <example>Find the current API behavior in official documentation.</example>

--- a/.agents/skills/senpai-tool-telemetry/.senpai-developer-only
+++ b/.agents/skills/senpai-tool-telemetry/.senpai-developer-only
@@ -1,0 +1,2 @@
+This skill is for operators developing Senpai and must not be installed into
+advisor or student runtime homes.

--- a/.agents/skills/senpai-tool-telemetry/SKILL.md
+++ b/.agents/skills/senpai-tool-telemetry/SKILL.md
@@ -1,0 +1,62 @@
+---
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: skills
+
+name: senpai-tool-telemetry
+description: Audit recent tool use across local Senpai OpenHands root and recursively delegated conversations without exposing tool arguments. Use for provider comparisons, tool-loop diagnosis, status-poll analysis, error rates, and latency reports.
+---
+
+# Senpai tool telemetry
+
+Use this developer-only skill when inspecting a copied or mounted Senpai
+OpenHands state tree. It is deliberately excluded from the skills installed
+into advisor and student runtimes.
+
+Run the read-only analyzer from the Senpai repository:
+
+```bash
+uv run python tools/senpai_tool_telemetry.py \
+  /path/to/openhands_state \
+  --hours 12 \
+  --naive-timezone UTC \
+  --json /tmp/senpai-tool-telemetry.json
+```
+
+Pass multiple state roots to compare deployments in one report. The command
+recursively discovers root and delegated-child `events/` directories. It
+prints a compact table and writes structured JSON containing per
+source/root-or-child-depth/role/model/tool calls, successes, errors, pending
+calls, retained tool latency, explicit status-check volume, and identical-call
+repetition signals.
+
+OpenHands SDK v1.40 event timestamps may be naive local wall time. Give the
+capture host's actual timezone with `--naive-timezone`, using an IANA name,
+`UTC`, or a fixed offset such as `+02:00`. For copied roots from different
+hosts, add a repeatable override such as
+`--source-timezone /path/to/cedar=+02:00`. A naive timestamp without a matching
+default or source override fails clearly; the analyzer never guesses UTC or
+the machine running the report. Explicit offsets embedded in an event are
+preserved regardless of these options.
+
+Tool arguments are never included in the report. The analyzer creates a
+short-lived in-memory fingerprint only to identify repeated identical calls.
+Do not copy raw event bodies into a report merely to recover arguments.
+
+Interpret the output carefully:
+
+- `get_training_status` and `get_job_status` counts are model-issued tool
+  calls. They do not include cheap controller-internal monitor polls.
+- Latency is action-to-observation wall time when both timestamps survived.
+- Model attribution comes from each conversation's current
+  `base_state.json`. If a conversation changed models in place, older calls
+  cannot be attributed more precisely from the event store alone.
+- A pending call has no matching persisted observation. It may be genuinely
+  active or evidence of an interrupted turn.
+- A rapid repeat means the same conversation called the same tool with the
+  same arguments inside the configured repetition window. It is a diagnostic
+  signal, not automatically a bug.
+
+Report evidence before recommendations. Separate provider behavior from
+runtime failures such as dead terminal sessions, missing observations, or
+schema errors.

--- a/README.md
+++ b/README.md
@@ -241,24 +241,34 @@ After launch, the student can finish its turn. The deterministic controller poll
 
 Worker and container restarts preserve completed OpenHands events. Recovered live training is terminated safely rather than being adopted under an unverifiable process identity; the original student conversation receives the persisted terminal outcome.
 
+Interactive browser operations are progressively disclosed. A fresh root
+conversation initially sees only `load_browser`; invoking it adds the fourteen
+OpenHands browser operations and records the choice in conversation state so a
+resumed conversation restores them. `--no-browser` exposes neither the loader
+nor the browser family.
+
 ## Subagents
 
 `spawn_agents` launches a batch and immediately returns stable task IDs;
-`await_agents` collects them with an `all`, `first`, or `quorum` join. Every
-child runs in a fresh OpenHands conversation and separate process group.
+`await_agents` collects them with an `all`, `first`, `quorum`, or any-state
+`change` join; `change` also surfaces an uncollected terminal result
+immediately. A timed-out wait returns current state and suggests non-blocking
+next steps; it does not cancel the children. Every child runs in a fresh
+OpenHands conversation and separate process group.
 
 | Agent | Best for | Recommended tier |
 |---|---|---|
 | [General Purpose](.agents/agents/general-purpose.md) | Bounded work combining terminal investigation, code editing, task tracking, tests, and one controlled level of leaf delegation. | `smart` for ordinary implementation or review; `frontier` for the hardest generalist work. |
 | [Explore](.agents/agents/explore.md) | Read-only search across code, data, experiment artifacts, papers, or durable conversation history. It returns conclusions with paths and line numbers rather than dumping source. | `fast` for mechanical exploration; `smart` when relationships are subtle. |
-| [Search](.agents/agents/search.md) | External research through Exa in `general-web` or `research-publications` mode, with primary-source links. | `smart`. |
+| [Search](.agents/agents/search.md) | External research through Exa via the explicit `search_general_web` or `search_research_publications` task form, with primary-source links. | `smart`. |
 | [Bash Runner](.agents/agents/bash-runner.md) | Tests, builds, linters, dependency commands, Git inspection, and noisy CLI work. It returns counts and actionable failures rather than raw logs. | `fast`. |
 
 The model tier is independent of the agent specialization. With the default
 `agent=general-purpose`, `model=frontier` launches GPT-5.6 Sol at `max`, sent
 to the Responses API with `reasoning.mode: pro`
 with the general-purpose terminal and code-editing toolset. Pair `frontier`
-with `agent=search` when the hard task is external or publication research.
+with `search_general_web` or `search_research_publications` when the hard task
+is external research.
 
 A root spawn batch and its descendants form one delegation tree, which may
 create at most eight children total. A role runs at most eight active tasks

--- a/SPEC.md
+++ b/SPEC.md
@@ -395,19 +395,20 @@ spawn_agents(
   tasks: [{
     key: str | null = null,
     task: str,
-    agent: general-purpose | explore | search | bash-runner = general-purpose,
+    agent: general-purpose | explore | search_general_web |
+           search_research_publications | bash-runner = general-purpose,
     model: fast | smart | frontier = smart,
     include_context: bool = false,
-    search_mode: general-web | research-publications | null = null,
   }],
 ) -> {tasks: [{task_id, key, status, agent, model, result?, error?}]}
 
 await_agents(
   task_ids: [str],
-  join: all | first | quorum = all,
+  join: all | first | quorum | change = all,
   quorum: int | null = null,
   timeout_seconds: float,
-) -> {join, satisfied, timed_out, tasks: [{task_id, key, status, agent, model, result?, error?}]}
+) -> {join, satisfied, timed_out, changed_task_ids, waited_seconds, guidance,
+      tasks: [{task_id, key, status, agent, model, result?, error?}]}
 
 agent_status(
   task_ids: [str] | null = null,
@@ -430,10 +431,14 @@ it never launches duplicate children. Reusing a batch key with a different
 task specification fails clearly.
 
 `await_agents` is the only blocking delegation operation. `all` waits for every
-selected task to reach a terminal state, `first` waits for any one, and
-`quorum` waits for the requested number. Its timeout is required and capped at
-300 seconds; expiry returns `satisfied=false` plus the current records without
-cancelling unfinished work. `agent_status` is a non-blocking snapshot. With no
+selected task to reach a terminal state, `first` waits for any one, `quorum`
+waits for the requested number, and `change` returns when any selected task
+changes state or immediately when one has an uncollected terminal result. Its
+timeout is required and capped at 300 seconds; expiry returns
+`satisfied=false`, current records, elapsed time, and next-step guidance without
+cancelling unfinished work. Any terminal results included in that response are
+marked collected so a later event does not repeat them. `agent_status` is a
+non-blocking snapshot. With no
 task IDs, it returns up to eight direct tasks that are active or have an
 uncollected terminal result; explicit task IDs can retrieve older history.
 `cancel_agents` terminates selected pending or running process groups and
@@ -458,7 +463,7 @@ This makes chains such as Explore -> Explore impossible without constraining a
 later research phase to the first batch's lifetime budget.
 
 The tree inherits one absolute root-turn deadline. Each task also has a tier
-runtime cap: 300 seconds for `fast`, 600 for `smart`, and 1,500 for `frontier`.
+runtime cap: 600 seconds for `fast`, 1,800 for `smart`, and 3,600 for `frontier`.
 The effective deadline is the earlier of that cap and the inherited root
 deadline. Reaching it interrupts the complete process group and records a
 terminal timeout; no descendant survives the tree deadline.
@@ -479,16 +484,17 @@ combinations fail clearly. The built-in file agents inherit the selected
 profile's effort.
 
 `explore` searches code, data, PR artifacts, and durable history and returns
-concise conclusions with paths and line numbers. `search` requires exactly one
-mode: `general-web` uses Exa's general index with agent-oriented defaults,
-while `research-publications` uses Exa's publication index and primary papers.
+concise conclusions with paths and line numbers. `search_general_web` uses
+Exa's general index with agent-oriented defaults, while
+`search_research_publications` uses Exa's publication index and primary papers.
 `general-purpose` handles mixed terminal investigation, code editing, task
 tracking, tests, and one controlled level of leaf delegation. It is the default
 frontier agent, so a frontier task is generalist unless the caller deliberately
-selects `explore`, `search`, or `bash-runner`. `bash-runner` has only the
-terminal and runs tests, builds, linters, formatters, dependency commands, Git
-inspection, or system checks. It normally uses the fast model and returns
-counts and actionable failures rather than raw command output.
+selects `explore`, one of the explicit search forms, or `bash-runner`.
+`bash-runner` has only the terminal and runs tests, builds, linters, formatters,
+dependency commands, Git inspection, or system checks. It normally uses the
+fast model and returns counts and actionable failures rather than raw command
+output.
 
 With `include_context=false`, the child receives the merged system prompt and
 task and may search the parent's durable history path. With

--- a/plugins/senpai/scripts/agent-context.sh
+++ b/plugins/senpai/scripts/agent-context.sh
@@ -12,6 +12,10 @@ install_senpai_agent_context() {
 
     mkdir -p "$HOME/.agents/skills"
     cp -a "$workdir/.agents/." "$HOME/.agents/"
+    for marker in "$HOME"/.agents/skills/*/.senpai-developer-only; do
+        [ -e "$marker" ] || continue
+        rm -rf -- "${marker%/.senpai-developer-only}"
+    done
     cp -a "$source_plugin" "$runtime_plugin"
     "$SENPAI_PYTHON" -m senpai_agent.agent_markdown \
         "$HOME/.agents" "$runtime_plugin"

--- a/senpai_agent/delegation.py
+++ b/senpai_agent/delegation.py
@@ -40,6 +40,19 @@ if TYPE_CHECKING:
 
 
 AgentKind = Literal["general-purpose", "explore", "search", "bash-runner"]
+TaskAgentKind = Literal[
+    "general-purpose",
+    "explore",
+    "search_general_web",
+    "search_research_publications",
+    "bash-runner",
+]
+LeafTaskAgentKind = Literal[
+    "explore",
+    "search_general_web",
+    "search_research_publications",
+    "bash-runner",
+]
 ModelTier = Literal["smart", "fast", "frontier"]
 SearchMode = Literal["general-web", "research-publications"]
 MAX_PARALLEL_AGENTS = 8
@@ -59,7 +72,7 @@ TaskStatus = Literal[
     "failed",
     "cancelled",
 ]
-JoinMode = Literal["all", "first", "quorum"]
+JoinMode = Literal["all", "first", "quorum", "change"]
 TERMINAL_TASK_STATUSES = frozenset({"finished", "failed", "cancelled"})
 
 
@@ -560,7 +573,16 @@ class DelegateAgentObservation(Observation):
         ]
 
 
-class AgentTask(BaseModel):
+def resolve_task_agent(agent: TaskAgentKind) -> tuple[AgentKind, SearchMode | None]:
+    if agent == "search_general_web":
+        return "search", "general-web"
+    if agent == "search_research_publications":
+        return "search", "research-publications"
+    return agent, None
+
+
+class AgentTaskBase(BaseModel):
+    agent: TaskAgentKind
     key: str | None = Field(
         default=None,
         min_length=1,
@@ -571,10 +593,6 @@ class AgentTask(BaseModel):
         min_length=1,
         description="Self-contained assignment and requested evidence-linked report.",
     )
-    agent: AgentKind = Field(
-        default="general-purpose",
-        description="Use a leaf specialization or general-purpose for mixed work.",
-    )
     model: ModelTier = Field(
         default="smart",
         description="Fast for mechanical work, smart for synthesis, frontier for the hardest work.",
@@ -583,16 +601,88 @@ class AgentTask(BaseModel):
         default=False,
         description="Copy the complete model-visible parent history into this child.",
     )
-    search_mode: SearchMode | None = Field(
-        default=None,
-        description="Required only for search: general-web or research-publications.",
+
+    def resolved_agent(self) -> tuple[AgentKind, SearchMode | None]:
+        return resolve_task_agent(self.agent)
+
+    @model_validator(mode="before")
+    @classmethod
+    def restore_persisted_search_task(cls, value: object) -> object:
+        if not isinstance(value, Mapping) or value.get("agent") != "search":
+            return value
+        modes = {
+            "general-web": "search_general_web",
+            "research-publications": "search_research_publications",
+        }
+        restored = dict(value)
+        restored["agent"] = modes.get(restored.pop("search_mode", None), "search")
+        return restored
+
+
+class AgentTask(AgentTaskBase):
+    agent: TaskAgentKind = Field(
+        default="general-purpose",
+        description=(
+            "Use general-purpose for mixed work, explore or bash-runner for local "
+            "leaf work, and an explicit search form for external research."
+        ),
     )
 
-    @model_validator(mode="after")
-    def validate_search_mode(self) -> Self:
-        if (self.agent == "search") != (self.search_mode is not None):
-            raise ValueError("search_mode is required only when agent=search")
-        return self
+
+class LeafAgentTask(AgentTaskBase):
+    agent: LeafTaskAgentKind = Field(
+        default="explore",
+        description=(
+            "Choose a leaf specialization: explore, bash-runner, "
+            "search_general_web, or search_research_publications."
+        ),
+    )
+
+
+_PERSISTED_TASK_SPEC_FIELDS = frozenset(AgentTask.model_fields) | {"search_mode"}
+
+
+def _task_specs_json(specs: Sequence[AgentTaskBase]) -> str:
+    return json.dumps(
+        [spec.model_dump(mode="json") for spec in specs],
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _canonical_persisted_task_specs(encoded: str) -> str:
+    try:
+        payload = json.loads(encoded)
+    except json.JSONDecodeError as error:
+        raise RuntimeError(
+            "persisted delegation task specifications are invalid"
+        ) from error
+    if not isinstance(payload, list):
+        raise RuntimeError("persisted delegation task specifications must be a list")
+
+    specs = []
+    for item in payload:
+        if not isinstance(item, Mapping):
+            raise RuntimeError(
+                "persisted delegation task specifications must be objects"
+            )
+        unknown = set(item) - _PERSISTED_TASK_SPEC_FIELDS
+        if unknown:
+            fields = ", ".join(sorted(unknown))
+            raise RuntimeError(
+                f"persisted delegation task specifications have unknown fields: {fields}"
+            )
+        if item.get("agent") != "search" and item.get("search_mode") is not None:
+            raise RuntimeError(
+                "persisted delegation task specifications have an invalid search mode"
+            )
+        try:
+            specs.append(AgentTask.model_validate(item))
+        except ValueError as error:
+            raise RuntimeError(
+                "persisted delegation task specifications are invalid"
+            ) from error
+    return _task_specs_json(specs)
 
 
 class AgentTaskState(BaseModel):
@@ -684,14 +774,10 @@ class DelegationRegistry:
         parent_conversation_id: str,
         parent_task_id: str | None,
         depth: int,
-        specs: Sequence[AgentTask],
+        specs: Sequence[AgentTaskBase],
         deadlines: Sequence[float],
     ) -> tuple[list[sqlite3.Row], bool]:
-        specs_json = json.dumps(
-            [spec.model_dump(mode="json") for spec in specs],
-            sort_keys=True,
-            separators=(",", ":"),
-        )
+        specs_json = _task_specs_json(specs)
         keys = [spec.key or str(index) for index, spec in enumerate(specs)]
         if len(keys) != len(set(keys)):
             raise ValueError("task keys must be unique within a spawn batch")
@@ -713,7 +799,10 @@ class DelegationRegistry:
                 (operation_key,),
             ).fetchone()
             if existing is not None:
-                if existing["specs_json"] != specs_json:
+                if (
+                    _canonical_persisted_task_specs(existing["specs_json"])
+                    != specs_json
+                ):
                     raise ValueError(
                         "batch_key was already used with different task specifications"
                     )
@@ -761,6 +850,7 @@ class DelegationRegistry:
             for task_id, key, spec, deadline in zip(
                 task_ids, keys, specs, deadlines, strict=True
             ):
+                agent, search_mode = spec.resolved_agent()
                 database.execute(
                     """
                     INSERT INTO tasks (
@@ -777,9 +867,9 @@ class DelegationRegistry:
                         parent_task_id,
                         spec.key,
                         spec.task,
-                        spec.agent,
+                        agent,
                         spec.model,
-                        spec.search_mode,
+                        search_mode,
                         depth,
                         deadline,
                         now,
@@ -1229,7 +1319,7 @@ class _DelegationManager:
         with self.registry.lifecycle():
             self._reconcile(self.registry.active_rows())
 
-    def _validate_spawn(self, tasks: Sequence[AgentTask]) -> None:
+    def _validate_spawn(self, tasks: Sequence[AgentTaskBase]) -> None:
         if not tasks or len(tasks) > MAX_SPAWN_BATCH:
             raise ValueError(f"spawn_agents requires 1 to {MAX_SPAWN_BATCH} tasks")
         if self.config.depth >= MAX_DELEGATION_DEPTH:
@@ -1241,7 +1331,7 @@ class _DelegationManager:
                 raise ValueError(
                     "explore, search, and bash-runner agents are delegation leaves"
                 )
-            if any(task.agent == "general-purpose" for task in tasks):
+            if any(task.resolved_agent()[0] == "general-purpose" for task in tasks):
                 raise ValueError("depth-2 helpers must be leaf agents")
 
     def spawn(
@@ -1293,13 +1383,14 @@ class _DelegationManager:
             context = (
                 _model_visible_context(conversation) if task.include_context else ()
             )
+            agent, search_mode = task.resolved_agent()
             request = DelegationRequest(
                 task_id=row["task_id"],
                 parent_conversation_id=parent_id,
                 parent_context=context,
-                agent=task.agent,
+                agent=agent,
                 model=task.model,
-                search_mode=task.search_mode,
+                search_mode=search_mode,
                 tree_id=tree_id,
                 depth=self.config.depth + 1,
                 deadline_epoch=row["deadline_epoch"],
@@ -1396,11 +1487,38 @@ class _DelegationManager:
         with self.registry.lifecycle():
             return self._states_locked(task_ids, conversation)
 
+    def await_snapshot(
+        self,
+        task_ids: Sequence[str],
+        conversation: LocalConversation,
+    ) -> tuple[list[AgentTaskState], frozenset[str]]:
+        with self.registry.lifecycle():
+            rows = self._owned_rows_locked(task_ids, conversation)
+            return (
+                [_row_state(row) for row in rows],
+                frozenset(
+                    row["task_id"]
+                    for row in rows
+                    if row["status"] in TERMINAL_TASK_STATUSES
+                    and row["collected_at"] is None
+                ),
+            )
+
     def _states_locked(
         self,
         task_ids: Sequence[str] | None,
         conversation: LocalConversation,
     ) -> list[AgentTaskState]:
+        return [
+            _row_state(row)
+            for row in self._owned_rows_locked(task_ids, conversation)
+        ]
+
+    def _owned_rows_locked(
+        self,
+        task_ids: Sequence[str] | None,
+        conversation: LocalConversation,
+    ) -> list[sqlite3.Row]:
         rows = self.registry.rows(
             task_ids,
             parent_conversation_id=(str(conversation.id) if task_ids is None else None),
@@ -1408,12 +1526,7 @@ class _DelegationManager:
         if any(row["parent_conversation_id"] != str(conversation.id) for row in rows):
             raise ValueError("a caller may inspect only its own subagent tasks")
         self._reconcile(rows)
-        return [
-            _row_state(row)
-            for row in self.registry.rows(
-                [row["task_id"] for row in rows],
-            )
-        ]
+        return self.registry.rows([row["task_id"] for row in rows])
 
     def cancel(
         self,
@@ -1470,6 +1583,19 @@ class SpawnAgentsAction(Action):
     )
 
 
+class LeafSpawnAgentsAction(Action):
+    batch_key: str = Field(
+        min_length=1,
+        max_length=128,
+        description="Stable idempotency key; changed specs on replay are rejected.",
+    )
+    tasks: list[LeafAgentTask] = Field(
+        min_length=1,
+        max_length=MAX_SPAWN_BATCH,
+        description="One to eight leaf tasks started without waiting for results.",
+    )
+
+
 class SpawnAgentsObservation(Observation):
     tasks: list[AgentTaskState]
 
@@ -1486,7 +1612,10 @@ class AwaitAgentsAction(Action):
     )
     join: JoinMode = Field(
         default="all",
-        description="Return after all, the first, or a quorum become terminal.",
+        description=(
+            "Return after all, the first, or a quorum become terminal, or after "
+            "any selected task changes state or has an uncollected terminal result."
+        ),
     )
     quorum: int | None = Field(
         default=None,
@@ -1516,6 +1645,9 @@ class AwaitAgentsObservation(Observation):
     satisfied: bool
     timed_out: bool
     tasks: list[AgentTaskState]
+    changed_task_ids: list[str] = Field(default_factory=list)
+    waited_seconds: float = 0
+    guidance: str = ""
 
     @property
     def to_llm_content(self) -> Sequence[TextContent]:
@@ -1605,32 +1737,65 @@ class _AwaitAgentsExecutor(ToolExecutor[AwaitAgentsAction, AwaitAgentsObservatio
         if conversation is None:
             raise ValueError("await_agents requires its parent conversation")
         self._interrupted.clear()
+        started = time.monotonic()
         inherited = self.manager.config.deadline_epoch or float("inf")
         deadline = min(time.time() + action.timeout_seconds, inherited)
+        tasks, uncollected_terminal = self.manager.await_snapshot(
+            action.task_ids,
+            conversation,
+        )
+        initial_statuses = {task.task_id: task.status for task in tasks}
         while True:
-            tasks = self.manager.states(action.task_ids, conversation)
             terminal = sum(task.status in TERMINAL_TASK_STATUSES for task in tasks)
-            required = {
-                "all": len(tasks),
-                "first": 1,
-                "quorum": action.quorum or len(tasks),
-            }[action.join]
-            if terminal >= required:
+            changed = [
+                task.task_id
+                for task in tasks
+                if task.status != initial_statuses[task.task_id]
+            ]
+            if action.join == "change":
+                satisfied = bool(changed) or bool(uncollected_terminal)
+            else:
+                required = {
+                    "all": len(tasks),
+                    "first": 1,
+                    "quorum": action.quorum or len(tasks),
+                }[action.join]
+                satisfied = terminal >= required
+            if satisfied:
                 self._acknowledge(tasks)
                 return AwaitAgentsObservation(
                     join=action.join,
                     satisfied=True,
                     timed_out=False,
                     tasks=tasks,
+                    changed_task_ids=changed,
+                    waited_seconds=round(time.monotonic() - started, 3),
+                    guidance=(
+                        "Use the returned state now; unfinished sibling tasks keep "
+                        "running unless you cancel them explicitly."
+                    ),
                 )
             remaining = deadline - time.time()
             if remaining <= 0 or self._interrupted.wait(min(0.1, remaining)):
+                self._acknowledge(tasks)
                 return AwaitAgentsObservation(
                     join=action.join,
                     satisfied=False,
                     timed_out=True,
                     tasks=tasks,
+                    changed_task_ids=changed,
+                    waited_seconds=round(time.monotonic() - started, 3),
+                    guidance=(
+                        "The tasks keep running. Continue useful parent work, inspect "
+                        "later with agent_status, or use join='change' for the next "
+                        "bounded wait; repeating the same long all-results "
+                        "wait will block on the same unfinished tasks."
+                    ),
                 )
+            tasks, uncollected_terminal = self.manager.await_snapshot(
+                action.task_ids,
+                conversation,
+            )
 
     def _acknowledge(self, tasks: Sequence[AgentTaskState]) -> None:
         terminal = [
@@ -1756,10 +1921,16 @@ class SpawnAgentsTool(_DelegationTool[SpawnAgentsAction, SpawnAgentsObservation]
         event_db_path=None,
     ) -> Sequence[Self]:
         manager = cls._manager(child_runner_factory, event_sink, event_db_path)
+        action_type = (
+            LeafSpawnAgentsAction
+            if manager.config.depth == 1
+            and manager.config.agent_name == "general-purpose"
+            else SpawnAgentsAction
+        )
         return [
             cls(
                 description="Start one bounded batch of subagents and return task IDs immediately.",
-                action_type=SpawnAgentsAction,
+                action_type=action_type,
                 observation_type=SpawnAgentsObservation,
                 annotations=ToolAnnotations(
                     title="Spawn agents",
@@ -1781,7 +1952,12 @@ class AwaitAgentsTool(_DelegationTool[AwaitAgentsAction, AwaitAgentsObservation]
         manager = cls._manager(None, None, event_db_path)
         return [
             cls(
-                description="Wait for all, the first, or a quorum of spawned agents.",
+                description=(
+                    "Wait for all, the first, a quorum, or any state change among "
+                    "spawned agents. The change join also immediately surfaces an "
+                    "uncollected terminal result. A timeout returns live state and "
+                    "practical next-step feedback without cancelling work."
+                ),
                 action_type=AwaitAgentsAction,
                 observation_type=AwaitAgentsObservation,
                 annotations=ToolAnnotations(title="Await agents", readOnlyHint=False),

--- a/senpai_agent/openhands_runner.py
+++ b/senpai_agent/openhands_runner.py
@@ -27,6 +27,7 @@ from senpai_agent.advisor import (
     compose_system_instructions,
 )
 from senpai_agent.delegation import (
+    MAX_DELEGATION_DEPTH,
     MAX_PARALLEL_AGENTS,
     DelegationConfig,
     cancel_pending_descendants,
@@ -425,6 +426,12 @@ def sanitized_project_skills(workspace: Path) -> list[Skill]:
     return [
         skill.model_copy(update={"content": strip_spdx_header(skill.content)})
         for skill in load_project_skills(workspace)
+        if not (
+            skill.source
+            and (
+                workspace / Path(skill.source).parent / ".senpai-developer-only"
+            ).is_file()
+        )
     ]
 
 
@@ -448,6 +455,24 @@ def sanitized_agent_definitions(workspace: Path) -> list[AgentDefinition]:
             ),
         )
     ]
+
+
+def depth_aware_child_definition(
+    definition: AgentDefinition,
+    *,
+    child: bool,
+    depth: int,
+) -> AgentDefinition:
+    """Expose recursive spawn only to the one child role that can use it."""
+
+    if not child or (
+        definition.name == "general-purpose"
+        and 0 < depth < MAX_DELEGATION_DEPTH
+    ):
+        return definition
+    return definition.model_copy(
+        update={"tools": [tool for tool in definition.tools if tool != "spawn_agents"]}
+    )
 
 
 def register_agent_definitions(
@@ -969,7 +994,7 @@ def build_main_tools(config: RunnerConfig) -> list[Tool]:
     tools = [
         tool
         for tool in get_default_tools(
-            enable_browser=config.enable_browser,
+            enable_browser=False,
             enable_sub_agents=False,
         )
         if tool.name != "terminal"
@@ -989,6 +1014,10 @@ def build_main_tools(config: RunnerConfig) -> list[Tool]:
             ),
         )
     )
+    if config.enable_browser:
+        # Keep the persisted spec name stable while its resolver exposes only
+        # the lightweight load_browser definition until the model opts in.
+        tools.append(Tool(name="browser_tool_set"))
     delegation_params = {"event_db_path": str(local_event_db_path(config))}
     if not config.child:
         tools.append(Tool(name="delegate_agent", params=delegation_params))
@@ -1201,7 +1230,7 @@ def run_openhands(
     scrub_model_credentials(os.environ, config)
     harness_instructions = read_role_instructions(config.harness_file)
     role_instructions = read_role_instructions(config.role_file)
-    register_default_tools(enable_browser=config.enable_browser)
+    register_default_tools(enable_browser=False)
     register_senpai_tools()
     file_agents = sanitized_agent_definitions(config.workspace)
     register_agent_definitions(file_agents, config.workspace)
@@ -1287,7 +1316,11 @@ def run_openhands(
             ),
         )
         if config.agent_name:
-            definition = find_named_agent(config.agent_name, file_agents)
+            definition = depth_aware_child_definition(
+                find_named_agent(config.agent_name, file_agents),
+                child=config.child,
+                depth=config.delegation_depth,
+            )
             agent = agent_definition_to_factory(
                 definition,
                 work_dir=config.workspace,

--- a/senpai_agent/tools.py
+++ b/senpai_agent/tools.py
@@ -12,17 +12,20 @@ from typing import TYPE_CHECKING, Literal, Self
 from openhands.sdk.llm import TextContent
 from openhands.sdk.tool import (
     Action,
+    DeclaredResources,
     Observation,
     ToolAnnotations,
     ToolDefinition,
     ToolExecutor,
     register_tool,
 )
+from openhands.tools.browser_use import BrowserToolSet
 from openhands.tools.terminal import (
     TerminalAction,
     TerminalObservation,
     TerminalTool,
 )
+from openhands.tools.task_tracker import TaskTrackerTool
 from pydantic import Field, model_validator
 
 from senpai_agent.delegation import (
@@ -43,13 +46,117 @@ from senpai_agent.training import (
 )
 
 if TYPE_CHECKING:
-    from openhands.sdk.conversation import LocalConversation
+    from openhands.sdk.conversation import ConversationState, LocalConversation
 
 
 _TRAINING_RUNTIMES: dict[
     Path,
     tuple[TrainingSupervisor, MonitorStore],
 ] = {}
+_BROWSER_ENABLED_STATE_KEY = "senpai.browser_enabled"
+
+
+class LoadBrowserAction(Action):
+    """Enable the browser tool family for this conversation."""
+
+
+class LoadBrowserObservation(Observation):
+    tools: tuple[str, ...]
+
+    @property
+    def to_llm_content(self) -> Sequence[TextContent]:
+        return [
+            TextContent(
+                text=(
+                    "Browser tools are now available: "
+                    + ", ".join(self.tools)
+                    + "."
+                )
+            )
+        ]
+
+
+class _LoadBrowserExecutor(
+    ToolExecutor[LoadBrowserAction, LoadBrowserObservation]
+):
+    def __call__(
+        self,
+        action: LoadBrowserAction,  # noqa: ARG002
+        conversation: LocalConversation | None = None,
+    ) -> LoadBrowserObservation:
+        if conversation is None:
+            raise ValueError("load_browser requires its parent conversation")
+        if conversation.state.agent_state.get(_BROWSER_ENABLED_STATE_KEY):
+            names = tuple(
+                name
+                for name in conversation.agent.tools_map
+                if name.startswith("browser_")
+            )
+            return LoadBrowserObservation(tools=names)
+
+        browser_tools = BrowserToolSet.create(conversation.state)
+        conversation.agent.add_runtime_tools(browser_tools)
+        conversation.state.agent_state = {
+            **conversation.state.agent_state,
+            _BROWSER_ENABLED_STATE_KEY: True,
+        }
+        return LoadBrowserObservation(tools=tuple(tool.name for tool in browser_tools))
+
+
+class LoadBrowserTool(ToolDefinition[LoadBrowserAction, LoadBrowserObservation]):
+    name = "load_browser"
+
+    def declared_resources(self, action: Action) -> DeclaredResources:  # noqa: ARG002
+        return DeclaredResources(keys=("browser-tools",), declared=True)
+
+    @classmethod
+    def create(
+        cls,
+        conv_state: ConversationState,
+    ) -> Sequence[ToolDefinition]:
+        if conv_state.agent_state.get(_BROWSER_ENABLED_STATE_KEY):
+            return BrowserToolSet.create(conv_state)
+        return [
+            cls(
+                description=(
+                    "Load the full browser tool family for this conversation. "
+                    "Use it when interactive web navigation or page inspection is "
+                    "needed; the browser operations become available on the next step."
+                ),
+                action_type=LoadBrowserAction,
+                observation_type=LoadBrowserObservation,
+                annotations=ToolAnnotations(
+                    title="Load browser tools",
+                    readOnlyHint=False,
+                    destructiveHint=False,
+                    idempotentHint=True,
+                    openWorldHint=True,
+                ),
+                executor=_LoadBrowserExecutor(),
+            )
+        ]
+
+
+_TASK_TRACKER_DESCRIPTION = """Maintain an optional persisted task list for complex work.
+
+Use it when a task has several meaningful steps or concurrent workstreams and a
+compact todo/in-progress/done record will prevent omissions. Multiple items may
+be in progress when the work is genuinely parallel. Skip it for short, atomic,
+or purely informational work. View the current list before replacing it, keep
+entries concise, and mark work done only when its required evidence is complete."""
+
+
+class SenpaiTaskTrackerTool(TaskTrackerTool):
+    """OpenHands task persistence with a concise, concurrency-safe description."""
+
+    name = "task_tracker"
+
+    @classmethod
+    def create(cls, conv_state: ConversationState) -> Sequence[ToolDefinition]:
+        return [
+            tool.model_copy(update={"description": _TASK_TRACKER_DESCRIPTION})
+            for tool in super().create(conv_state)
+        ]
 
 
 def training_runtime(
@@ -609,5 +716,8 @@ def register_senpai_tools() -> None:
     register_tool("agent_status", AgentStatusTool)
     register_tool("cancel_agents", CancelAgentsTool)
     register_tool("delegate_agent", DelegateAgentTool)
+    register_tool("browser_tool_set", LoadBrowserTool)
+    register_tool("load_browser", LoadBrowserTool)
+    register_tool("task_tracker", SenpaiTaskTrackerTool)
     register_tool("senpai_terminal", SenpaiTerminalTool)
     _TOOLS_REGISTERED = True

--- a/system_instructions/ADVISOR.md
+++ b/system_instructions/ADVISOR.md
@@ -69,14 +69,15 @@ Use clear PR, run, and task identifiers so compacted history remains
 unambiguous. A new event does not invalidate unrelated ongoing research.
 
 Use `spawn_agents` whenever the work would benefit from our strongest
-available intelligence: broad literature overviews, synthesis across many
-results, a fresh angle after a plateau, or review of large, messy, or subtle
-code changes. In that spawn batch, set the task fields to `model="frontier"`,
-`agent="general-purpose"`, and `include_context=false`. Treat the frontier
-agent as an advisor, not a do-er: give it a self-contained question and
-relevant starting points, let it explore independently, and ask for research,
-critique, creative ideas, plans, or implementation guidance—not code changes
-or implementation. Do not pass prior
+available intelligence: synthesis across many results, a fresh angle after a
+plateau, or review of large, messy, or subtle code changes. For external
+research, select `search_general_web` or `search_research_publications`. For
+hard local or mixed-evidence synthesis, set the task fields to
+`model="frontier"`, `agent="general-purpose"`, and `include_context=false`.
+Treat the frontier agent as an advisor, not a do-er: give it a self-contained
+question and relevant starting points, let it explore independently, and ask
+for research, critique, creative ideas, plans, or implementation guidance—not
+code changes or implementation. Do not pass prior
 conversation context by default; its fresh perspective is part of the value.
 Use it readily when its breadth or judgment could materially improve the
 decision, while leaving routine work to smart or fast agents.

--- a/system_instructions/SENPAI-HARNESS.md
+++ b/system_instructions/SENPAI-HARNESS.md
@@ -39,11 +39,13 @@ only when its named tool is present in your schema:
   in separate processes and immediately returns stable task IDs. Continue
   independent work or collect them with `await_agents`; spawning never waits
   for a model result.
-- `await_agents` supports `join=all`, `join=first`, and `join=quorum`. Give it
-  one timeout of at most five minutes. A timeout returns the current results
-  without cancelling unfinished work. Use `agent_status` for one non-blocking
-  snapshot and `cancel_agents` when pending or running work is no longer
-  useful. Do not poll either tool in a loop.
+- `await_agents` supports `join=all`, `join=first`, `join=quorum`, and
+  `join=change`; `change` returns on any selected task transition or an
+  uncollected terminal result. Give it one
+  timeout of at most five minutes. A timeout returns current results and
+  next-step guidance without cancelling unfinished work. Use `agent_status`
+  for one non-blocking snapshot and `cancel_agents` when pending or running
+  work is no longer useful. Do not poll either tool in a loop.
 - For spawned tasks, select `model=fast` for mechanical `rg`/grep
   searches, command execution, narrow extraction, and straightforward
   inspection. Select `model=smart` for code review, ambiguous synthesis,
@@ -54,10 +56,11 @@ only when its named tool is present in your schema:
   task tracking, and spawn one bounded level of leaf helpers.
 - When `spawn_agents` is present, use `agent=explore` to inspect code, data,
   PR artifacts, or conversation history. Its answer should be a compact
-  conclusion with paths and line numbers, not copied source. Use `agent=search`
-  with exactly one of `general-web` or `research-publications`. Both modes use
-  Exa with mode-appropriate parameters; publication research should follow
-  results into primary papers. Use `agent=bash-runner`, normally with
+  conclusion with paths and line numbers, not copied source. Use
+  `agent=search_general_web` for current public sources or
+  `agent=search_research_publications` for scholarly literature. Both use Exa
+  with mode-appropriate parameters; publication research should follow results
+  into primary papers. Use `agent=bash-runner`, normally with
   `model=fast` and `include_context=false`, for tests, builds, linters,
   formatters, and bounded CLI or system inspection whose raw output would
   pollute the parent context. Delay awaiting it only when the parent will not
@@ -73,6 +76,9 @@ only when its named tool is present in your schema:
   monitor without model polling. `cancel_training` stops one supervised run
   and retires its monitor; use it instead of killing training processes through
   the terminal.
+- When present, `load_browser` adds the full interactive browser family on the
+  next step. Call it only when browser navigation or page inspection is useful;
+  loading is idempotent and persists for the conversation.
 - When present, operation-specific GitHub tools own the complete mutation they
   name. Advisors may receive `create_assignment`, `publish_advisor_branch`,
   `repair_assignment_routing`, `send_assignment_feedback`,
@@ -98,8 +104,9 @@ attention, submit them in one batch. Every task needs a precise deliverable and
 compact report contract. Give the batch its required stable key. Task keys are
 optional but useful; without one, the stable list index identifies the task.
 Reuse a key only for the identical specification. Use `join=all` only when
-every answer is required; prefer `first` or `quorum` when enough evidence can
-support the next decision, then cancel work that no longer has value.
+every answer is required; prefer `change`, `first`, or `quorum` when partial
+progress can support the next decision, then cancel work that no longer has
+value.
 
 Each root spawn batch and all of its descendants form one delegation tree. A
 tree can create at most eight children in total, every spawn batch is limited

--- a/tests/test_advisor_runtime.py
+++ b/tests/test_advisor_runtime.py
@@ -17,7 +17,7 @@ from senpai_agent.advisor import (
     advisor_main,
     deliver_pending_events,
 )
-from senpai_agent.delegation import DelegateAgentAction, DelegateAgentObservation
+from senpai_agent.delegation import AgentStatusAction, AgentStatusObservation
 
 
 class ConversationStateStub:
@@ -47,33 +47,29 @@ class ConversationStateStub:
         self._lock.release()
 
 
-def pending_delegate_action() -> ActionEvent:
-    action = DelegateAgentAction(task="Inspect the timeout")
+def pending_tool_action() -> ActionEvent:
+    action = AgentStatusAction()
     return ActionEvent(
         thought=[],
         action=action,
-        tool_name="delegate_agent",
-        tool_call_id="delegate-call",
+        tool_name="agent_status",
+        tool_call_id="status-call",
         tool_call=MessageToolCall(
-            id="delegate-call",
-            name="delegate_agent",
+            id="status-call",
+            name="agent_status",
             arguments=json.dumps(action.model_dump(mode="json")),
             origin="completion",
         ),
-        llm_response_id="delegate-response",
+        llm_response_id="status-response",
     )
 
 
-def completed_delegate_action(action: ActionEvent) -> ObservationEvent:
+def completed_tool_action(action: ActionEvent) -> ObservationEvent:
     return ObservationEvent(
-        tool_name="delegate_agent",
+        tool_name="agent_status",
         tool_call_id=action.tool_call_id,
         action_id=action.id,
-        observation=DelegateAgentObservation(
-            task_id="task-1",
-            status="finished",
-            result="done",
-        ),
+        observation=AgentStatusObservation(tasks=[]),
     )
 
 
@@ -174,7 +170,7 @@ def test_event_pump_keeps_events_queued_while_a_tool_action_is_unmatched(
 
     class Conversation:
         def __init__(self):
-            self.state = ConversationStateStub([pending_delegate_action()])
+            self.state = ConversationStateStub([pending_tool_action()])
             self.messages: list[str] = []
 
         def send_message(self, message: str) -> None:
@@ -199,7 +195,7 @@ def test_event_pump_delivers_queued_event_after_the_tool_boundary_is_safe(
         dedupe_key="agent_result:task-1",
         payload={"task_id": "task-1"},
     )
-    action = pending_delegate_action()
+    action = pending_tool_action()
 
     class Conversation:
         def __init__(self):
@@ -219,7 +215,7 @@ def test_event_pump_delivers_queued_event_after_the_tool_boundary_is_safe(
             assert conversation.messages == []
             assert store.pending() == [event]
 
-            conversation.state.append(completed_delegate_action(action))
+            conversation.state.append(completed_tool_action(action))
             assert conversation.received.wait(1)
 
         assert conversation.messages == [event.to_user_message()]

--- a/tests/test_agent_markdown.py
+++ b/tests/test_agent_markdown.py
@@ -117,6 +117,7 @@ def test_agent_context_installer_builds_loadable_sanitized_runtime_copies(
 
     assert "review-experiment" in {skill.name for skill in plugin.skills}
     assert "bash-runner" in {agent.name for agent in agents}
+    assert not (home / ".agents/skills/senpai-tool-telemetry").exists()
     assert all(
         strip_spdx_header(text) == text
         for root in (runtime_plugin, home / ".agents")

--- a/tests/test_openhands_config.py
+++ b/tests/test_openhands_config.py
@@ -94,6 +94,21 @@ def test_project_instructions_and_file_agents_are_sanitized_without_mutation(
     assert "# SPDX-" in definition.read_text(encoding="utf-8")
 
 
+def test_developer_only_project_skills_are_not_exposed_to_senpai(tmp_path: Path):
+    workspace = tmp_path / "target"
+    skill_dir = workspace / ".agents" / "skills" / "telemetry"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: telemetry\ndescription: Developer diagnostics.\n---\n",
+        encoding="utf-8",
+    )
+    (skill_dir / ".senpai-developer-only").touch()
+
+    assert "telemetry" not in {
+        skill.name for skill in sanitized_project_skills(workspace)
+    }
+
+
 def test_resolved_config_separates_runtime_credentials_from_command_secrets(
     tmp_path: Path,
 ):

--- a/tests/test_openhands_tools_and_agents.py
+++ b/tests/test_openhands_tools_and_agents.py
@@ -3,9 +3,11 @@ import shutil
 import subprocess
 import sys
 import textwrap
+from types import SimpleNamespace
 
 import pytest
 from openhands.sdk import Agent, LLM, Tool
+from openhands.sdk.tool import resolve_tool
 from openhands.sdk.plugin import Plugin
 from openhands.sdk.subagent import AgentDefinition, agent_definition_to_factory
 from openhands.tools.preset.default import register_default_tools
@@ -13,12 +15,18 @@ from pydantic import SecretStr
 
 from senpai_agent.openhands_runner import (
     build_main_tools,
+    depth_aware_child_definition,
     delegation_config,
     find_named_agent,
     resolve_plugin_dir,
     sanitized_agent_definitions,
 )
-from senpai_agent.tools import register_senpai_tools
+from senpai_agent.tools import (
+    LoadBrowserAction,
+    LoadBrowserTool,
+    SenpaiTaskTrackerTool,
+    register_senpai_tools,
+)
 from openhands_support import AGENT_DIR, PLUGIN_DIR, REPO_ROOT, runtime_config
 
 
@@ -54,6 +62,65 @@ def test_child_mode_keeps_bounded_delegation_lifecycle_tools(tmp_path):
     assert "delegate_agent" not in names
     assert "senpai_training" not in names
     assert delegation_config(config).depth == 0
+
+
+def test_browser_family_is_lazy_and_respects_disable_flag(tmp_path):
+    enabled_tools = build_main_tools(runtime_config(tmp_path, enable_browser=True))
+    enabled = {tool.name for tool in enabled_tools}
+    disabled = {tool.name for tool in build_main_tools(runtime_config(tmp_path, enable_browser=False))}
+    state = SimpleNamespace(agent_state={})
+    resolved = resolve_tool(
+        next(tool for tool in enabled_tools if tool.name == "browser_tool_set"),
+        state,
+    )
+
+    assert "browser_tool_set" in enabled
+    assert [tool.name for tool in resolved] == ["load_browser"]
+    assert "load_browser" not in disabled
+    assert "browser_tool_set" not in disabled
+
+
+def test_lazy_browser_keeps_the_persisted_tool_spec_compatible():
+    llm = LLM(
+        model="anthropic/claude-opus-4-8",
+        api_key=SecretStr("test-key"),
+    )
+    persisted = Agent(llm=llm, tools=[Tool(name="browser_tool_set")])
+    runtime = Agent(llm=llm, tools=[Tool(name="browser_tool_set")])
+
+    assert runtime.verify(persisted) is runtime
+
+
+def test_browser_loader_uses_runtime_tools_and_persists_activation(monkeypatch):
+    from openhands.tools.browser_use import BrowserToolSet
+
+    browser_tool = SimpleNamespace(name="browser_navigate")
+    monkeypatch.setattr(
+        BrowserToolSet,
+        "create",
+        classmethod(lambda cls, state: [browser_tool]),
+    )
+
+    class RuntimeAgent:
+        def __init__(self):
+            self.tools_map = {"load_browser": object()}
+            self.added = []
+
+        def add_runtime_tools(self, tools):
+            self.added.extend(tools)
+            self.tools_map.update({tool.name: tool for tool in tools})
+
+    state = SimpleNamespace(agent_state={})
+    agent = RuntimeAgent()
+    conversation = SimpleNamespace(state=state, agent=agent)
+    loader = LoadBrowserTool.create(state)[0]
+
+    observation = loader(LoadBrowserAction(), conversation)
+
+    assert observation.tools == ("browser_navigate",)
+    assert agent.added == [browser_tool]
+    assert state.agent_state == {"senpai.browser_enabled": True}
+    assert LoadBrowserTool.create(state) == [browser_tool]
 
 
 @pytest.mark.parametrize(
@@ -178,6 +245,33 @@ def test_target_agents_cannot_shadow_senpai_delegation_agents(tmp_path):
         "cancel_agents",
     }
     assert "Shadowed instructions" not in definition.system_prompt
+
+
+def test_child_definition_exposes_spawn_only_to_depth_one_generalist():
+    general = AgentDefinition.load(AGENT_DIR / "general-purpose.md")
+    explore = AgentDefinition.load(AGENT_DIR / "explore.md")
+
+    assert "spawn_agents" in depth_aware_child_definition(
+        general, child=False, depth=2
+    ).tools
+    assert "spawn_agents" in depth_aware_child_definition(
+        general, child=True, depth=1
+    ).tools
+    assert "spawn_agents" not in depth_aware_child_definition(
+        general, child=True, depth=2
+    ).tools
+    assert "spawn_agents" not in depth_aware_child_definition(
+        explore, child=True, depth=1
+    ).tools
+
+
+def test_senpai_task_tracker_description_is_concise_and_parallel_safe(tmp_path):
+    state = type("State", (), {"persistence_dir": str(tmp_path)})()
+    tool = SenpaiTaskTrackerTool.create(state)[0]
+
+    assert "genuinely parallel" in tool.description
+    assert "Limit active work to ONE" not in tool.description
+    assert len(tool.description) < 700
 
 
 def test_markdown_agents_register_and_construct_with_the_native_loader(tmp_path):

--- a/tests/test_tool_telemetry.py
+++ b/tests/test_tool_telemetry.py
@@ -1,0 +1,269 @@
+import json
+import subprocess
+import sys
+from datetime import UTC, datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from tools.senpai_tool_telemetry import build_report, parse_timestamp, render_table
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def write_conversation(
+    state_dir: Path,
+    conversation_id: str,
+    *,
+    model: str,
+    tools: list[dict],
+    events: list[dict],
+) -> Path:
+    conversation = state_dir / conversation_id
+    event_dir = conversation / "events"
+    event_dir.mkdir(parents=True)
+    (conversation / "base_state.json").write_text(
+        json.dumps(
+            {
+                "id": conversation_id,
+                "agent": {"llm": {"model": model}, "tools": tools},
+            }
+        ),
+        encoding="utf-8",
+    )
+    for index, event in enumerate(events):
+        (event_dir / f"event-{index:05d}-{index}.json").write_text(
+            json.dumps(event),
+            encoding="utf-8",
+        )
+    return event_dir
+
+
+def action(call_id: str, tool: str, at: datetime, arguments: dict) -> dict:
+    return {
+        "kind": "ActionEvent",
+        "timestamp": at.isoformat(),
+        "tool_name": tool,
+        "tool_call_id": call_id,
+        "tool_call": {
+            "id": call_id,
+            "name": tool,
+            "arguments": json.dumps(arguments),
+        },
+    }
+
+
+def observation(call_id: str, tool: str, at: datetime, *, error=False) -> dict:
+    return {
+        "kind": "ObservationEvent",
+        "timestamp": at.isoformat(),
+        "tool_name": tool,
+        "tool_call_id": call_id,
+        "observation": {"is_error": error, "kind": "TestObservation"},
+    }
+
+
+def telemetry_fixture(tmp_path: Path, now: datetime) -> Path:
+    state = tmp_path / "state"
+    root_events = [
+        action("launch", "run_training", now - timedelta(minutes=10), {"secret": "launch-secret"}),
+        observation("launch", "run_training", now - timedelta(minutes=9, seconds=55)),
+        action("status-1", "get_training_status", now - timedelta(minutes=8), {"training_id": "job-1"}),
+        observation("status-1", "get_training_status", now - timedelta(minutes=7, seconds=59)),
+        action("status-2", "get_training_status", now - timedelta(minutes=7, seconds=30), {"training_id": "job-1"}),
+        observation("status-2", "get_training_status", now - timedelta(minutes=7, seconds=29), error=True),
+        action("old", "terminal", now - timedelta(hours=13), {"command": "old-secret"}),
+    ]
+    write_conversation(
+        state,
+        "root-conversation",
+        model="openai/gpt-test",
+        tools=[{"name": "senpai_terminal", "params": {"role": "student"}}],
+        events=root_events,
+    )
+    write_conversation(
+        state / "children" / "task-1",
+        "child-conversation",
+        model="openai/gpt-fast",
+        tools=[{"name": "terminal", "params": {}}],
+        events=[
+            action("child", "terminal", now - timedelta(minutes=6), {"command": "token=child-secret"}),
+            observation("child", "terminal", now - timedelta(minutes=5, seconds=58)),
+        ],
+    )
+    return state
+
+
+def test_recursive_report_counts_outcomes_latency_polling_and_repetition(tmp_path: Path):
+    now = datetime(2026, 8, 7, 12, tzinfo=UTC)
+    state = telemetry_fixture(tmp_path, now)
+
+    report = build_report(
+        [state],
+        now=now,
+        hours=12,
+        repeat_window_seconds=120,
+    )
+
+    assert report["conversations"] == 2
+    assert report["tool_calls"] == 4
+    assert report["arguments_redacted"] is True
+    assert report["status_polling"] == {
+        "checks": 2,
+        "successful_job_launches": 1,
+        "checks_per_successful_launch": 2.0,
+        "rapid_repeats": 1,
+    }
+    assert report["repetition"]["rapid_repeats"] == 1
+
+    rows = {
+        (row["role"], row["model"], row["tool"]): row
+        for row in report["by_source_scope_role_model_tool"]
+    }
+    assert rows[("student", "openai/gpt-test", "get_training_status")][
+        "errors"
+    ] == 1
+    assert rows[("student", "openai/gpt-test", "get_training_status")][
+        "latency"
+    ]["p50_seconds"] == 1.0
+    assert rows[("student", "openai/gpt-fast", "terminal")]["successes"] == 1
+    assert {row["source"] for row in rows.values()} == {str(state.resolve())}
+    assert rows[("student", "openai/gpt-test", "run_training")]["scope"] == "root"
+    assert rows[("student", "openai/gpt-test", "run_training")]["depth"] == 0
+    assert rows[("student", "openai/gpt-fast", "terminal")]["scope"] == "child"
+    assert rows[("student", "openai/gpt-fast", "terminal")]["depth"] == 1
+
+    encoded = json.dumps(report)
+    assert "launch-secret" not in encoded
+    assert "child-secret" not in encoded
+    assert "old-secret" not in encoded
+    assert "Status polling: 2 checks / 1 launches" in render_table(report)
+
+
+def test_naive_timestamps_use_the_explicit_positive_offset_for_their_source(
+    tmp_path: Path,
+):
+    now = datetime(2026, 8, 7, 12, tzinfo=UTC)
+    state = tmp_path / "positive-offset-state"
+    write_conversation(
+        state,
+        "root-conversation",
+        model="openai/gpt-test",
+        tools=[{"name": "senpai_terminal", "params": {"role": "student"}}],
+        events=[
+            action(
+                "outside-window",
+                "terminal",
+                datetime(2026, 8, 7, 12, 30),
+                {"command": "redacted-old"},
+            ),
+            action(
+                "inside-window",
+                "terminal",
+                datetime(2026, 8, 7, 13, 30),
+                {"command": "redacted-current"},
+            ),
+            observation(
+                "inside-window",
+                "terminal",
+                datetime(2026, 8, 7, 13, 30, 2),
+            ),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="naive event timestamp requires"):
+        build_report(
+            [state],
+            now=now,
+            hours=1,
+            repeat_window_seconds=120,
+        )
+
+    report = build_report(
+        [state],
+        now=now,
+        hours=1,
+        repeat_window_seconds=120,
+        default_naive_timezone=UTC,
+        source_naive_timezones={state: timezone(timedelta(hours=2))},
+    )
+
+    assert report["tool_calls"] == 1
+    assert report["by_source_scope_role_model_tool"][0]["latency"][
+        "p50_seconds"
+    ] == 2.0
+    assert report["naive_timestamp_timezones"] == {
+        "default": "UTC",
+        "by_source": {str(state.resolve()): "UTC+02:00"},
+    }
+
+
+def test_aware_timestamp_keeps_its_embedded_offset():
+    assert parse_timestamp(
+        "2026-08-07T13:30:00+02:00",
+        naive_timezone=timezone(-timedelta(hours=7)),
+    ) == datetime(2026, 8, 7, 11, 30, tzinfo=UTC)
+
+
+def test_cli_prints_table_and_writes_json(tmp_path: Path):
+    now = datetime.now(UTC)
+    state = telemetry_fixture(tmp_path, now)
+    output = tmp_path / "report.json"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "tools" / "senpai_tool_telemetry.py"),
+            str(state),
+            "--hours",
+            "12",
+            "--json",
+            str(output),
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "Tool telemetry: 4 calls, 2 conversations" in completed.stdout
+    assert json.loads(output.read_text(encoding="utf-8"))["tool_calls"] == 4
+
+
+def test_cli_applies_a_source_specific_timezone_to_naive_events(tmp_path: Path):
+    now = datetime.now(UTC)
+    local_now = now.astimezone(timezone(timedelta(hours=2))).replace(tzinfo=None)
+    state = tmp_path / "source"
+    write_conversation(
+        state,
+        "root-conversation",
+        model="openai/gpt-test",
+        tools=[{"name": "senpai_terminal", "params": {"role": "student"}}],
+        events=[action("call", "terminal", local_now, {"secret": "never-print"})],
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "tools" / "senpai_tool_telemetry.py"),
+            str(state),
+            "--hours",
+            "1",
+            "--source-timezone",
+            f"{state}=+02:00",
+            "--json",
+            "-",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    report = json.loads(completed.stdout)
+    assert report["tool_calls"] == 1
+    assert report["naive_timestamp_timezones"]["by_source"] == {
+        str(state.resolve()): "UTC+02:00"
+    }
+    assert "never-print" not in completed.stdout

--- a/tests/test_tools_delegation.py
+++ b/tests/test_tools_delegation.py
@@ -1,7 +1,8 @@
+import json
+import sqlite3
 import threading
 import time
 import uuid
-import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -22,8 +23,8 @@ from senpai_agent.delegation import (
     DelegationConfig,
     DelegationRegistry,
     DelegationRequest,
-    DelegateAgentAction,
-    DelegateAgentTool,
+    LeafAgentTask,
+    LeafSpawnAgentsAction,
     MODEL_TIER_TIMEOUT_SECONDS,
     SpawnAgentsAction,
     SpawnAgentsTool,
@@ -39,6 +40,134 @@ def test_model_tier_runtime_limits():
         "smart": 1800,
         "frontier": 3600,
     }
+
+
+def test_explicit_search_task_forms_resolve_to_internal_search_modes():
+    web = AgentTask(task="Find current documentation", agent="search_general_web")
+    papers = LeafAgentTask(
+        task="Find primary papers",
+        agent="search_research_publications",
+    )
+
+    assert web.resolved_agent() == ("search", "general-web")
+    assert papers.resolved_agent() == ("search", "research-publications")
+    assert "search_mode" not in web.model_dump()
+
+
+def test_persisted_search_task_restores_without_exposing_the_old_schema():
+    restored = AgentTask.model_validate(
+        {
+            "task": "Find primary papers",
+            "agent": "search",
+            "search_mode": "research-publications",
+        }
+    )
+
+    assert restored.agent == "search_research_publications"
+    task_schema = AgentTask.model_json_schema()["properties"]
+    assert "search_mode" not in task_schema
+    assert "search" not in task_schema["agent"]["enum"]
+
+
+@pytest.mark.parametrize(
+    ("current", "legacy"),
+    [
+        (
+            AgentTask(key="inspect", task="Inspect the code", agent="explore"),
+            {
+                "key": "inspect",
+                "task": "Inspect the code",
+                "agent": "explore",
+                "model": "smart",
+                "include_context": False,
+                "search_mode": None,
+            },
+        ),
+        (
+            AgentTask(
+                key="papers",
+                task="Find primary papers",
+                agent="search_research_publications",
+            ),
+            {
+                "key": "papers",
+                "task": "Find primary papers",
+                "agent": "search",
+                "model": "smart",
+                "include_context": False,
+                "search_mode": "research-publications",
+            },
+        ),
+    ],
+)
+def test_pre_upgrade_registry_specs_replay_semantically(
+    tmp_path: Path,
+    current: AgentTask,
+    legacy: dict,
+):
+    registry = DelegationRegistry(tmp_path / "tasks.sqlite3")
+    operation_key = "conversation:stable-batch"
+    reserve = {
+        "operation_key": operation_key,
+        "tree_id": "tree",
+        "parent_conversation_id": "conversation",
+        "parent_task_id": None,
+        "depth": 1,
+        "deadlines": [time.time() + 60],
+    }
+    original, created = registry.reserve(specs=[current], **reserve)
+    with sqlite3.connect(registry.path) as database:
+        database.execute(
+            "UPDATE operations SET specs_json = ? WHERE operation_key = ?",
+            (
+                json.dumps([legacy], sort_keys=True, separators=(",", ":")),
+                operation_key,
+            ),
+        )
+
+    replayed, replay_created = registry.reserve(specs=[current], **reserve)
+
+    assert created is True
+    assert replay_created is False
+    assert replayed[0]["task_id"] == original[0]["task_id"]
+    with pytest.raises(ValueError, match="different task specifications"):
+        registry.reserve(
+            specs=[current.model_copy(update={"task": "Do something else"})],
+            **reserve,
+        )
+    with sqlite3.connect(registry.path) as database:
+        database.execute(
+            "UPDATE operations SET specs_json = ? WHERE operation_key = ?",
+            (
+                json.dumps(
+                    [{**legacy, "unexpected": "must not disappear"}],
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ),
+                operation_key,
+            ),
+        )
+    with pytest.raises(RuntimeError, match="unknown fields: unexpected"):
+        registry.reserve(specs=[current], **reserve)
+
+
+def test_depth_one_generalist_schema_cannot_request_generalist_child(tmp_path):
+    configure_delegation(config(tmp_path, depth=0))
+    root = SpawnAgentsTool.create(child_runner_factory=lambda _: None)[0]
+    assert root.action_type is SpawnAgentsAction
+
+    configure_delegation(
+        config(tmp_path, depth=1, agent_name="general-purpose")
+    )
+    nested = SpawnAgentsTool.create(child_runner_factory=lambda _: None)[0]
+    assert nested.action_type is LeafSpawnAgentsAction
+    with pytest.raises(ValueError, match="literal_error"):
+        LeafSpawnAgentsAction.model_validate(
+            {
+                "batch_key": "invalid-generalist-chain",
+                "tasks": [{"task": "Recurse", "agent": "general-purpose"}],
+            }
+        )
 
 
 class EventSink:
@@ -150,39 +279,6 @@ def tools(tmp_path: Path, factory, sink=None, **config_updates):
     return spawn, await_tool, status, cancel
 
 
-def test_deprecated_delegate_agent_never_constructs_or_launches_a_runner(
-    tmp_path,
-    monkeypatch,
-):
-    def forbidden_factory():
-        raise AssertionError("legacy delegate_agent reached the runner factory")
-
-    monkeypatch.setattr(
-        "senpai_agent.delegation.configured_child_runner_factory",
-        forbidden_factory,
-    )
-    tool = DelegateAgentTool.create(
-        event_db_path=tmp_path / "events.sqlite3"
-    )[0]
-
-    observation = tool(
-        DelegateAgentAction(
-            task="Launch an Explore child",
-            agent="explore",
-            model="fast",
-            background=True,
-        ),
-        parent_conversation(),
-    )
-
-    assert observation.status == "finished"
-    assert observation.task_id == "deprecated"
-    assert "cannot launch" in (observation.result or "")
-    assert "spawn_agents" in (observation.result or "")
-    assert "await_agents" in (observation.result or "")
-    assert not (tmp_path / "events.sqlite3").exists()
-
-
 def test_spawn_is_nonblocking_and_await_first_collects_the_first_result(tmp_path):
     releases = [threading.Event(), threading.Event()]
     children = []
@@ -230,6 +326,43 @@ def test_spawn_is_nonblocking_and_await_first_collects_the_first_result(tmp_path
     releases[0].set()
 
 
+def test_search_task_form_is_resolved_in_registry_and_child_request(tmp_path):
+    release = threading.Event()
+    release.set()
+    requests = []
+
+    def factory(request):
+        requests.append(request)
+        return FakeChild(release)
+
+    spawn, *_ = tools(tmp_path, factory)
+    parent = parent_conversation()
+    spawned = spawn(
+        SpawnAgentsAction(
+            batch_key="publication-search",
+            tasks=[
+                AgentTask(
+                    task="Find primary sources",
+                    agent="search_research_publications",
+                )
+            ],
+        ),
+        parent,
+    )
+    row = DelegationRegistry(
+        tmp_path / "state" / "delegation" / "tasks.sqlite3"
+    ).rows([spawned.tasks[0].task_id])[0]
+
+    assert (requests[0].agent, requests[0].search_mode) == (
+        "search",
+        "research-publications",
+    )
+    assert (row["agent"], row["search_mode"]) == (
+        "search",
+        "research-publications",
+    )
+
+
 def test_await_quorum_and_timeout_leave_unfinished_tasks_running(tmp_path):
     releases = [threading.Event() for _ in range(3)]
     children = []
@@ -273,7 +406,135 @@ def test_await_quorum_and_timeout_leave_unfinished_tasks_running(tmp_path):
     assert timed_out.satisfied is False
     assert timed_out.timed_out is True
     assert timed_out.tasks[0].status == "running"
+    assert timed_out.waited_seconds >= 0.05
+    assert "keep running" in timed_out.guidance
+    assert "join='change'" in timed_out.guidance
+    assert "join='first'" not in timed_out.guidance
     releases[2].set()
+
+
+def test_await_change_returns_on_the_next_task_transition(tmp_path):
+    release = threading.Event()
+    spawn, await_tool, _status, _cancel = tools(
+        tmp_path,
+        lambda _request: FakeChild(release),
+    )
+    parent = parent_conversation()
+    task = spawn(
+        SpawnAgentsAction(
+            batch_key="next-state-change",
+            tasks=[AgentTask(task="Finish after the signal", agent="explore")],
+        ),
+        parent,
+    ).tasks[0]
+
+    threading.Timer(0.05, release.set).start()
+    changed = await_tool(
+        AwaitAgentsAction(
+            task_ids=[task.task_id],
+            join="change",
+            timeout_seconds=2,
+        ),
+        parent,
+    )
+
+    assert changed.satisfied is True
+    assert changed.timed_out is False
+    assert changed.changed_task_ids == [task.task_id]
+    assert changed.tasks[0].status == "finished"
+
+
+def test_repeated_await_change_ignores_a_collected_terminal_sibling(tmp_path):
+    releases = [threading.Event(), threading.Event()]
+    children = []
+
+    def factory(_request):
+        child = FakeChild(releases[len(children)])
+        children.append(child)
+        return child
+
+    spawn, await_tool, status, _cancel = tools(tmp_path, factory)
+    parent = parent_conversation()
+    spawned = spawn(
+        SpawnAgentsAction(
+            batch_key="successive-change",
+            tasks=[AgentTask(task="First"), AgentTask(task="Second")],
+        ),
+        parent,
+    )
+    releases[0].set()
+    while status(
+        AgentStatusAction(task_ids=[spawned.tasks[0].task_id]), parent
+    ).tasks[0].status == "running":
+        time.sleep(0.01)
+
+    first = await_tool(
+        AwaitAgentsAction(
+            task_ids=[task.task_id for task in spawned.tasks],
+            join="change",
+            timeout_seconds=1,
+        ),
+        parent,
+    )
+    repeated = await_tool(
+        AwaitAgentsAction(
+            task_ids=[task.task_id for task in spawned.tasks],
+            join="change",
+            timeout_seconds=0.05,
+        ),
+        parent,
+    )
+
+    assert first.satisfied is True
+    assert first.changed_task_ids == []
+    assert repeated.satisfied is False
+    assert repeated.timed_out is True
+    assert repeated.changed_task_ids == []
+    assert [task.status for task in repeated.tasks] == ["finished", "running"]
+    assert repeated.waited_seconds >= 0.05
+    releases[1].set()
+
+
+def test_timed_out_await_collects_results_it_already_returned(tmp_path):
+    releases = [threading.Event(), threading.Event()]
+    children = []
+
+    def factory(_request):
+        child = FakeChild(releases[len(children)])
+        children.append(child)
+        return child
+
+    spawn, await_tool, status, _cancel = tools(tmp_path, factory)
+    parent = parent_conversation()
+    spawned = spawn(
+        SpawnAgentsAction(
+            batch_key="partial-timeout",
+            tasks=[AgentTask(task="First"), AgentTask(task="Second")],
+        ),
+        parent,
+    )
+    releases[0].set()
+    while status(
+        AgentStatusAction(task_ids=[spawned.tasks[0].task_id]), parent
+    ).tasks[0].status == "running":
+        time.sleep(0.01)
+
+    result = await_tool(
+        AwaitAgentsAction(
+            task_ids=[task.task_id for task in spawned.tasks],
+            join="all",
+            timeout_seconds=0.05,
+        ),
+        parent,
+    )
+    uncollected = DelegationRegistry(
+        tmp_path / "state" / "delegation" / "tasks.sqlite3"
+    ).uncollected_for_parent(str(parent.id))
+
+    assert result.timed_out is True
+    assert [task.status for task in result.tasks].count("finished") == 1
+    assert [row["task_id"] for row in uncollected] == [spawned.tasks[1].task_id]
+    releases[1].set()
 
 
 def test_replayed_batch_reuses_task_ids_and_changed_specs_fail(tmp_path):

--- a/tools/senpai_tool_telemetry.py
+++ b/tools/senpai_tool_telemetry.py
@@ -1,0 +1,643 @@
+#!/usr/bin/env python3
+
+"""Summarize tool use across a Senpai OpenHands state tree."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import re
+import sys
+from collections import defaultdict
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta, timezone, tzinfo
+from pathlib import Path
+from typing import Any, Sequence
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+
+EVENT_INDEX = re.compile(r"^event-(\d+)-")
+STATUS_TOOLS = frozenset({"get_training_status", "get_job_status"})
+LAUNCH_TOOLS = frozenset({"run_training", "run_job"})
+
+
+@dataclass(frozen=True, slots=True)
+class Conversation:
+    source_root: Path
+    event_dir: Path
+    conversation_id: str
+    model: str
+    role: str | None
+    depth: int
+
+    @property
+    def state_root(self) -> Path:
+        return self.event_dir.parent.parent
+
+
+@dataclass(frozen=True, slots=True)
+class ToolCall:
+    source_root: Path
+    conversation_id: str
+    role: str
+    model: str
+    depth: int
+    tool: str
+    occurred_at: datetime | None
+    argument_fingerprint: str
+    outcome: str
+    latency_seconds: float | None
+
+
+def parse_timezone(value: str) -> tzinfo:
+    normalized = value.strip()
+    if normalized.upper() in {"UTC", "Z"}:
+        return UTC
+    if re.fullmatch(r"[+-]\d{2}:\d{2}", normalized):
+        parsed = datetime.fromisoformat(f"2000-01-01T00:00:00{normalized}")
+        offset = parsed.utcoffset()
+        if offset is None:
+            raise ValueError(f"invalid UTC offset: {value}")
+        return timezone(offset)
+    try:
+        return ZoneInfo(normalized)
+    except ZoneInfoNotFoundError as error:
+        raise ValueError(
+            f"unknown timezone {value!r}; use an IANA name, UTC, or an offset like +02:00"
+        ) from error
+
+
+def parse_timestamp(
+    value: object,
+    *,
+    naive_timezone: tzinfo | None,
+) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        if naive_timezone is None:
+            raise ValueError(
+                "naive event timestamp requires --naive-timezone or a matching "
+                "--source-timezone"
+            )
+        parsed = parsed.replace(tzinfo=naive_timezone)
+    return parsed.astimezone(UTC)
+
+
+def event_sort_key(path: Path) -> tuple[int, str]:
+    match = EVENT_INDEX.match(path.name)
+    return (int(match.group(1)) if match else sys.maxsize, path.name)
+
+
+def discover_event_dirs(roots: Sequence[Path]) -> list[tuple[Path, Path]]:
+    discovered: dict[Path, Path] = {}
+    for source_root in roots:
+        source_root = source_root.expanduser().resolve()
+        if source_root.name == "events" and any(source_root.glob("event-*.json")):
+            discovered.setdefault(source_root, source_root)
+        if source_root.exists():
+            for path in source_root.rglob("event-*.json"):
+                if path.parent.name == "events":
+                    discovered.setdefault(path.parent.resolve(), source_root)
+    return sorted(
+        ((source_root, event_dir) for event_dir, source_root in discovered.items()),
+        key=lambda item: (str(item[0]), str(item[1])),
+    )
+
+
+def _base_state(event_dir: Path) -> dict[str, Any]:
+    path = event_dir.parent / "base_state.json"
+    return json.loads(path.read_text(encoding="utf-8")) if path.is_file() else {}
+
+
+def _explicit_role(base_state: dict[str, Any], event_dir: Path) -> str | None:
+    tags = base_state.get("tags") or {}
+    if tags.get("role") in {"advisor", "student"}:
+        return str(tags["role"])
+
+    tools = ((base_state.get("agent") or {}).get("tools") or [])
+    for tool in tools:
+        params = tool.get("params") or {}
+        if params.get("role") in {"advisor", "student"}:
+            return str(params["role"])
+    if any(tool.get("name") == "senpai_training" for tool in tools):
+        return "student"
+
+    for part in reversed(event_dir.parts):
+        lowered = part.lower()
+        if lowered == "advisor" or lowered.startswith("advisor-"):
+            return "advisor"
+        if lowered == "student" or lowered.startswith("student-"):
+            return "student"
+    return None
+
+
+def load_conversations(event_dirs: Sequence[tuple[Path, Path]]) -> list[Conversation]:
+    partial: list[Conversation] = []
+    root_roles: dict[tuple[Path, Path], str] = {}
+    for source_root, event_dir in event_dirs:
+        base_state = _base_state(event_dir)
+        role = _explicit_role(base_state, event_dir)
+        conversation = Conversation(
+            source_root=source_root,
+            event_dir=event_dir,
+            conversation_id=str(base_state.get("id") or event_dir.parent.name),
+            model=str(
+                ((base_state.get("agent") or {}).get("llm") or {}).get("model")
+                or "unknown"
+            ),
+            role=role,
+            depth=sum(
+                part == "children"
+                for part in event_dir.relative_to(source_root).parts
+            ),
+        )
+        partial.append(conversation)
+        if role is not None and "children" not in event_dir.parts:
+            root_roles[(source_root, conversation.state_root)] = role
+
+    conversations = []
+    for conversation in partial:
+        role = conversation.role
+        if role is None:
+            role = next(
+                (
+                    inherited
+                    for ancestor in conversation.event_dir.parents
+                    if (
+                        inherited := root_roles.get(
+                            (conversation.source_root, ancestor)
+                        )
+                    )
+                    is not None
+                ),
+                "unknown",
+            )
+        conversations.append(
+            Conversation(
+                source_root=conversation.source_root,
+                event_dir=conversation.event_dir,
+                conversation_id=conversation.conversation_id,
+                model=conversation.model,
+                role=role,
+                depth=conversation.depth,
+            )
+        )
+    return conversations
+
+
+def _argument_fingerprint(event: dict[str, Any]) -> str:
+    tool_call = event.get("tool_call") or {}
+    arguments: object = tool_call.get("arguments")
+    if arguments is None:
+        arguments = {
+            key: value
+            for key, value in (event.get("action") or {}).items()
+            if key != "kind"
+        }
+    if isinstance(arguments, str):
+        try:
+            arguments = json.loads(arguments)
+        except json.JSONDecodeError:
+            pass
+    encoded = json.dumps(
+        arguments,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _observation_failed(event: dict[str, Any]) -> bool:
+    observation = event.get("observation") or {}
+    return bool(
+        event.get("is_error")
+        or observation.get("is_error")
+        or str(observation.get("kind", "")).lower().startswith("error")
+    )
+
+
+def load_tool_calls(
+    conversations: Sequence[Conversation],
+    *,
+    since: datetime,
+    default_naive_timezone: tzinfo | None,
+    source_naive_timezones: Mapping[Path, tzinfo],
+) -> tuple[list[ToolCall], list[str], int]:
+    calls: list[ToolCall] = []
+    parse_errors: list[str] = []
+    event_count = 0
+    for conversation in conversations:
+        naive_timezone = source_naive_timezones.get(
+            conversation.source_root,
+            default_naive_timezone,
+        )
+        events: list[dict[str, Any]] = []
+        for path in sorted(conversation.event_dir.glob("event-*.json"), key=event_sort_key):
+            try:
+                events.append(json.loads(path.read_text(encoding="utf-8")))
+            except (OSError, json.JSONDecodeError) as error:
+                parse_errors.append(f"{path}: {type(error).__name__}: {error}")
+        event_count += len(events)
+        observations = {
+            str(event.get("tool_call_id")): event
+            for event in events
+            if event.get("kind") == "ObservationEvent" and event.get("tool_call_id")
+        }
+        for event in events:
+            if event.get("kind") != "ActionEvent":
+                continue
+            occurred_at = parse_timestamp(
+                event.get("timestamp"),
+                naive_timezone=naive_timezone,
+            )
+            if occurred_at is not None and occurred_at < since:
+                continue
+            tool = str(event.get("tool_name") or "unknown")
+            observation = observations.get(str(event.get("tool_call_id")))
+            latency = None
+            outcome = "pending"
+            if observation is not None:
+                outcome = "error" if _observation_failed(observation) else "success"
+                observed_at = parse_timestamp(
+                    observation.get("timestamp"),
+                    naive_timezone=naive_timezone,
+                )
+                if occurred_at is not None and observed_at is not None:
+                    latency = max(0.0, (observed_at - occurred_at).total_seconds())
+            calls.append(
+                ToolCall(
+                    source_root=conversation.source_root,
+                    conversation_id=conversation.conversation_id,
+                    role=conversation.role or "unknown",
+                    model=conversation.model,
+                    depth=conversation.depth,
+                    tool=tool,
+                    occurred_at=occurred_at,
+                    argument_fingerprint=_argument_fingerprint(event),
+                    outcome=outcome,
+                    latency_seconds=latency,
+                )
+            )
+    return calls, parse_errors, event_count
+
+
+def percentile(values: Sequence[float], quantile: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    return ordered[max(0, math.ceil(quantile * len(ordered)) - 1)]
+
+
+def latency_summary(values: Sequence[float]) -> dict[str, float | int | None]:
+    return {
+        "samples": len(values),
+        "mean_seconds": round(sum(values) / len(values), 3) if values else None,
+        "p50_seconds": _rounded(percentile(values, 0.50)),
+        "p95_seconds": _rounded(percentile(values, 0.95)),
+        "max_seconds": round(max(values), 3) if values else None,
+    }
+
+
+def _rounded(value: float | None) -> float | None:
+    return round(value, 3) if value is not None else None
+
+
+def build_report(
+    roots: Sequence[Path],
+    *,
+    now: datetime,
+    hours: float,
+    repeat_window_seconds: float,
+    default_naive_timezone: tzinfo | None = None,
+    source_naive_timezones: Mapping[Path, tzinfo] | None = None,
+) -> dict[str, Any]:
+    now = now.astimezone(UTC)
+    since = now - timedelta(hours=hours)
+    event_dirs = discover_event_dirs(roots)
+    conversations = load_conversations(event_dirs)
+    resolved_source_timezones = {
+        path.expanduser().resolve(): zone
+        for path, zone in (source_naive_timezones or {}).items()
+    }
+    calls, parse_errors, event_count = load_tool_calls(
+        conversations,
+        since=since,
+        default_naive_timezone=default_naive_timezone,
+        source_naive_timezones=resolved_source_timezones,
+    )
+
+    grouped: dict[tuple[Path, int, str, str, str], list[ToolCall]] = defaultdict(
+        list
+    )
+    for call in calls:
+        grouped[
+            (call.source_root, call.depth, call.role, call.model, call.tool)
+        ].append(call)
+
+    rows = []
+    for (source_root, depth, role, model, tool), selected in sorted(grouped.items()):
+        latencies = [
+            call.latency_seconds
+            for call in selected
+            if call.latency_seconds is not None
+        ]
+        rows.append(
+            {
+                "source": str(source_root),
+                "scope": "root" if depth == 0 else "child",
+                "depth": depth,
+                "role": role,
+                "model": model,
+                "tool": tool,
+                "calls": len(selected),
+                "successes": sum(call.outcome == "success" for call in selected),
+                "errors": sum(call.outcome == "error" for call in selected),
+                "pending": sum(call.outcome == "pending" for call in selected),
+                "latency": latency_summary(latencies),
+            }
+        )
+
+    repeats: dict[tuple[Path, int, str, str, str], int] = defaultdict(int)
+    previous: dict[tuple[Path, str, str, str], datetime] = {}
+    for call in sorted(
+        (call for call in calls if call.occurred_at is not None),
+        key=lambda call: call.occurred_at or datetime.min.replace(tzinfo=UTC),
+    ):
+        key = (
+            call.source_root,
+            call.conversation_id,
+            call.tool,
+            call.argument_fingerprint,
+        )
+        last = previous.get(key)
+        if last is not None and (call.occurred_at - last).total_seconds() <= repeat_window_seconds:
+            repeats[
+                (call.source_root, call.depth, call.role, call.model, call.tool)
+            ] += 1
+        previous[key] = call.occurred_at
+
+    status_calls = [call for call in calls if call.tool in STATUS_TOOLS]
+    successful_launches = sum(
+        call.tool in LAUNCH_TOOLS and call.outcome == "success" for call in calls
+    )
+    repeated_rows = [
+        {
+            "source": str(source_root),
+            "scope": "root" if depth == 0 else "child",
+            "depth": depth,
+            "role": role,
+            "model": model,
+            "tool": tool,
+            "rapid_repeats": count,
+        }
+        for (source_root, depth, role, model, tool), count in sorted(repeats.items())
+    ]
+    return {
+        "generated_at": now.isoformat().replace("+00:00", "Z"),
+        "window": {
+            "hours": hours,
+            "since": since.isoformat().replace("+00:00", "Z"),
+        },
+        "roots": [str(path.expanduser().resolve()) for path in roots],
+        "naive_timestamp_timezones": {
+            "default": str(default_naive_timezone)
+            if default_naive_timezone is not None
+            else None,
+            "by_source": {
+                str(path): str(zone)
+                for path, zone in sorted(
+                    resolved_source_timezones.items(),
+                    key=lambda item: str(item[0]),
+                )
+            },
+        },
+        "arguments_redacted": True,
+        "model_source": "current conversation base_state.json",
+        "conversations": len(conversations),
+        "events": event_count,
+        "tool_calls": len(calls),
+        "parse_errors": parse_errors,
+        "status_polling": {
+            "checks": len(status_calls),
+            "successful_job_launches": successful_launches,
+            "checks_per_successful_launch": (
+                round(len(status_calls) / successful_launches, 3)
+                if successful_launches
+                else None
+            ),
+            "rapid_repeats": sum(
+                count
+                for (
+                    _source_root,
+                    _depth,
+                    _role,
+                    _model,
+                    tool,
+                ), count in repeats.items()
+                if tool in STATUS_TOOLS
+            ),
+        },
+        "repetition": {
+            "window_seconds": repeat_window_seconds,
+            "rapid_repeats": sum(repeats.values()),
+            "by_source_scope_role_model_tool": repeated_rows,
+        },
+        "by_source_scope_role_model_tool": rows,
+    }
+
+
+def render_table(report: dict[str, Any]) -> str:
+    rows = report["by_source_scope_role_model_tool"]
+    lines = [
+        (
+            f"Tool telemetry: {report['tool_calls']} calls, "
+            f"{report['conversations']} conversations, "
+            f"{report['window']['hours']:g}h window"
+        )
+    ]
+    if not rows:
+        lines.append("No tool calls found.")
+    else:
+        headers = (
+            "Source",
+            "Scope",
+            "Role",
+            "Model",
+            "Tool",
+            "Calls",
+            "OK",
+            "Err",
+            "Open",
+            "P50s",
+            "P95s",
+        )
+        body = []
+        for row in rows:
+            latency = row["latency"]
+            body.append(
+                (
+                    row["source"],
+                    f"{row['scope']}:{row['depth']}",
+                    row["role"],
+                    row["model"],
+                    row["tool"],
+                    str(row["calls"]),
+                    str(row["successes"]),
+                    str(row["errors"]),
+                    str(row["pending"]),
+                    _display_seconds(latency["p50_seconds"]),
+                    _display_seconds(latency["p95_seconds"]),
+                )
+            )
+        widths = [
+            max(len(headers[index]), *(len(row[index]) for row in body))
+            for index in range(len(headers))
+        ]
+        lines.extend(
+            (
+                _format_row(headers, widths),
+                _format_row(tuple("-" * width for width in widths), widths),
+                *(_format_row(row, widths) for row in body),
+            )
+        )
+
+    status = report["status_polling"]
+    ratio = status["checks_per_successful_launch"]
+    lines.append(
+        "Status polling: "
+        f"{status['checks']} checks / {status['successful_job_launches']} launches"
+        + (f" = {ratio:g} checks/launch" if ratio is not None else "")
+        + f"; {status['rapid_repeats']} rapid repeats"
+    )
+    lines.append(
+        "Repeated identical calls: "
+        f"{report['repetition']['rapid_repeats']} within "
+        f"{report['repetition']['window_seconds']:g}s"
+    )
+    if report["parse_errors"]:
+        lines.append(f"Parse errors: {len(report['parse_errors'])}")
+    lines.append("Arguments: redacted (only in-memory fingerprints were compared).")
+    return "\n".join(lines)
+
+
+def _format_row(values: Sequence[str], widths: Sequence[int]) -> str:
+    return "  ".join(value.ljust(width) for value, width in zip(values, widths, strict=True))
+
+
+def _display_seconds(value: float | None) -> str:
+    return "-" if value is None else f"{value:g}"
+
+
+def timezone_argument(value: str) -> tzinfo:
+    try:
+        return parse_timezone(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(str(error)) from error
+
+
+def source_timezone_argument(value: str) -> tuple[Path, tzinfo]:
+    path, separator, timezone_name = value.rpartition("=")
+    if not separator or not path or not timezone_name:
+        raise argparse.ArgumentTypeError(
+            "expected ROOT=TIMEZONE, for example /state/cedar=+02:00"
+        )
+    return Path(path), timezone_argument(timezone_name)
+
+
+def parser() -> argparse.ArgumentParser:
+    cli = argparse.ArgumentParser(
+        description=(
+            "Recursively summarize OpenHands tool events without exposing tool arguments."
+        )
+    )
+    cli.add_argument("roots", nargs="+", type=Path, help="State directories to scan.")
+    cli.add_argument(
+        "--hours",
+        type=float,
+        default=12,
+        help="Include calls from this many recent hours (default: 12).",
+    )
+    cli.add_argument(
+        "--repeat-window-seconds",
+        type=float,
+        default=120,
+        help="Window for identical-call repetition signals (default: 120).",
+    )
+    cli.add_argument(
+        "--naive-timezone",
+        type=timezone_argument,
+        metavar="TIMEZONE",
+        help=(
+            "Timezone for naive event timestamps in every source, as an IANA name, "
+            "UTC, or a fixed offset such as +02:00. Naive timestamps fail clearly "
+            "when no default or source-specific timezone is provided."
+        ),
+    )
+    cli.add_argument(
+        "--source-timezone",
+        action="append",
+        default=[],
+        type=source_timezone_argument,
+        metavar="ROOT=TIMEZONE",
+        help=(
+            "Timezone for one positional state root; repeat for roots captured in "
+            "different timezones. Overrides --naive-timezone for that root."
+        ),
+    )
+    cli.add_argument(
+        "--json",
+        dest="json_output",
+        metavar="PATH",
+        help="Also write the full JSON report; use - for JSON on stdout.",
+    )
+    return cli
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    if args.hours <= 0 or args.repeat_window_seconds <= 0:
+        raise SystemExit("--hours and --repeat-window-seconds must be positive")
+    roots = [path.expanduser().resolve() for path in args.roots]
+    missing = [str(path) for path in roots if not path.exists()]
+    if missing:
+        raise SystemExit(f"state path does not exist: {', '.join(missing)}")
+    source_timezones: dict[Path, tzinfo] = {}
+    for path, zone in args.source_timezone:
+        resolved = path.expanduser().resolve()
+        if resolved not in roots:
+            raise SystemExit(f"--source-timezone path is not a state root: {resolved}")
+        if resolved in source_timezones:
+            raise SystemExit(f"duplicate --source-timezone path: {resolved}")
+        source_timezones[resolved] = zone
+
+    try:
+        report = build_report(
+            roots,
+            now=datetime.now(UTC),
+            hours=args.hours,
+            repeat_window_seconds=args.repeat_window_seconds,
+            default_naive_timezone=args.naive_timezone,
+            source_naive_timezones=source_timezones,
+        )
+    except ValueError as error:
+        raise SystemExit(str(error)) from error
+    table = render_table(report)
+    encoded = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.json_output == "-":
+        print(table, file=sys.stderr)
+        sys.stdout.write(encoded)
+    else:
+        print(table)
+        if args.json_output:
+            Path(args.json_output).expanduser().write_text(encoded, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- expose explicit search task forms, lazy browser loading, and concise task tracking
- make delegation collection support change-based waits with actionable timeout metadata while preserving persisted delegate compatibility
- add developer-only delegation telemetry with explicit timezone handling
- document the 10/30/60-minute tier limits and bounded recursion/parallelism contracts

## Safety and compatibility

- keeps the deprecated delegate tool as a no-op compatibility surface for existing conversations
- prevents collected terminal siblings from creating change- or first-wait busy loops
- requires an explicit timezone for naive historical timestamps instead of silently assuming UTC
- does not alter training, GitHub reconciliation, or controller recovery behavior

## Verification

- full suite: 822 passed, 6 skipped
- final focused suite: 92 passed
- independent review: no remaining findings
- git diff --check
