### PR TITLE
Generalize supervised jobs and retire the think tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ and keeps 600 events as an emergency fuse. The 82,144-token margin below W&B's
 model response. OpenAI Responses and Anthropic keep their native compaction and
 ignore all three local limits.
 
+Every advisor root turn also receives a live controller invariant in its
+non-condensed system context: the campaign is active, no campaign round limit
+is configured, and round labels or compaction summaries cannot declare the
+research finished. `max_turns` is identified explicitly as a per-turn safety
+bound, not a research-completion counter.
+
 Set positive values to override any dimension with
 `local_condenser_max_events`, `local_condenser_max_tokens`, and
 `local_condenser_target_events`; the target must leave room for the preserved
@@ -484,7 +490,7 @@ flowchart LR
     H["Advisor records hypothesis, baseline, and acceptance rule"]
     P["Typed draft PR<br/>student:name + status:wip"]
     I["Student implements and commits"]
-    T["Supervised training<br/>W&B metrics"]
+    T["Supervised jobs<br/>optional W&B metrics"]
     R["Structured result<br/>status:review"]
     D["Advisor merges, closes, requests a revision, or sends feedback"]
 
@@ -515,28 +521,54 @@ new feedback still do.
 
 `get_prs` returns complete PR bodies and discussions. Up to five PRs are returned in context by default; larger selections become a Markdown artifact outside the target checkout so long histories do not pollute the main conversation.
 
-## Long-running training and monitoring
+## Long-running jobs and monitoring
 
-Students do not start GPU work, stream logs, sleep, or poll through the terminal. Four typed tools make training a durable controller operation:
+Advisor and student root conversations receive four typed tools for durable,
+non-blocking process supervision. Students use them for GPU work; advisors can
+use them for repository-side watchers or other bounded long-running commands.
 
 | Tool | Contract |
 |---|---|
-| `run_training` | Accepts structured `argv`, `cwd`, and a hard timeout. It requires a clean assignment worktree, starts a supervised process group without blocking, persists its identity, full log, and bounded error tail, discovers W&B run IDs, and automatically registers terminal-state monitoring for the current conversation. |
-| `get_training_status` | Performs one bounded read of the latest persisted state, exit code, elapsed time, W&B run IDs, and error tail. |
-| `monitor_training` | Adds a W&B metric, minimize/maximize direction, `lte`, `gte`, `improved_by`, or `regressed_by` gates, a poll interval, and stale-update detection. It cannot disable terminal wakes. |
-| `cancel_training` | Stops the complete process group through the supervised TERM/KILL path, waits for a durable terminal state, and retires its monitor. |
+| `run_job` | Accepts structured `argv`, `cwd`, a hard timeout, a `read_only` or `mutable` workspace-access declaration, and an optional W&B credential grant. It starts a supervised process group without blocking, persists its identity, full log, and bounded error tail, discovers W&B run IDs, and automatically registers terminal-state monitoring for the current conversation. Suitable work includes training, inference, evaluation, builds, and receipt watchers. |
+| `get_job_status` | Performs one bounded read of the latest persisted state, exit code, elapsed time, W&B run IDs, and error tail. |
+| `monitor_job` | Sets or replaces optional W&B policy for an already-running job: metric, minimize/maximize direction, `lte`, `gte`, `improved_by`, or `regressed_by` gates, poll interval, and stale-update detection. It cannot disable terminal wakes. |
+| `cancel_job` | Stops the complete process group through the supervised TERM/KILL path, waits for a durable terminal state, and retires its monitor. |
 
-After launch, the student can finish its turn. The deterministic controller polls process state and at most one selected W&B metric without consuming model tokens. A threshold crossing, regression, stale metric, terminal state, or monitor error creates one compact durable event and resumes the same student conversation. One broken monitor cannot block other training, GitHub feedback, or child-agent results.
+After launch, the role can finish its turn. The deterministic controller polls
+process state and at most one selected W&B metric without consuming model
+tokens. A threshold crossing, regression, stale metric, terminal state, or
+monitor error creates one compact durable event and resumes the same
+conversation. Due monitors are processed in bounded batches with a time budget;
+a slow or broken monitor can delay its batch only within those bounds and cannot
+prevent later jobs, GitHub feedback, or child-agent results from being
+processed. Monitor policy and ownership have one durable SQLite source of truth.
+While any monitor is active, the controller sleeps only until its earliest due
+poll rather than the ordinary advisor/student heartbeat.
+
+`workspace_access="mutable"` is the default for builds, training, evaluation,
+or any command that can write in the checkout. A student must have a clean
+worktree before launching such a job, and controller-driven branch changes wait
+until it finishes. `read_only` is reserved for passive watchers and does not take
+that lease. A job receives no ambient credentials; request `WANDB_API_KEY` in
+`secret_env` only when it actually communicates with W&B.
 
 `improved_by` and `regressed_by` compare with the monitor policy's first observed sample; they do not silently reuse the assignment's documented baseline.
 
-Worker and container restarts preserve completed OpenHands events. Recovered live training is terminated safely rather than being adopted under an unverifiable process identity; the original student conversation receives the persisted terminal outcome.
+Worker and container restarts preserve completed OpenHands events. A recovered
+live job is terminated safely rather than adopted under an unverifiable process
+identity; its original conversation receives the persisted terminal outcome.
 
 Interactive browser operations are progressively disclosed. A fresh root
 conversation initially sees only `load_browser`; invoking it adds the fourteen
 OpenHands browser operations and records the choice in conversation state so a
 resumed conversation restores them. `--no-browser` exposes neither the loader
 nor the browser family.
+
+`task_tracker` is optional persisted working memory for multi-step work, parallel
+workstreams, delegated agents, and long-running jobs; several items may be
+`in_progress` when the work is genuinely concurrent. The legacy `think`
+scratchpad tool is not exposed to any Senpai root or child—the selected models'
+native reasoning remains enabled.
 
 ## Subagents
 
@@ -584,7 +616,7 @@ also copies the model-visible parent history. The root advisor or student may
 leave useful tasks running and receives their terminal results as durable
 events; nested children may not detach descendants.
 
-Children share the parent workspace, so their process and conversation are isolated but their filesystem is not. They receive only their declared tools and never receive GitHub credentials, GitHub workflow tools, or training tools.
+Children share the parent workspace, so their process and conversation are isolated but their filesystem is not. They receive only their declared tools and never receive GitHub credentials, GitHub workflow tools, or job tools.
 
 ## Task guides
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -11,7 +11,7 @@ composing fragile tool calls:
 
 - GitHub polling, workflow operations, and verification;
 - assignment branch publication;
-- training process supervision and W&B metric monitoring;
+- generic long-running process supervision and optional W&B metric monitoring;
 - conversation selection and durable local events;
 - command policy and stop checks; and
 - cadence, retry, deadlines, and shutdown.
@@ -30,7 +30,7 @@ dependencies.
 5. GitHub mutations are typed, preconditioned, convergent on replay, and
    verified against remote state.
 6. The advisor uses one durable conversation UUID. A student uses one UUID per
-   assignment revision, and monitor wakes continue it.
+   assignment revision, and job-monitor wakes continue the owning conversation.
 7. Conversation and generated artifact state cannot fall back into the target
    checkout.
 8. Senpai does not prune conversation history.
@@ -116,8 +116,10 @@ protocol.
 
 The only SQLite databases are `advisor-events.sqlite3`, for unacknowledged
 advisor watcher/child events; `student-events.sqlite3`, for unacknowledged
-student feedback/child events; and `training/monitors.sqlite3`, for student
-monitor policy, samples, and deduplicated actionable signals. OpenHands
+student feedback/child events; and `training/monitors.sqlite3`, for role-local
+job-monitor policy, samples, and deduplicated actionable signals. The
+`training/` state-directory name is retained so live persisted conversations
+and supervised processes remain recoverable across this surface change. OpenHands
 conversation history is a separate file-backed per-UUID event log.
 
 ## State and conversations
@@ -130,6 +132,11 @@ Advisor state:
 ├── controller-lease.json
 ├── advisor-events.sqlite3
 ├── conversation-state.json
+├── training/
+│   ├── <job-id>.json
+│   ├── <job-id>.log
+│   ├── monitors.sqlite3
+│   └── monitors/<job-id>.json
 ├── github/
 └── conversations managed by OpenHands
 ```
@@ -147,10 +154,10 @@ Student state:
 ├── student-events.sqlite3
 ├── conversation-state.json
 ├── training/
-│   ├── <training-id>.json
-│   ├── <training-id>.log
+│   ├── <job-id>.json
+│   ├── <job-id>.log
 │   ├── monitors.sqlite3
-│   └── monitors/<training-id>.json
+│   └── monitors/<job-id>.json
 ├── github/
 └── conversations managed by OpenHands
 ```
@@ -160,8 +167,8 @@ UUID. `conversation-state.json` records, per UUID, both successful initial
 instruction delivery and the digest of the delivered merged system context.
 The controller replaces this one document atomically after a successful turn,
 so a restart cannot observe those two facts at different revisions. A
-`training_monitor` event carries its original conversation UUID and therefore
-resumes, rather than replaces, the student conversation.
+`job_monitor` carries its original conversation UUID and therefore resumes,
+rather than replaces, the owning advisor or student conversation.
 
 `github-feedback.json` records every immutable PR feedback key's first-seen
 assignment revision, then marks it acknowledged only after its student turn
@@ -261,6 +268,12 @@ token trigger. OpenHands persists the returned typed compaction block in the
 normal event log and replays it first in each later request, including after a
 process restart. The local condenser is disabled for these conversations.
 Other providers retain the high-quality OpenHands condenser.
+
+Every advisor root turn appends one controller-derived liveness invariant to
+the system-message suffix, outside condensed history. It states that the
+campaign is active, that this runtime has no campaign round limit, and that
+`max_turns` limits one OpenHands turn rather than the research programme. Round
+labels, final-round claims, and summaries cannot authorize stopping.
 
 The complete durable transcript remains available as plain event JSON under
 `$SENPAI_OPENHANDS_STATE_DIR/$SENPAI_CONVERSATION_ID/events/`. The harness
@@ -503,82 +516,96 @@ Bash Runner have no delegation tools. A depth-one General Purpose child can use
 the lifecycle tools for depth-two leaf work, subject to the same tree budget
 and deadline. Children receive neither GitHub credentials nor GitHub
 read/write tools; the parent prepares any large PR Markdown artifact and owns
-every typed GitHub operation. They do not receive training tools.
+every typed GitHub operation. They do not receive job tools.
 
 When `review_ready` arrives during other advisor work, the advisor can spawn a
 smart, full-context General Purpose review and continue unrelated work. Every
 terminal record includes its root conversation identity, allowing the
 controller to resume the exact advisor or student conversation after its turn.
 
-### Training and monitoring
+### Long-running jobs and monitoring
 
-Students receive:
+Advisor and student root conversations receive:
 
 ```text
-run_training(spec: TrainingSpec) -> TrainingResult
-get_training_status(training_id: str) -> TrainingResult
-cancel_training(training_id: str) -> TrainingResult
-monitor_training(
-  training_id,
-  metric=None,
+run_job(spec: JobSpec) -> JobResult
+get_job_status(job_id: str) -> JobResult
+cancel_job(job_id: str) -> JobResult
+monitor_job(
+  job_id,
+  wandb_metric=None,
   direction=None,
   gates=(),
   poll_interval_seconds=60,
   stale_after_seconds=600,
-) -> MonitorTrainingObservation
+) -> MonitorJobObservation
 ```
 
-`TrainingSupervisor` owns one process group, the configured timeout ceiling,
+The process supervisor owns one process group, the configured timeout ceiling,
 TERM/KILL cleanup, restart identity checks using PID/PGID/create-time, a bounded
 8 KiB error tail, streamed 64 KiB log parsing, persisted state, and discovered
-W&B run IDs. Run IDs are persisted while training is still running so metric
-monitoring can begin immediately.
+W&B run IDs. Run IDs are persisted while the job is still running so optional
+metric monitoring can begin immediately.
 
-The student commits the exact implementation and cleans the worktree before an
-expensive launch. Every successful `run_training` launch immediately registers
-a terminal-state monitor bound to the current conversation. `monitor_training`
-is an optional policy upgrade for useful metric gates or staleness detection;
-repeating it replaces the default or previous policy.
+The generic job supervisor confines `cwd` to the role workspace. Jobs declare
+`workspace_access` as `mutable` or `read_only`. A student mutable job requires a
+clean worktree at launch and holds an exclusive workspace lease, so assignment
+hydration, feedback checkout, and branch reconciliation wait until it reaches a
+terminal state. Advisor jobs and truly passive student watchers may be
+`read_only` and remain usable while notes are being edited. Jobs receive a
+scrubbed environment and may request only registered credentials explicitly;
+the current public grant is `WANDB_API_KEY`. Every successful `run_job` call
+immediately registers a terminal-state monitor bound to the current
+conversation. `monitor_job` sets or replaces optional W&B metric gates and
+staleness detection for an already-running job; it never disables terminal
+wakes.
 
 The timeout is a total wall-clock ceiling, not merely the point at which
 shutdown begins. TERM is sent early enough that the configured grace period
 ends at the deadline, after which the complete process group is killed.
-`cancel_training` follows the same process-group cleanup path and does not
-return until the supervisor has persisted a terminal state. Target training
-code remains responsible for handling SIGTERM and flushing external services
+`cancel_job` follows the same process-group cleanup path and does not return
+until the supervisor has persisted a terminal state. Target job code remains
+responsible for handling SIGTERM and flushing external services
 such as W&B before the grace period expires.
 
 The controller polls only monitors that are due. It fetches one latest selected
 metric value from W&B, evaluates deterministic threshold/change/staleness and
 terminal-state rules, and persists deduplicated compact signals. Ordinary
-polls use no LLM tokens.
+polls use no LLM tokens. The monitor store reports its earliest due poll to the
+controller, which shortens the ordinary heartbeat sleep accordingly; a
+minute-scale job therefore does not wait for the default ten-minute cadence.
 
-Metric samples reject NaN and infinities. A failure in one monitor's training
-status or W&B lookup advances that monitor's schedule and emits one
-deduplicated `monitor_error` hard signal; it cannot block other monitors,
+Metric samples reject NaN and infinities. Due monitors are ordered and processed
+in a capped batch with an overall time budget. A failure in one monitor's job
+status or W&B lookup advances that monitor's schedule and emits one deduplicated
+`monitor_error` hard signal. A slow external request can delay the current batch
+within its timeout and budget, but it cannot prevent later controller cycles,
 GitHub events, child results, or an already-pending hard-failure wake. A changed
-monitor policy resets its derived samples and signals to match the new marker.
+monitor policy resets its derived samples and signals to match the new persisted
+policy. The SQLite monitor store is the single source of truth for ownership,
+schedule, and active state; there is no second marker to reconcile.
 
-Every persisted actionable signal directly creates a compact
-`training_monitor` wake for the signal's original student conversation UUID.
-No intermediate LLM call gates these events: registering the monitor policy is
-the student's request to resume when one of its conditions emits a signal. The
+Every persisted actionable signal directly creates a compact `job_monitor`
+wake for the signal's original advisor or student conversation UUID. No
+intermediate LLM call gates these events: registering the monitor policy is the
+role's request to resume when one of its conditions emits a signal. The
 signal remains pending until that exact conversation successfully handles it.
 
 Controller events are partitioned by their exact conversation UUID before a
 turn. Each partition is acknowledged only after its own successful turn, so a
-child result for one assignment cannot consume or permanently block a training
+child result for one assignment cannot consume or permanently block a job
 event for another.
 
-The Stop hook verifies the automatic monitor marker and a clean worktree,
-allowing the student turn to end while the controller supervises the process.
-The advisor and advisor children never receive training tools.
+The advisor and student Stop hooks verify that every live supervised job has an
+active SQLite monitor record. The student hook also verifies a clean worktree,
+allowing its turn to end while the controller supervises the process. Advisor
+and student children never receive job tools.
 
 ## Hooks, deadlines, and shutdown
 
 The native plugin declares OpenHands `PreToolUse`, `Stop`, and `SessionEnd`
 hooks. Its pre-tool hook covers both `senpai_terminal` and the raw `terminal`
-used by file-defined children, so delegation cannot bypass workflow or training
+used by file-defined children, so delegation cannot bypass workflow or job
 boundaries. Hooks give early model-visible feedback. `senpai_terminal` also
 evaluates the same pure policy in-process and fails closed if policy evaluation
 fails.
@@ -591,7 +618,7 @@ Every OpenHands turn has a controller-configured hard deadline. The deadline
 interrupts the conversation, produces a non-success result, and leaves durable
 events unacknowledged. The controller then retries with bounded exponential
 backoff. Controller termination interrupts and closes the current conversation,
-cancels active supervised training, closes local stores, and flushes Weave
+cancels active supervised jobs, closes local stores, and flushes Weave
 before the controller exits. Standalone and child runners flush Weave at runner
 exit.
 
@@ -683,11 +710,16 @@ Removed:
 Retained intentionally:
 
 - Agent skills and their model/effort metadata under `.agents`;
-- OpenHands Browser, task tracker, Think, and the high-quality default
+- OpenHands Browser, task tracker, and the high-quality default
   condenser for providers not using stored OpenAI Responses continuation or
   Anthropic native compaction;
 - the pinned `weave-openhands` agent, LLM, and tool tracing integration; and
 - only a small bootstrap shell path for clone, identity, and Git push guards.
+
+The task tracker is described as optional persisted coordination memory for parallel
+work, delegated agents, and long-running jobs; it does not impose a single
+`in_progress` item. The legacy model-visible `think` scratchpad is omitted from
+root and child tool surfaces while provider-native reasoning stays enabled.
 
 ## Acceptance
 

--- a/plugins/senpai/skills/submit-experiment-results/SKILL.md
+++ b/plugins/senpai/skills/submit-experiment-results/SKILL.md
@@ -84,5 +84,7 @@ Do not run `git push`, edit labels, write result markers, or call `gh pr ready`
 yourself.
 
 If any run is still active or could change the conclusion, keep the assignment
-in progress and register it with `monitor_training`; do not submit a terminal
-result.
+in progress. Start long-running work with `run_job`; it registers terminal-state
+monitoring automatically. Use `monitor_job` only when an active W&B run also
+benefits from a metric threshold or staleness policy. Do not submit a terminal
+result until the evidence is terminal.

--- a/senpai_agent/controller.py
+++ b/senpai_agent/controller.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import os
 import random
 import signal
@@ -17,12 +18,12 @@ from string import Template
 from typing import Literal, Protocol
 from uuid import UUID
 
-from senpai_agent.agent_markdown import read_agent_markdown, strip_spdx_header
 from senpai_agent.advisor import (
     AdvisorEvent,
     AdvisorEventStore,
     compose_system_instructions,
 )
+from senpai_agent.agent_markdown import read_agent_markdown, strip_spdx_header
 from senpai_agent.github.mailbox import ActiveGitHubWatcher, GitHubMailbox
 from senpai_agent.mailbox import (
     CompositeMailbox,
@@ -44,8 +45,11 @@ from senpai_agent.state import (
     WorkspaceDivergenceLedger,
 )
 from senpai_agent.supervisor import LEASE_ENV, ProgressLease
-from senpai_agent.workspace import StudentWorkspaceReconciler, WorkspaceDivergence
-
+from senpai_agent.workspace import (
+    StudentWorkspaceReconciler,
+    WorkspaceDivergence,
+    WorkspaceJobRunning,
+)
 
 _EDGE_TRIGGERED_EVENT_KINDS = frozenset({"research_base_changed"})
 
@@ -83,9 +87,7 @@ def _is_context_history_failure(error: Exception) -> bool:
     )
 
     cause = (
-        error.original_exception
-        if isinstance(error, ConversationRunError)
-        else error
+        error.original_exception if isinstance(error, ConversationRunError) else error
     )
     return isinstance(
         cause,
@@ -151,9 +153,7 @@ class OpenHandsTurnRunner:
                 )
                 remaining = turn_deadline - time.monotonic()
                 if remaining <= 0:
-                    timeout = TimeoutError(
-                        "no turn time remains for context recovery"
-                    )
+                    timeout = TimeoutError("no turn time remains for context recovery")
                     raise ConversationRecoveryExhausted(
                         conversation_id,
                         timeout,
@@ -266,8 +266,15 @@ class Controller:
         sleep: Callable[[float], None] = time.sleep,
         poll_interval_seconds: float = 600,
         jitter_seconds: float = 120,
+        next_monitor_poll_seconds: Callable[[], float | None] | None = None,
     ):
-        if min(poll_interval_seconds, jitter_seconds) < 0:
+        if (
+            not all(
+                math.isfinite(value)
+                for value in (poll_interval_seconds, jitter_seconds)
+            )
+            or min(poll_interval_seconds, jitter_seconds) < 0
+        ):
             raise ValueError("poll and jitter intervals must not be negative")
         if start_gate_poll_seconds <= 0:
             raise ValueError("start-gate polling interval must be positive")
@@ -296,6 +303,7 @@ class Controller:
         self.sleep = sleep
         self.poll_interval_seconds = poll_interval_seconds
         self.jitter_seconds = jitter_seconds
+        self.next_monitor_poll_seconds = next_monitor_poll_seconds
         self.event_reminder_seconds = (
             max(poll_interval_seconds, 600)
             if event_reminder_seconds is None
@@ -328,6 +336,36 @@ class Controller:
                             self._publish_progress("reconcile")
                             try:
                                 self.reconcile(batch_events)
+                            except WorkspaceJobRunning as busy:
+                                retry_delay = 30.0
+                                retry_at = time.monotonic() + retry_delay
+                                checkout_kinds = {
+                                    "student_assignment",
+                                    "student_pr_feedback",
+                                }
+                                deferred_events = tuple(
+                                    event
+                                    for event in batch_events
+                                    if event.kind in checkout_kinds
+                                )
+                                batch_events = tuple(
+                                    event
+                                    for event in batch_events
+                                    if event.kind not in checkout_kinds
+                                )
+                                for event in deferred_events:
+                                    self._visible.pop(event.dedupe_key, None)
+                                    self._deferred_until[event.dedupe_key] = retry_at
+                                print(
+                                    "SENPAI_WORKSPACE_JOB_DEFERRED "
+                                    f"conversation_id={conversation_id} "
+                                    f"retry_after_seconds={retry_delay:g} "
+                                    f"jobs={','.join(busy.job_ids)}",
+                                    file=sys.stderr,
+                                    flush=True,
+                                )
+                                if not batch_events:
+                                    continue
                             except WorkspaceDivergence as conflict:
                                 workspace_divergence = conflict
                                 print(
@@ -404,7 +442,7 @@ class Controller:
                             flush=True,
                         )
                         continue
-                    except Exception as error:  # noqa: BLE001
+                    except Exception as error:
                         turn_failures += 1
                         for event in batch_events:
                             self._visible.pop(event.dedupe_key, None)
@@ -426,9 +464,7 @@ class Controller:
                             *(event.dedupe_key for event in batch_events),
                             *sorted(result.delivered_event_keys),
                         )
-                        self.mailbox.acknowledge(
-                            tuple(dict.fromkeys(acknowledged))
-                        )
+                        self.mailbox.acknowledge(tuple(dict.fromkeys(acknowledged)))
                         if workspace_divergence is not None:
                             self._record_workspace_divergence(
                                 conversation_id,
@@ -486,10 +522,8 @@ class Controller:
                 return
             if turn_failed:
                 continue
-            self._sleep(
-                "sleep",
-                self.poll_interval_seconds + random.uniform(0, self.jitter_seconds),
-            )
+            phase, delay = self._idle_delay()
+            self._sleep(phase, delay)
 
     def _event_batches(
         self,
@@ -527,6 +561,33 @@ class Controller:
             max(seconds + self.operation_timeout_seconds, 1),
         )
         self.sleep(seconds)
+
+    def _idle_delay(self) -> tuple[str, float]:
+        heartbeat = max(
+            1.0,
+            self.poll_interval_seconds + random.uniform(0, self.jitter_seconds),
+        )
+        if self.next_monitor_poll_seconds is None:
+            return "sleep", heartbeat
+        try:
+            monitor_delay = self.next_monitor_poll_seconds()
+        except Exception as error:  # noqa: BLE001
+            print(
+                f"SENPAI_MONITOR_SCHEDULE_ERROR {type(error).__name__}: {error}",
+                file=sys.stderr,
+                flush=True,
+            )
+            return "monitor-backoff", min(heartbeat, 5.0)
+        if monitor_delay is None:
+            return "sleep", heartbeat
+        if not math.isfinite(monitor_delay) or monitor_delay < 0:
+            print(
+                f"SENPAI_MONITOR_SCHEDULE_INVALID delay={monitor_delay!r}",
+                file=sys.stderr,
+                flush=True,
+            )
+            return "monitor-backoff", min(heartbeat, 5.0)
+        return "monitor-sleep", max(1.0, min(heartbeat, monitor_delay))
 
     def _has_started(self, conversation_id: UUID) -> bool:
         return conversation_id in self._started or (
@@ -739,29 +800,35 @@ def controller_main(
     mailbox: Mailbox = github_mailbox
     conversation_selector = None
     reconcile = None
+    job_supervisor, monitor_store = training_runtime(
+        runner_config.workspace,
+        runner_config.state_dir / "training",
+        max_timeout_seconds=runner_config.training_max_timeout_seconds,
+    )
+    monitor_mailbox = MonitorMailbox(
+        TrainingMonitorEngine(
+            monitor_store,
+            job_supervisor,
+            WandbMetricSource(
+                env["WANDB_ENTITY"],
+                env["WANDB_PROJECT"],
+                api_key=runner_config.command_secrets.get("WANDB_API_KEY"),
+            ),
+        ),
+        monitor_store,
+    )
 
     if role == "advisor":
         mailbox = CompositeMailbox(
             github_mailbox,
             LocalAdvisorMailbox(runner_config.state_dir / "advisor-events.sqlite3"),
+            monitor_mailbox,
         )
     else:
-        training, monitor_store = training_runtime(
-            runner_config.workspace,
-            runner_config.state_dir / "training",
-            max_timeout_seconds=runner_config.training_max_timeout_seconds,
-        )
-        metrics = WandbMetricSource(
-            env["WANDB_ENTITY"],
-            env["WANDB_PROJECT"],
-        )
         mailbox = CompositeMailbox(
             github_mailbox,
             LocalStudentMailbox(runner_config.state_dir / "student-events.sqlite3"),
-            MonitorMailbox(
-                TrainingMonitorEngine(monitor_store, training, metrics),
-                monitor_store,
-            ),
+            monitor_mailbox,
         )
         registry = AssignmentConversationRegistry(
             runner_config.state_dir / "student-conversations.json"
@@ -771,6 +838,7 @@ def controller_main(
             runner_config.workspace,
             repo=runner_config.github_repo,
             token=runner_config.github_token,
+            active_mutable_job_ids=job_supervisor.active_mutable_job_ids,
         )
 
     full_prompt = _full_prompt(role, env)
@@ -779,8 +847,7 @@ def controller_main(
         read_role_instructions(runner_config.role_file),
     )
     continuation_context = (
-        f"{system_context.strip()}\n\n"
-        f"# Current research brief\n\n{full_prompt}"
+        f"{system_context.strip()}\n\n# Current research brief\n\n{full_prompt}"
     )
     turns = OpenHandsTurnRunner(
         runner_config,
@@ -845,6 +912,7 @@ def controller_main(
             "POLL_JITTER_S",
             120,
         ),
+        next_monitor_poll_seconds=monitor_store.seconds_until_next_poll,
     )
 
     def interrupt(_signum: int, _frame: object) -> None:

--- a/senpai_agent/git_workflow.py
+++ b/senpai_agent/git_workflow.py
@@ -24,14 +24,14 @@ class PushResult:
     head_sha: str
 
 
-def require_clean_training_worktree(workspace: Path) -> None:
-    """Require every tracked and untracked assignment change to be committed."""
+def require_clean_job_worktree(workspace: Path) -> None:
+    """Require a student job to run against committed assignment state."""
 
     workspace = Path(workspace).resolve()
     _git(workspace, "rev-parse", "--is-inside-work-tree")
     if _git(workspace, "status", "--porcelain", "--untracked-files=all"):
         raise GitWorkflowPreconditionError(
-            "assignment worktree must be clean before training"
+            "student assignment worktree must be clean before run_job"
         )
 
 

--- a/senpai_agent/hooks.py
+++ b/senpai_agent/hooks.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 import shlex
+import sqlite3
 import subprocess
 import sys
 from collections.abc import Mapping, Sequence
@@ -106,19 +107,14 @@ def _without_literal_file_heredocs(command: str) -> str:
     tree = Parser(Language(tree_sitter_bash.language())).parse(source)
     if tree.root_node.has_error:
         return command
-    if any(
-        node.type == "function_definition"
-        for node in _descendants(tree.root_node)
-    ):
+    if any(node.type == "function_definition" for node in _descendants(tree.root_node)):
         return command
 
     policy_source = bytearray(source)
     nodes = [tree.root_node]
     while nodes:
         node = nodes.pop()
-        if node.type == "heredoc_redirect" and _is_literal_cat_file_sink(
-            node, source
-        ):
+        if node.type == "heredoc_redirect" and _is_literal_cat_file_sink(node, source):
             start = next(
                 child for child in node.children if child.type == "heredoc_start"
             )
@@ -151,9 +147,7 @@ def _is_literal_cat_file_sink(node: object, source: bytes) -> bool:
         if redirect.type == "file_redirect"
     ]
     stdout_redirects = [
-        redirect
-        for redirect in redirects
-        if _redirects_stdout(redirect, source)
+        redirect for redirect in redirects if _redirects_stdout(redirect, source)
     ]
     if not stdout_redirects:
         return False
@@ -188,9 +182,11 @@ def _redirects_stdout_to_literal_file(redirect: object, source: bytes) -> bool:
     ):
         return False
     target = source[destination.start_byte : destination.end_byte].strip(b"'\"")
-    return target not in {b"-", b"/dev/stdout", b"/dev/stderr"} and not target.startswith(
-        (b"/dev/fd/", b"/proc/")
-    )
+    return target not in {
+        b"-",
+        b"/dev/stdout",
+        b"/dev/stderr",
+    } and not target.startswith((b"/dev/fd/", b"/proc/"))
 
 
 def _descendants(root: object) -> list[object]:
@@ -289,8 +285,12 @@ def _gh_policy(tokens: list[str], index: int) -> PolicyDecision:
             False,
             f"Use a typed Senpai GitHub tool for `gh {noun}` mutations.",
         )
-    if noun == "pr" and operation == "checks" and any(
-        value == "--watch" or value.startswith("--watch=") for value in remaining
+    if (
+        noun == "pr"
+        and operation == "checks"
+        and any(
+            value == "--watch" or value.startswith("--watch=") for value in remaining
+        )
     ):
         return PolicyDecision(
             False,
@@ -489,7 +489,13 @@ def _git_policy(arguments: list[str]) -> PolicyDecision:
     )
 
 
-def _segment_policy(tokens: list[str]) -> PolicyDecision:
+def _segment_policy(
+    tokens: list[str],
+    *,
+    role: str,
+    workspace: Path,
+    supervised: bool = False,
+) -> PolicyDecision:
     index = _program_index(tokens)
     if index is None:
         return PolicyDecision(True)
@@ -497,23 +503,69 @@ def _segment_policy(tokens: list[str]) -> PolicyDecision:
 
     arguments = tokens[index + 1 :]
     if program in _SHELL_BODY_PREFIXES:
-        return _segment_policy(arguments)
+        return _segment_policy(
+            arguments,
+            role=role,
+            workspace=workspace,
+            supervised=supervised,
+        )
     if program == "env":
         command = _env_command(arguments)
-        return _segment_policy(command) if command else PolicyDecision(True)
+        return (
+            _segment_policy(
+                command,
+                role=role,
+                workspace=workspace,
+                supervised=supervised,
+            )
+            if command
+            else PolicyDecision(True)
+        )
     if program in {"command", "exec", "nohup"}:
         command = _wrapper_command(arguments)
-        return _segment_policy(command) if command else PolicyDecision(True)
+        return (
+            _segment_policy(
+                command,
+                role=role,
+                workspace=workspace,
+                supervised=supervised,
+            )
+            if command
+            else PolicyDecision(True)
+        )
     if program == "timeout":
         command = _timeout_command(arguments)
-        return _segment_policy(command) if command else PolicyDecision(True)
+        return (
+            _segment_policy(
+                command,
+                role=role,
+                workspace=workspace,
+                supervised=supervised,
+            )
+            if command
+            else PolicyDecision(True)
+        )
     if program == "setsid":
         command = _wrapper_command(arguments)
-        return _segment_policy(command) if command else PolicyDecision(True)
+        return (
+            _segment_policy(
+                command,
+                role=role,
+                workspace=workspace,
+                supervised=supervised,
+            )
+            if command
+            else PolicyDecision(True)
+        )
     if program in {"bash", "dash", "sh", "zsh"}:
         command = _shell_command(arguments)
         if command is not None:
-            return terminal_policy(command, "", Path.cwd())
+            return _command_policy(
+                command,
+                role=role,
+                workspace=workspace,
+                supervised=supervised,
+            )
     if program == "eval":
         return PolicyDecision(
             False,
@@ -528,21 +580,32 @@ def _segment_policy(tokens: list[str]) -> PolicyDecision:
         return _curl_policy(tokens, index)
 
     if program == "uv" and arguments[:1] == ["run"]:
-        return _segment_policy(tokens[index + 2 :])
-    if program.startswith("python") and _python_launches_training(tokens, index):
-        return PolicyDecision(
-            False,
-            "Use run_training so timeouts, logs, status, and W&B IDs are supervised.",
+        return _segment_policy(
+            tokens[index + 2 :],
+            role=role,
+            workspace=workspace,
+            supervised=supervised,
         )
     if (
-        program in _TRAIN_LAUNCHERS or _TRAIN_SCRIPT.fullmatch(program)
-    ) and not _help_only(arguments):
+        not supervised
+        and program.startswith("python")
+        and _python_launches_training(tokens, index)
+    ):
         return PolicyDecision(
             False,
-            "Use run_training so timeouts, logs, status, and W&B IDs are supervised.",
+            "Use run_job so timeouts, logs, status, and W&B IDs are supervised.",
+        )
+    if (
+        not supervised
+        and (program in _TRAIN_LAUNCHERS or _TRAIN_SCRIPT.fullmatch(program))
+        and not _help_only(arguments)
+    ):
+        return PolicyDecision(
+            False,
+            "Use run_job so timeouts, logs, status, and W&B IDs are supervised.",
         )
 
-    if program == "for":
+    if not supervised and program == "for":
         if any("((" in argument for argument in arguments):
             return PolicyDecision(
                 False,
@@ -550,20 +613,63 @@ def _segment_policy(tokens: list[str]) -> PolicyDecision:
                 "events or status tools.",
             )
         return PolicyDecision(True)
-    if program in {"sleep", "watch", "while", "until"}:
+    if not supervised and program in {"sleep", "watch", "while", "until"}:
         return PolicyDecision(
             False,
             "Do not run foreground polling loops; use Senpai events or status tools.",
         )
-    if program == "tail" and any(
-        argument == "--follow" or argument.startswith("-") and "f" in argument[1:]
-        for argument in tokens[index + 1 :]
+    if (
+        not supervised
+        and program == "tail"
+        and any(
+            argument == "--follow" or argument.startswith("-") and "f" in argument[1:]
+            for argument in tokens[index + 1 :]
+        )
     ):
         return PolicyDecision(
             False,
-            "Do not stream logs; use get_training_status for bounded updates.",
+            "Do not stream logs; use get_job_status for bounded updates.",
         )
     return PolicyDecision(True)
+
+
+def _command_policy(
+    command: str,
+    *,
+    role: str,
+    workspace: Path,
+    supervised: bool,
+) -> PolicyDecision:
+    if not supervised and _has_background_command(command):
+        return PolicyDecision(
+            False,
+            "Use run_job for background or detached work so its process group, "
+            "workspace lease, logs, and terminal state remain supervised.",
+        )
+    for segment in _command_segments(command):
+        decision = _segment_policy(
+            segment,
+            role=role,
+            workspace=workspace,
+            supervised=supervised,
+        )
+        if not decision.allowed:
+            return decision
+    return PolicyDecision(True)
+
+
+def _has_background_command(command: str) -> bool:
+    import tree_sitter_bash
+    from tree_sitter import Language, Parser
+
+    source = _without_literal_file_heredocs(command).encode()
+    root = Parser(Language(tree_sitter_bash.language())).parse(source).root_node
+    return any(
+        node.type == "&"
+        and node.parent is not None
+        and node.parent.type != "binary_expression"
+        for node in _descendants(root)
+    )
 
 
 def terminal_policy(
@@ -571,12 +677,34 @@ def terminal_policy(
     role: str,
     workspace: Path,
 ) -> PolicyDecision:
-    del role, workspace
-    for segment in _command_segments(command):
-        decision = _segment_policy(segment)
-        if not decision.allowed:
-            return decision
-    return PolicyDecision(True)
+    return _command_policy(
+        command,
+        role=role,
+        workspace=workspace,
+        supervised=False,
+    )
+
+
+def supervised_job_policy(
+    argv: Sequence[str],
+    role: str,
+    workspace: Path,
+) -> PolicyDecision:
+    """Apply terminal safety rules to structured, supervisor-bounded argv.
+
+    Supervision makes long-running commands safe to launch, but it does not
+    make hidden shell evaluation or GitHub mutations safe. Nested shell bodies
+    and wrappers therefore receive the same recursive policy evaluation.
+    """
+
+    if not argv or not argv[0] or any("\0" in value for value in argv):
+        return PolicyDecision(False, "Job argv must contain valid non-empty words.")
+    return _segment_policy(
+        list(argv),
+        role=role,
+        workspace=workspace,
+        supervised=True,
+    )
 
 
 def _stop_policy(
@@ -584,7 +712,7 @@ def _stop_policy(
     working_dir: Path,
     state_dir: Path | None,
 ) -> PolicyDecision:
-    if role != "student" or not (working_dir / ".git").exists():
+    if role not in {"advisor", "student"} or not (working_dir / ".git").exists():
         return PolicyDecision(True)
     if state_dir is not None:
         running = {
@@ -592,18 +720,19 @@ def _stop_policy(
             for path in training_result_paths(state_dir / "training")
             if json.loads(path.read_text()).get("state") == "running"
         }
-        monitored = {
-            path.stem for path in (state_dir / "training" / "monitors").glob("*.json")
-        }
+        monitored = _active_monitor_ids(state_dir / "training" / "monitors.sqlite3")
         unmonitored = running - monitored
         if unmonitored:
             return PolicyDecision(
                 False,
-                "Training is still running without the terminal monitor that "
-                "run_training normally registers; call monitor_training to "
-                "repair it before finishing: "
+                "A job is still running without the terminal monitor that "
+                "run_job normally registers. Do not finish until the orphan "
+                "has been inspected and cancelled or the controller has been "
+                "repaired: "
                 f"{', '.join(sorted(unmonitored))}",
             )
+    if role == "advisor":
+        return PolicyDecision(True)
     status = subprocess.run(
         ["git", "status", "--porcelain"],
         cwd=working_dir,
@@ -614,10 +743,25 @@ def _stop_policy(
     if status.strip():
         return PolicyDecision(
             False,
-            "Commit the exact implementation before training or discard incidental "
+            "Commit the exact implementation before a job or discard incidental "
             "assignment changes before finishing.",
         )
     return PolicyDecision(True)
+
+
+def _active_monitor_ids(database: Path) -> set[str]:
+    if not database.is_file():
+        return set()
+    connection = sqlite3.connect(f"file:{database}?mode=ro", uri=True)
+    try:
+        return {
+            str(row[0])
+            for row in connection.execute(
+                "SELECT training_id FROM monitors WHERE active = 1"
+            )
+        }
+    finally:
+        connection.close()
 
 
 def _emit(decision: PolicyDecision) -> int:

--- a/senpai_agent/monitor.py
+++ b/senpai_agent/monitor.py
@@ -1,11 +1,13 @@
-"""Durable, programmatic training-monitor state and signal evaluation."""
+"""Durable, programmatic job-monitor state and signal evaluation."""
 
 from __future__ import annotations
 
 import math
 import sqlite3
+import sys
 import threading
-from collections.abc import Sequence
+import time
+from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 from types import TracebackType
@@ -14,28 +16,28 @@ from uuid import UUID
 
 from pydantic import Field
 
-from senpai_agent.models import Contract
 from senpai_agent.mailbox import ControllerEvent
+from senpai_agent.models import Contract
 from senpai_agent.training import TrainingResult, TrainingState
 
 
 class MetricGate(Contract):
-    """One threshold or change that should be surfaced to the student."""
+    """One W&B threshold or change surfaced to the owning conversation."""
 
     operator: Literal["lte", "gte", "improved_by", "regressed_by"]
     threshold: float
 
 
 class TrainingMonitorSpec(Contract):
-    """Durable monitoring policy for one training process and conversation."""
+    """Internal durable policy for one supervised process and conversation."""
 
     training_id: str = Field(min_length=1)
     conversation_id: UUID
     metric: str | None = None
     direction: Literal["min", "max"] | None = None
     gates: tuple[MetricGate, ...] = ()
-    poll_interval_seconds: float = Field(default=60, gt=0)
-    stale_after_seconds: float = Field(default=600, gt=0)
+    poll_interval_seconds: float = Field(default=60, ge=5, allow_inf_nan=False)
+    stale_after_seconds: float = Field(default=600, gt=0, allow_inf_nan=False)
     notify_on_status: frozenset[TrainingState] = Field(
         default_factory=lambda: frozenset(
             {
@@ -64,7 +66,7 @@ class MetricSample(Contract):
 
 
 class MonitorSignal(Contract):
-    """Compact event handed back to the student conversation."""
+    """Compact internal signal handed back to the owning conversation."""
 
     kind: Literal[
         "metric_gate",
@@ -79,6 +81,7 @@ class MonitorSignal(Contract):
     state: TrainingState | None
     detail: str = Field(min_length=1, max_length=1_000)
     hard_failure: bool = False
+
 
 class MonitorEvaluation(Contract):
     signals: tuple[MonitorSignal, ...] = ()
@@ -121,7 +124,7 @@ def evaluate_monitor(
                     training_id=spec.training_id,
                     state=result.state,
                     detail=(
-                        f"Training reached terminal state {result.state.value}"
+                        f"Job reached terminal state {result.state.value}"
                         + (
                             f" with exit code {result.exit_code}."
                             if result.exit_code is not None
@@ -213,15 +216,13 @@ def _gate_crossed(
 
 
 class MonitorStore:
-    """SQLite state plus a tiny JSON presence marker used by the Stop hook."""
+    """Thread-safe SQLite state for durable process-monitor ownership."""
 
     def __init__(self, path: Path):
         path.parent.mkdir(parents=True, exist_ok=True)
         self.path = path
-        self.marker_dir = path.parent / "monitors"
-        self.marker_dir.mkdir(exist_ok=True)
         self.connection = sqlite3.connect(path, check_same_thread=False)
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
         self.connection.execute("BEGIN IMMEDIATE")
         try:
             self.connection.execute(
@@ -247,8 +248,7 @@ class MonitorStore:
                 """
             )
             monitor_columns = {
-                row[1]
-                for row in self.connection.execute("PRAGMA table_info(monitors)")
+                row[1] for row in self.connection.execute("PRAGMA table_info(monitors)")
             }
             if "baseline_sample_json" not in monitor_columns:
                 self.connection.execute(
@@ -277,17 +277,22 @@ class MonitorStore:
                 """,
                 (spec.training_id,),
             ).fetchone()
-            existing = (
-                TrainingMonitorSpec.model_validate_json(row[0])
-                if row is not None
-                else None
-            )
+            try:
+                existing = (
+                    TrainingMonitorSpec.model_validate_json(row[0])
+                    if row is not None
+                    else None
+                )
+                if existing is not None and existing.training_id != spec.training_id:
+                    raise ValueError("monitor row ID does not match its policy")
+            except Exception as error:  # noqa: BLE001
+                self._quarantine_locked(spec.training_id, error)
+                existing = None
             unchanged = (
                 existing is not None
                 and bool(row[1])
                 and _same_monitor_policy(existing, spec)
             )
-            effective = existing if unchanged else spec
             if not unchanged:
                 with self.connection:
                     self.connection.execute(
@@ -314,73 +319,106 @@ class MonitorStore:
                         "DELETE FROM monitor_signals WHERE training_id = ?",
                         (spec.training_id,),
                     )
-            self._write_marker(effective)
             return not unchanged
 
-    def _write_marker(self, spec: TrainingMonitorSpec) -> None:
-        marker = self.marker_dir / f"{spec.training_id}.json"
-        temporary = marker.with_suffix(".tmp")
-        temporary.write_text(spec.model_dump_json(indent=2), encoding="utf-8")
-        temporary.replace(marker)
-
     def active(self) -> list[TrainingMonitorSpec]:
-        rows = self.connection.execute(
-            """
-            SELECT spec_json FROM monitors
-            WHERE active = 1
-            ORDER BY rowid
-            """
-        ).fetchall()
-        return [TrainingMonitorSpec.model_validate_json(row[0]) for row in rows]
+        with self._lock:
+            rows = self.connection.execute(
+                """
+                SELECT training_id, spec_json FROM monitors
+                WHERE active = 1
+                ORDER BY rowid
+                """
+            ).fetchall()
+            return self._validated_specs_locked(rows)
 
     def spec(self, training_id: str) -> TrainingMonitorSpec:
-        row = self.connection.execute(
-            "SELECT spec_json FROM monitors WHERE training_id = ?",
-            (training_id,),
-        ).fetchone()
-        if row is None:
-            raise KeyError(training_id)
-        return TrainingMonitorSpec.model_validate_json(row[0])
+        with self._lock:
+            row = self.connection.execute(
+                "SELECT spec_json FROM monitors WHERE training_id = ?",
+                (training_id,),
+            ).fetchone()
+            if row is None:
+                raise KeyError(training_id)
+            try:
+                spec = TrainingMonitorSpec.model_validate_json(row[0])
+                if spec.training_id != training_id:
+                    raise ValueError("monitor row ID does not match its policy")
+                return spec
+            except Exception as error:
+                self._quarantine_locked(training_id, error)
+                raise RuntimeError(
+                    f"monitor state for {training_id} was quarantined"
+                ) from error
 
     def due(
         self,
         now: datetime | None = None,
+        *,
+        limit: int = 32,
     ) -> list[TrainingMonitorSpec]:
+        if limit <= 0:
+            raise ValueError("monitor due limit must be positive")
         timestamp = (now or datetime.now(UTC)).timestamp()
-        rows = self.connection.execute(
-            """
-            SELECT spec_json FROM monitors
-            WHERE active = 1 AND next_poll_at <= ?
-            ORDER BY rowid
-            """,
-            (timestamp,),
-        ).fetchall()
-        return [TrainingMonitorSpec.model_validate_json(row[0]) for row in rows]
+        with self._lock:
+            rows = self.connection.execute(
+                """
+                SELECT training_id, spec_json FROM monitors
+                WHERE active = 1 AND next_poll_at <= ?
+                ORDER BY next_poll_at, rowid
+                LIMIT ?
+                """,
+                (timestamp, limit),
+            ).fetchall()
+            return self._validated_specs_locked(rows)
+
+    def seconds_until_next_poll(self, now: datetime | None = None) -> float | None:
+        """Return when the earliest active monitor is due, or None when idle."""
+
+        timestamp = (now or datetime.now(UTC)).timestamp()
+        with self._lock:
+            rows = self.connection.execute(
+                "SELECT training_id, next_poll_at FROM monitors WHERE active = 1"
+            ).fetchall()
+            delays: list[float] = []
+            for training_id, value in rows:
+                try:
+                    poll_at = float(value)
+                    if not math.isfinite(poll_at):
+                        raise ValueError("next_poll_at is not finite")
+                except (TypeError, ValueError) as error:
+                    self._quarantine_locked(training_id, error)
+                    continue
+                delays.append(max(0.0, poll_at - timestamp))
+            return min(delays) if delays else None
 
     def emitted(self, training_id: str) -> frozenset[str]:
-        rows = self.connection.execute(
-            "SELECT dedupe_key FROM monitor_signals WHERE training_id = ?",
-            (training_id,),
-        ).fetchall()
-        return frozenset(row[0] for row in rows)
+        with self._lock:
+            rows = self.connection.execute(
+                "SELECT dedupe_key FROM monitor_signals WHERE training_id = ?",
+                (training_id,),
+            ).fetchall()
+            return frozenset(row[0] for row in rows)
 
     def previous_sample(self, training_id: str) -> MetricSample | None:
-        row = self.connection.execute(
-            "SELECT previous_sample_json FROM monitors WHERE training_id = ?",
-            (training_id,),
-        ).fetchone()
-        if row is None or row[0] is None:
-            return None
-        return MetricSample.model_validate_json(row[0])
+        with self._lock:
+            row = self.connection.execute(
+                "SELECT previous_sample_json FROM monitors WHERE training_id = ?",
+                (training_id,),
+            ).fetchone()
+            if row is None or row[0] is None:
+                return None
+            return MetricSample.model_validate_json(row[0])
 
     def baseline_sample(self, training_id: str) -> MetricSample | None:
-        row = self.connection.execute(
-            "SELECT baseline_sample_json FROM monitors WHERE training_id = ?",
-            (training_id,),
-        ).fetchone()
-        if row is None or row[0] is None:
-            return None
-        return MetricSample.model_validate_json(row[0])
+        with self._lock:
+            row = self.connection.execute(
+                "SELECT baseline_sample_json FROM monitors WHERE training_id = ?",
+                (training_id,),
+            ).fetchone()
+            if row is None or row[0] is None:
+                return None
+            return MetricSample.model_validate_json(row[0])
 
     def record_poll(
         self,
@@ -391,35 +429,35 @@ class MonitorStore:
         now: datetime | None = None,
     ) -> None:
         now = now or datetime.now(UTC)
-        for signal in evaluation.signals:
+        with self._lock, self.connection:
+            for signal in evaluation.signals:
+                self.connection.execute(
+                    """
+                    INSERT OR IGNORE INTO monitor_signals
+                    (dedupe_key, training_id, signal_json)
+                    VALUES (?, ?, ?)
+                    """,
+                    (
+                        signal.dedupe_key,
+                        spec.training_id,
+                        signal.model_dump_json(),
+                    ),
+                )
             self.connection.execute(
                 """
-                INSERT OR IGNORE INTO monitor_signals
-                (dedupe_key, training_id, signal_json)
-                VALUES (?, ?, ?)
+                UPDATE monitors
+                SET previous_sample_json = ?,
+                    baseline_sample_json = COALESCE(baseline_sample_json, ?),
+                    next_poll_at = ?
+                WHERE training_id = ?
                 """,
                 (
-                    signal.dedupe_key,
+                    sample.model_dump_json() if sample is not None else None,
+                    sample.model_dump_json() if sample is not None else None,
+                    now.timestamp() + spec.poll_interval_seconds,
                     spec.training_id,
-                    signal.model_dump_json(),
                 ),
             )
-        self.connection.execute(
-            """
-            UPDATE monitors
-            SET previous_sample_json = ?,
-                baseline_sample_json = COALESCE(baseline_sample_json, ?),
-                next_poll_at = ?
-            WHERE training_id = ?
-            """,
-            (
-                sample.model_dump_json() if sample is not None else None,
-                sample.model_dump_json() if sample is not None else None,
-                now.timestamp() + spec.poll_interval_seconds,
-                spec.training_id,
-            ),
-        )
-        self.connection.commit()
 
     def record_poll_error(
         self,
@@ -440,7 +478,7 @@ class MonitorStore:
             detail=_monitor_error_detail(error),
             hard_failure=True,
         )
-        with self.connection:
+        with self._lock, self.connection:
             cursor = self.connection.execute(
                 """
                 INSERT OR IGNORE INTO monitor_signals
@@ -473,32 +511,80 @@ class MonitorStore:
         return signal if cursor.rowcount == 1 else None
 
     def pending_signals(self) -> list[MonitorSignal]:
-        rows = self.connection.execute(
-            """
-            SELECT signal_json FROM monitor_signals
-            WHERE handled = 0
-            ORDER BY rowid
-            """
-        ).fetchall()
-        return [MonitorSignal.model_validate_json(row[0]) for row in rows]
+        with self._lock:
+            rows = self.connection.execute(
+                """
+                SELECT dedupe_key, signal_json FROM monitor_signals
+                WHERE handled = 0
+                ORDER BY rowid
+                """
+            ).fetchall()
+            signals: list[MonitorSignal] = []
+            for dedupe_key, payload in rows:
+                try:
+                    signals.append(MonitorSignal.model_validate_json(payload))
+                except Exception as error:  # noqa: BLE001
+                    with self.connection:
+                        self.connection.execute(
+                            """
+                            UPDATE monitor_signals SET handled = 1
+                            WHERE dedupe_key = ?
+                            """,
+                            (dedupe_key,),
+                        )
+                    print(
+                        "SENPAI_MONITOR_SIGNAL_QUARANTINED "
+                        f"dedupe_key={dedupe_key} error={type(error).__name__}",
+                        file=sys.stderr,
+                        flush=True,
+                    )
+            return signals
 
     def acknowledge(self, dedupe_key: str) -> None:
-        self.connection.execute(
-            "UPDATE monitor_signals SET handled = 1 WHERE dedupe_key = ?",
-            (dedupe_key,),
-        )
-        self.connection.commit()
+        with self._lock, self.connection:
+            self.connection.execute(
+                "UPDATE monitor_signals SET handled = 1 WHERE dedupe_key = ?",
+                (dedupe_key,),
+            )
 
     def complete(self, training_id: str) -> None:
-        self.connection.execute(
-            "UPDATE monitors SET active = 0 WHERE training_id = ?",
-            (training_id,),
+        with self._lock, self.connection:
+            self.connection.execute(
+                "UPDATE monitors SET active = 0 WHERE training_id = ?",
+                (training_id,),
+            )
+
+    def _validated_specs_locked(
+        self,
+        rows: Sequence[tuple[str, str]],
+    ) -> list[TrainingMonitorSpec]:
+        specs: list[TrainingMonitorSpec] = []
+        for training_id, payload in rows:
+            try:
+                spec = TrainingMonitorSpec.model_validate_json(payload)
+                if spec.training_id != training_id:
+                    raise ValueError("monitor row ID does not match its policy")
+                specs.append(spec)
+            except Exception as error:  # noqa: BLE001
+                self._quarantine_locked(training_id, error)
+        return specs
+
+    def _quarantine_locked(self, training_id: str, error: Exception) -> None:
+        with self.connection:
+            self.connection.execute(
+                "UPDATE monitors SET active = 0 WHERE training_id = ?",
+                (training_id,),
+            )
+        print(
+            "SENPAI_MONITOR_QUARANTINED "
+            f"job_id={training_id} error={type(error).__name__}",
+            file=sys.stderr,
+            flush=True,
         )
-        self.connection.commit()
-        (self.marker_dir / f"{training_id}.json").unlink(missing_ok=True)
 
     def close(self) -> None:
-        self.connection.close()
+        with self._lock:
+            self.connection.close()
 
     def __enter__(self) -> Self:
         return self
@@ -523,17 +609,26 @@ class MetricSource(Protocol):
 class WandbMetricSource:
     """Fetch one latest metric value without carrying history into the agent."""
 
-    def __init__(self, entity: str, project: str, timeout_seconds: int = 30):
+    def __init__(
+        self,
+        entity: str,
+        project: str,
+        timeout_seconds: int = 20,
+        *,
+        api_key: str | None = None,
+    ):
         self.entity = entity
         self.project = project
         self.timeout_seconds = timeout_seconds
+        self.api_key = api_key
 
     def latest(self, run_id: str, metric: str) -> MetricSample | None:
         import wandb
 
-        run = wandb.Api(timeout=self.timeout_seconds).run(
-            f"{self.entity}/{self.project}/{run_id}"
-        )
+        run = wandb.Api(
+            api_key=self.api_key,
+            timeout=self.timeout_seconds,
+        ).run(f"{self.entity}/{self.project}/{run_id}")
         rows = run.history(
             keys=[metric, "_timestamp"],
             samples=2,
@@ -557,22 +652,38 @@ class WandbMetricSource:
 
 
 class TrainingMonitorEngine:
-    """Poll due monitors and persist only compact, deduplicated signals."""
+    """Poll due job monitors and persist only compact, deduplicated signals."""
 
     def __init__(
         self,
         store: MonitorStore,
         training: TrainingStatusSource,
         metrics: MetricSource,
+        *,
+        max_polls_per_cycle: int = 4,
+        poll_budget_seconds: float = 120,
+        monotonic: Callable[[], float] = time.monotonic,
     ):
+        if max_polls_per_cycle <= 0:
+            raise ValueError("max_polls_per_cycle must be positive")
+        if not math.isfinite(poll_budget_seconds) or poll_budget_seconds <= 0:
+            raise ValueError("poll_budget_seconds must be finite and positive")
         self.store = store
         self.training = training
         self.metrics = metrics
+        self.max_polls_per_cycle = max_polls_per_cycle
+        self.poll_budget_seconds = poll_budget_seconds
+        self.monotonic = monotonic
 
     def poll(self, now: datetime | None = None) -> tuple[MonitorSignal, ...]:
         now = now or datetime.now(UTC)
         produced: list[MonitorSignal] = []
-        for spec in self.store.due(now):
+        deadline = self.monotonic() + self.poll_budget_seconds
+        for index, spec in enumerate(
+            self.store.due(now, limit=self.max_polls_per_cycle)
+        ):
+            if index and self.monotonic() >= deadline:
+                break
             try:
                 result = self.training.get_training_status(spec.training_id)
             except Exception as error:  # noqa: BLE001
@@ -645,7 +756,7 @@ class TrainingMonitorEngine:
 
 
 class MonitorMailbox:
-    """Resume a student for every signal its monitor policy requested."""
+    """Resume the owning role conversation for each requested monitor signal."""
 
     def __init__(self, engine: TrainingMonitorEngine, store: MonitorStore):
         self.engine = engine
@@ -653,22 +764,39 @@ class MonitorMailbox:
 
     def poll(self) -> tuple[ControllerEvent, ...]:
         self.engine.poll()
-        return tuple(
-            ControllerEvent(
-                kind="training_monitor",
-                dedupe_key=signal.dedupe_key,
-                payload={
-                    "conversation_id": str(
-                        self.store.spec(signal.training_id).conversation_id
-                    ),
-                    "training_id": signal.training_id,
-                    "summary": signal.detail,
-                    "reason": "The registered monitor policy emitted this signal.",
-                    "signal": signal.model_dump(mode="json"),
-                },
+        events = []
+        for signal in self.store.pending_signals():
+            try:
+                owner = self.store.spec(signal.training_id).conversation_id
+            except (KeyError, RuntimeError) as error:
+                self.store.acknowledge(signal.dedupe_key)
+                print(
+                    "SENPAI_MONITOR_SIGNAL_ORPHANED "
+                    f"dedupe_key={signal.dedupe_key} "
+                    f"error={type(error).__name__}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                continue
+            serialized = signal.model_dump(mode="json")
+            serialized["job_id"] = serialized.pop("training_id")
+            serialized["wandb_metric"] = serialized.pop("metric")
+            if serialized["kind"] == "training_status":
+                serialized["kind"] = "job_status"
+            events.append(
+                ControllerEvent(
+                    kind="job_monitor",
+                    dedupe_key=signal.dedupe_key,
+                    payload={
+                        "conversation_id": str(owner),
+                        "job_id": signal.training_id,
+                        "summary": signal.detail,
+                        "reason": "The registered job monitor emitted this signal.",
+                        "signal": serialized,
+                    },
+                )
             )
-            for signal in self.store.pending_signals()
-        )
+        return tuple(events)
 
     def acknowledge(self, dedupe_keys: Sequence[str]) -> None:
         for key in dedupe_keys:

--- a/senpai_agent/openhands_runner.py
+++ b/senpai_agent/openhands_runner.py
@@ -1,6 +1,5 @@
 """Run one bounded Senpai OpenHands turn for the Python controller."""
 
-# ruff: noqa: E402
 # OpenHands imports intentionally follow Weave initialization below.
 
 from __future__ import annotations
@@ -34,6 +33,13 @@ from senpai_agent.delegation import (
     configure_delegation,
     record_delegated_task_result,
 )
+from senpai_agent.model_compatibility import (
+    REASONING_EFFORTS,
+    WANDB_GLM_52_MODEL,
+    WANDB_GLM_52_TOKENIZER,
+    register_litellm_model_compatibility,
+    supports_reasoning_effort,
+)
 from senpai_agent.secrets import (
     GITHUB_TOKEN_ENV_NAMES,
     GITHUB_TOKEN_FD_ENV,
@@ -45,13 +51,6 @@ from senpai_agent.weave_monitoring import (
     initialize_weave_monitoring,
     register_trace_secret,
     weave_conversation_url,
-)
-from senpai_agent.model_compatibility import (
-    REASONING_EFFORTS,
-    WANDB_GLM_52_MODEL,
-    WANDB_GLM_52_TOKENIZER,
-    register_litellm_model_compatibility,
-    supports_reasoning_effort,
 )
 
 WEAVE_PROJECT = initialize_weave_monitoring()
@@ -466,8 +465,7 @@ def depth_aware_child_definition(
     """Expose recursive spawn only to the one child role that can use it."""
 
     if not child or (
-        definition.name == "general-purpose"
-        and 0 < depth < MAX_DELEGATION_DEPTH
+        definition.name == "general-purpose" and 0 < depth < MAX_DELEGATION_DEPTH
     ):
         return definition
     return definition.model_copy(
@@ -613,9 +611,7 @@ def resolve_config(
         raise RuntimeError("SENPAI_DELEGATION_DEPTH must be between 0 and 2")
     deadline_value = env.get("SENPAI_DELEGATION_DEADLINE_EPOCH")
     try:
-        delegation_deadline_epoch = (
-            float(deadline_value) if deadline_value else None
-        )
+        delegation_deadline_epoch = float(deadline_value) if deadline_value else None
     except ValueError as error:
         raise RuntimeError(
             "SENPAI_DELEGATION_DEADLINE_EPOCH must be numeric"
@@ -634,12 +630,11 @@ def resolve_config(
         or DEFAULT_REASONING_EFFORT
     )
     reasoning_effort = openhands_reasoning_effort(reasoning_effort, model)
-    api_key_env = (
-        env_value(args.api_key_env, env, "SENPAI_OPENHANDS_API_KEY_ENV")
-        or infer_api_key_env(
-            model,
-            override_env="SENPAI_OPENHANDS_API_KEY_ENV",
-        )
+    api_key_env = env_value(
+        args.api_key_env, env, "SENPAI_OPENHANDS_API_KEY_ENV"
+    ) or infer_api_key_env(
+        model,
+        override_env="SENPAI_OPENHANDS_API_KEY_ENV",
     )
 
     smart_default_model = (
@@ -857,6 +852,7 @@ def with_role_and_project_context(
     harness_instructions: str,
     role_instructions: str,
     project_skills: Sequence[Skill] = (),
+    runtime_invariant: str = "",
 ) -> Agent:
     context = agent.agent_context or AgentContext()
     skills = {skill.name: skill for skill in context.skills}
@@ -865,6 +861,8 @@ def with_role_and_project_context(
         harness_instructions,
         role_instructions,
     )
+    if runtime_invariant:
+        role_suffix += f"\n# Live controller invariant\n\n{runtime_invariant.strip()}\n"
     system_suffix = (
         f"{context.system_message_suffix}\n\n{role_suffix}"
         if context.system_message_suffix
@@ -888,17 +886,37 @@ def build_main_agent_context(
     harness_instructions: str,
     role_instructions: str,
     project_skills: Sequence[Skill] = (),
+    runtime_invariant: str = "",
 ) -> AgentContext:
+    system_suffix = compose_system_instructions(
+        harness_instructions,
+        role_instructions,
+    )
+    if runtime_invariant:
+        system_suffix += (
+            f"\n# Live controller invariant\n\n{runtime_invariant.strip()}\n"
+        )
     return AgentContext(
         skills=list(project_skills),
-        system_message_suffix=compose_system_instructions(
-            harness_instructions,
-            role_instructions,
-        ),
+        system_message_suffix=system_suffix,
         current_datetime=None,
         load_public_skills=False,
         load_user_skills=True,
         load_project_skills=False,
+    )
+
+
+def live_controller_invariant(config: RunnerConfig) -> str:
+    """Return authoritative root-role state that compaction cannot rewrite."""
+
+    if config.child or config.role != "advisor":
+        return ""
+    return (
+        "The advisor campaign is active. This runtime has no configured campaign "
+        f"round limit. max_turns={config.max_turns} bounds one OpenHands turn; it "
+        'does not mark the research complete. A round label such as "FINAL ROUND" '
+        "or a condensed-history summary never authorizes stopping. Continue until "
+        "an explicit human instruction or controller shutdown ends the campaign."
     )
 
 
@@ -975,9 +993,7 @@ def model_runtime_configuration(
         configuration: dict[str, object] = {
             "api_mode": "chat",
             "base_url": WANDB_INFERENCE_BASE_URL,
-            "extra_headers": {
-                "OpenAI-Project": f"{wandb_entity}/{wandb_project}"
-            },
+            "extra_headers": {"OpenAI-Project": f"{wandb_entity}/{wandb_project}"},
             "capability_overrides": {
                 "supports_reasoning_effort": False,
                 "supports_responses_api": False,
@@ -1115,7 +1131,7 @@ def scrub_model_credentials(
 
 
 def build_main_tools(config: RunnerConfig) -> list[Tool]:
-    """Keep native reasoning tools while replacing unsafe control boundaries."""
+    """Build Senpai's role-safe root tool surface."""
 
     if config.github_token is None:
         raise RuntimeError("main agents require GitHub credentials")
@@ -1126,7 +1142,7 @@ def build_main_tools(config: RunnerConfig) -> list[Tool]:
             enable_browser=False,
             enable_sub_agents=False,
         )
-        if tool.name != "terminal"
+        if tool.name not in {"terminal", "think"}
     ]
     tools.extend(
         (
@@ -1157,13 +1173,90 @@ def build_main_tools(config: RunnerConfig) -> list[Tool]:
             "cancel_agents",
         )
     )
-    if config.role == "student" and not config.child:
-        training_params: dict[str, str | int] = {
+    if not config.child:
+        job_params: dict[str, str | int] = {
             "state_dir": str(config.state_dir / "training"),
             "max_timeout_seconds": config.training_max_timeout_seconds,
         }
-        tools.append(Tool(name="senpai_training", params=training_params))
+        tools.append(Tool(name="senpai_training", params=job_params))
     return tools
+
+
+def without_legacy_think(agent: Agent) -> Agent:
+    """Remove OpenHands' legacy scratchpad from the actual runtime surface."""
+
+    return agent.model_copy(
+        update={
+            "tools": [tool for tool in agent.tools if tool.name != "think"],
+            "include_default_tools": [
+                name for name in agent.include_default_tools if name != "ThinkTool"
+            ],
+        }
+    )
+
+
+def migrate_persisted_disabled_tools(
+    state_dir: Path,
+    conversation_id: uuid.UUID,
+) -> bool:
+    """Atomically remove only Think declarations from one saved agent spec."""
+
+    path = Path(state_dir) / conversation_id.hex / "base_state.json"
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return False
+    except (json.JSONDecodeError, OSError) as error:
+        raise RuntimeError(
+            f"cannot migrate persisted agent state at {path}: {error}"
+        ) from error
+    if not isinstance(payload, dict) or not isinstance(payload.get("agent"), dict):
+        raise TypeError(f"persisted agent state at {path} has an unknown shape")
+    saved_agent = payload["agent"]
+    tools = saved_agent.get("tools")
+    defaults = saved_agent.get("include_default_tools")
+    if not isinstance(tools, list) or not all(
+        isinstance(tool, dict) and isinstance(tool.get("name"), str) for tool in tools
+    ):
+        raise RuntimeError(f"persisted agent tools at {path} have an unknown shape")
+    if defaults is not None and (
+        not isinstance(defaults, list)
+        or not all(isinstance(name, str) for name in defaults)
+    ):
+        raise RuntimeError(f"persisted default tools at {path} have an unknown shape")
+
+    migrated_tools = [tool for tool in tools if tool["name"] != "think"]
+    migrated_defaults = [
+        name
+        for name in (defaults if defaults is not None else ["FinishTool", "ThinkTool"])
+        if name != "ThinkTool"
+    ]
+    if migrated_tools == tools and migrated_defaults == defaults:
+        return False
+    saved_agent["tools"] = migrated_tools
+    saved_agent["include_default_tools"] = migrated_defaults
+
+    mode = stat.S_IMODE(path.stat().st_mode)
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        descriptor = os.open(
+            temporary,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            mode,
+        )
+        with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+            json.dump(payload, output, separators=(",", ":"))
+            output.flush()
+            os.fsync(output.fileno())
+        os.replace(temporary, path)
+        directory = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    finally:
+        temporary.unlink(missing_ok=True)
+    return True
 
 
 def delegation_config(
@@ -1469,15 +1562,14 @@ def run_openhands(
                 definition,
                 work_dir=config.workspace,
             )(llm)
-            agent = agent.model_copy(
-                update={"llm": apply_reasoning_profile(agent.llm)}
-            )
+            agent = agent.model_copy(update={"llm": apply_reasoning_profile(agent.llm)})
             require_exact_tokenizer(agent.llm)
             agent = with_role_and_project_context(
                 agent,
                 harness_instructions,
                 role_instructions,
                 project_skills,
+                live_controller_invariant(config),
             )
             agent = with_tool_concurrency(agent, MAX_PARALLEL_AGENTS)
             agent = agent.model_copy(
@@ -1505,10 +1597,22 @@ def run_openhands(
                     harness_instructions,
                     role_instructions,
                     project_skills,
+                    live_controller_invariant(config),
                 ),
                 system_prompt_kwargs={"cli_mode": True},
                 condenser=condenser,
                 tool_concurrency_limit=MAX_PARALLEL_AGENTS,
+            )
+        agent = without_legacy_think(agent)
+        if migrate_persisted_disabled_tools(
+            config.state_dir,
+            config.conversation_id,
+        ):
+            print(
+                "OPENHANDS_STATE_MIGRATION removed_tool=think "
+                f"conversation_id={config.conversation_id}",
+                file=sys.stderr,
+                flush=True,
             )
         conversation = LocalConversation(
             agent=agent,
@@ -1639,7 +1743,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             config = resolve_config(args)
             os.environ.pop(config.api_key_env, None)
             return run_openhands(prompt, config)
-        except BaseException as error:  # noqa: BLE001
+        except BaseException as error:
             if task_id := os.environ.get("SENPAI_DELEGATION_TASK_ID"):
                 record_delegated_task_result(
                     task_id,

--- a/senpai_agent/secrets.py
+++ b/senpai_agent/secrets.py
@@ -12,6 +12,40 @@ GITHUB_CREDENTIAL_ENV_NAMES = (
     GITHUB_TOKEN_FILE_ENV,
     GITHUB_TOKEN_FD_ENV,
 )
+_SECRET_ENV_NAMES = frozenset(
+    {
+        *GITHUB_CREDENTIAL_ENV_NAMES,
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "SSH_AUTH_SOCK",
+        "API_KEY",
+        "CREDENTIAL",
+        "CREDENTIALS",
+        "PASSWORD",
+        "PRIVATE_KEY",
+        "SECRET",
+        "TOKEN",
+    }
+)
+_SECRET_ENV_SUFFIXES = (
+    "_ACCESS_KEY",
+    "_API_KEY",
+    "_CREDENTIAL",
+    "_CREDENTIALS",
+    "_PASSWORD",
+    "_PRIVATE_KEY",
+    "_SECRET",
+    "_TOKEN",
+)
+
+
+def is_secret_environment_variable(name: str) -> bool:
+    """Return whether an environment variable conventionally carries auth."""
+
+    normalized = name.upper()
+    return normalized in _SECRET_ENV_NAMES or normalized.endswith(_SECRET_ENV_SUFFIXES)
 
 
 def scrub_github_credentials(environment: MutableMapping[str, str]) -> None:

--- a/senpai_agent/state.py
+++ b/senpai_agent/state.py
@@ -185,7 +185,7 @@ class StudentConversationSelector:
         )
 
     def _conversation_for(self, event: ControllerEvent) -> UUID:
-        if event.kind in {"local_events_pending", "training_monitor"}:
+        if event.kind in {"local_events_pending", "job_monitor", "training_monitor"}:
             return UUID(str(event.payload["conversation_id"]))
         if event.kind in {"student_assignment", "student_pr_feedback"}:
             return self.registry.for_assignment(

--- a/senpai_agent/tools.py
+++ b/senpai_agent/tools.py
@@ -19,12 +19,12 @@ from openhands.sdk.tool import (
     register_tool,
 )
 from openhands.tools.browser_use import BrowserToolSet
+from openhands.tools.task_tracker import TaskTrackerTool
 from openhands.tools.terminal import (
     TerminalAction,
     TerminalObservation,
     TerminalTool,
 )
-from openhands.tools.task_tracker import TaskTrackerTool
 from pydantic import Field, model_validator
 
 from senpai_agent.delegation import (
@@ -33,9 +33,11 @@ from senpai_agent.delegation import (
     CancelAgentsTool,
     SpawnAgentsTool,
 )
-from senpai_agent.git_workflow import require_clean_training_worktree
+from senpai_agent.git_workflow import require_clean_job_worktree
 from senpai_agent.github.tools import GitHubWorkflowToolSet
+from senpai_agent.hooks import supervised_job_policy
 from senpai_agent.monitor import MetricGate, MonitorStore, TrainingMonitorSpec
+from senpai_agent.secrets import is_secret_environment_variable
 from senpai_agent.training import (
     TrainingResult,
     TrainingSpec,
@@ -52,6 +54,7 @@ _TRAINING_RUNTIMES: dict[
     tuple[TrainingSupervisor, MonitorStore],
 ] = {}
 _BROWSER_ENABLED_STATE_KEY = "senpai.browser_enabled"
+_JOB_CONTROL_RESOURCE = "senpai-job-control"
 
 
 class LoadBrowserAction(Action):
@@ -65,21 +68,15 @@ class LoadBrowserObservation(Observation):
     def to_llm_content(self) -> Sequence[TextContent]:
         return [
             TextContent(
-                text=(
-                    "Browser tools are now available: "
-                    + ", ".join(self.tools)
-                    + "."
-                )
+                text=("Browser tools are now available: " + ", ".join(self.tools) + ".")
             )
         ]
 
 
-class _LoadBrowserExecutor(
-    ToolExecutor[LoadBrowserAction, LoadBrowserObservation]
-):
+class _LoadBrowserExecutor(ToolExecutor[LoadBrowserAction, LoadBrowserObservation]):
     def __call__(
         self,
-        action: LoadBrowserAction,  # noqa: ARG002
+        action: LoadBrowserAction,
         conversation: LocalConversation | None = None,
     ) -> LoadBrowserObservation:
         if conversation is None:
@@ -104,7 +101,7 @@ class _LoadBrowserExecutor(
 class LoadBrowserTool(ToolDefinition[LoadBrowserAction, LoadBrowserObservation]):
     name = "load_browser"
 
-    def declared_resources(self, action: Action) -> DeclaredResources:  # noqa: ARG002
+    def declared_resources(self, action: Action) -> DeclaredResources:
         return DeclaredResources(keys=("browser-tools",), declared=True)
 
     @classmethod
@@ -135,13 +132,14 @@ class LoadBrowserTool(ToolDefinition[LoadBrowserAction, LoadBrowserObservation])
         ]
 
 
-_TASK_TRACKER_DESCRIPTION = """Maintain an optional persisted task list for complex work.
+_TASK_TRACKER_DESCRIPTION = """Maintain an optional persisted task list as working memory across turns.
 
-Use it when a task has several meaningful steps or concurrent workstreams and a
-compact todo/in-progress/done record will prevent omissions. Multiple items may
-be in progress when the work is genuinely parallel. Skip it for short, atomic,
-or purely informational work. View the current list before replacing it, keep
-entries concise, and mark work done only when its required evidence is complete."""
+Use it when persistent coordination materially helps: multi-step work,
+concurrent workstreams, delegated agents, or long-running jobs. For straightforward
+work, proceed directly. Track independent work in parallel, with multiple items
+in progress when they are genuinely active. View the current list before
+replacing it, keep entries concise, and mark work done only when its required
+evidence is complete."""
 
 
 class SenpaiTaskTrackerTool(TaskTrackerTool):
@@ -186,6 +184,8 @@ def close_training_runtimes() -> None:
 
 
 class RunTrainingAction(Action):
+    """Persisted action type from the former model-visible tool surface."""
+
     spec: TrainingSpec = Field(
         description=(
             "Structured process argv, assignment-workspace directory, and hard "
@@ -195,6 +195,8 @@ class RunTrainingAction(Action):
 
 
 class GetTrainingStatusAction(Action):
+    """Persisted action type from the former model-visible tool surface."""
+
     training_id: str = Field(
         min_length=1,
         description="Training ID returned by run_training.",
@@ -202,6 +204,8 @@ class GetTrainingStatusAction(Action):
 
 
 class CancelTrainingAction(Action):
+    """Persisted action type from the former model-visible tool surface."""
+
     training_id: str = Field(
         min_length=1,
         description="Running training ID returned by run_training.",
@@ -209,6 +213,8 @@ class CancelTrainingAction(Action):
 
 
 class MonitorTrainingAction(Action):
+    """Persisted action type from the former model-visible tool surface."""
+
     training_id: str = Field(
         min_length=1,
         description="Training ID returned by run_training.",
@@ -230,12 +236,14 @@ class MonitorTrainingAction(Action):
     )
     poll_interval_seconds: float = Field(
         default=60,
-        gt=0,
+        ge=5,
+        allow_inf_nan=False,
         description="Seconds between programmatic monitor polls.",
     )
     stale_after_seconds: float = Field(
         default=600,
         gt=0,
+        allow_inf_nan=False,
         description="Notify when the selected metric has not updated this long.",
     )
 
@@ -245,11 +253,15 @@ class MonitorTrainingAction(Action):
         """Resume conversations written before terminal wakes became mandatory."""
 
         if isinstance(value, dict) and "notify_on_status" in value:
-            return {key: item for key, item in value.items() if key != "notify_on_status"}
+            return {
+                key: item for key, item in value.items() if key != "notify_on_status"
+            }
         return value
 
 
 class MonitorTrainingObservation(Observation):
+    """Persisted observation type from the former model-visible tool surface."""
+
     training_id: str
     conversation_id: str
     status: Literal["monitoring"] = "monitoring"
@@ -268,6 +280,8 @@ class MonitorTrainingObservation(Observation):
 
 
 class TrainingResultObservation(Observation):
+    """Persisted observation type from the former model-visible tool surface."""
+
     training_id: str
     state: TrainingState
     pid: int | None = None
@@ -281,7 +295,9 @@ class TrainingResultObservation(Observation):
 
     @classmethod
     def from_result(cls, result: TrainingResult) -> Self:
-        return cls.model_validate(result.model_dump())
+        values = result.model_dump()
+        values.pop("workspace_access", None)
+        return cls.model_validate(values)
 
     @property
     def to_llm_content(self) -> Sequence[TextContent]:
@@ -300,199 +316,430 @@ class TrainingResultObservation(Observation):
         return [TextContent(text=text)]
 
 
-class _RunTrainingExecutor(ToolExecutor[RunTrainingAction, TrainingResultObservation]):
-    def __init__(self, training: TrainingSupervisor, monitor_store: MonitorStore):
-        self.training = training
+class JobSpec(TrainingSpec):
+    """One argv-based process supervised as a durable Senpai job."""
+
+    argv: tuple[str, ...] = Field(
+        min_length=1,
+        description="Executable and arguments. Shell command strings are not allowed.",
+    )
+    cwd: Path = Field(description="Working directory inside the role workspace.")
+    timeout_seconds: int = Field(
+        gt=0,
+        description="Hard wall-clock deadline, including process-group shutdown.",
+    )
+    workspace_access: Literal["read_only", "mutable"] = Field(
+        default="mutable",
+        description=(
+            "Use mutable for builds, training, evaluation, or any process that may "
+            "write in the checkout. Use read_only only for passive watchers that "
+            "do not modify workspace files."
+        ),
+    )
+    secret_env: tuple[Literal["WANDB_API_KEY"], ...] = Field(
+        default=(),
+        description=(
+            "Registered credentials this process needs. Request WANDB_API_KEY "
+            "only for a process that communicates with W&B."
+        ),
+    )
+
+
+class RunJobAction(Action):
+    spec: JobSpec = Field(
+        description=(
+            "Structured argv, workspace directory, and hard timeout for one "
+            "long-running process."
+        )
+    )
+
+
+class GetJobStatusAction(Action):
+    job_id: str = Field(min_length=1, description="Job ID returned by run_job.")
+
+
+class CancelJobAction(Action):
+    job_id: str = Field(
+        min_length=1,
+        description="Running job ID returned by run_job.",
+    )
+
+
+class MonitorJobAction(Action):
+    job_id: str = Field(min_length=1, description="Job ID returned by run_job.")
+    wandb_metric: str | None = Field(
+        default=None,
+        description=(
+            "Optional W&B metric to monitor. Omit to keep terminal-state "
+            "monitoring only."
+        ),
+    )
+    direction: Literal["min", "max"] | None = Field(
+        default=None,
+        description="Whether lower or higher W&B metric values are better.",
+    )
+    gates: tuple[MetricGate, ...] = Field(
+        default=(),
+        description=(
+            "W&B metric thresholds or changes that should resume this "
+            "conversation. Ordinary polls do not consume model tokens."
+        ),
+    )
+    poll_interval_seconds: float = Field(
+        default=60,
+        ge=5,
+        allow_inf_nan=False,
+        description="Seconds between programmatic monitor polls.",
+    )
+    stale_after_seconds: float = Field(
+        default=600,
+        gt=0,
+        allow_inf_nan=False,
+        description="Notify when the selected W&B metric has not updated this long.",
+    )
+
+
+class MonitorJobObservation(Observation):
+    job_id: str
+    conversation_id: str
+    status: Literal["monitoring"] = "monitoring"
+
+    @property
+    def to_llm_content(self) -> Sequence[TextContent]:
+        return [
+            TextContent(
+                text=(
+                    f"Job {self.job_id} is durably monitored. You may finish "
+                    "this turn; the controller will resume this same "
+                    f"conversation ({self.conversation_id}) when action is needed."
+                )
+            )
+        ]
+
+
+class JobResultObservation(Observation):
+    job_id: str
+    state: TrainingState
+    pid: int | None = None
+    process_group_id: int | None = None
+    process_start_time: float | None = None
+    exit_code: int | None = None
+    elapsed_seconds: float
+    log_path: str
+    wandb_run_ids: tuple[str, ...] = ()
+    error_tail: str = ""
+
+    @classmethod
+    def from_result(
+        cls,
+        result: TrainingResult,
+        *,
+        mask: object | None = None,
+    ) -> Self:
+        values = result.model_dump()
+        values["job_id"] = values.pop("training_id")
+        # workspace_access is supervisor metadata rather than model output.
+        values.pop("workspace_access", None)
+        if callable(mask):
+            values["error_tail"] = mask(values["error_tail"])
+        return cls.model_validate(values)
+
+    @property
+    def to_llm_content(self) -> Sequence[TextContent]:
+        result = {
+            "job_id": self.job_id,
+            "state": self.state,
+            "pid": self.pid,
+            "exit_code": self.exit_code,
+            "elapsed_seconds": round(self.elapsed_seconds, 3),
+            "log_path": self.log_path,
+            "wandb_run_ids": self.wandb_run_ids,
+        }
+        if self.error_tail:
+            result["error_tail"] = self.error_tail
+        return [
+            TextContent(text=json.dumps(result, separators=(",", ":"), default=str))
+        ]
+
+
+class _RunJobExecutor(ToolExecutor[RunJobAction, JobResultObservation]):
+    def __init__(
+        self,
+        supervisor: TrainingSupervisor,
+        monitor_store: MonitorStore,
+        *,
+        role: str,
+    ):
+        self.supervisor = supervisor
         self.monitor_store = monitor_store
+        self.role = role
 
     def __call__(
         self,
-        action: RunTrainingAction,
+        action: RunJobAction,
         conversation: LocalConversation | None = None,
-    ) -> TrainingResultObservation:
+    ) -> JobResultObservation:
         if conversation is None:
-            raise ValueError("run_training requires its student conversation")
-        require_clean_training_worktree(self.training.workspace)
-        result = self.training.run_training(action.spec)
-        self.monitor_store.register(
-            TrainingMonitorSpec(
-                training_id=result.training_id,
-                conversation_id=conversation.id,
-            )
+            raise ValueError("run_job requires its parent conversation")
+        decision = supervised_job_policy(
+            action.spec.argv,
+            self.role,
+            self.supervisor.workspace,
         )
-        return TrainingResultObservation.from_result(result)
+        if not decision.allowed:
+            raise PermissionError(decision.reason)
+        if self.role == "student" and action.spec.workspace_access == "mutable":
+            require_clean_job_worktree(self.supervisor.workspace)
+
+        environment, redacted_values = _job_environment(
+            conversation,
+            action.spec.secret_env,
+        )
+        result = self.supervisor.run_training(
+            action.spec,
+            env=environment,
+            redacted_values=redacted_values,
+        )
+        try:
+            self.monitor_store.register(
+                TrainingMonitorSpec(
+                    training_id=result.training_id,
+                    conversation_id=conversation.id,
+                )
+            )
+        except BaseException as registration_error:
+            try:
+                self.supervisor.cancel_training(result.training_id)
+            except BaseException as cleanup_error:  # noqa: BLE001
+                registration_error.add_note(
+                    "job cancellation during monitor-registration rollback failed: "
+                    f"{type(cleanup_error).__name__}"
+                )
+            try:
+                self.monitor_store.complete(result.training_id)
+            except BaseException as cleanup_error:  # noqa: BLE001
+                registration_error.add_note(
+                    "monitor retirement during registration rollback failed: "
+                    f"{type(cleanup_error).__name__}"
+                )
+            raise
+        return _job_observation(result, conversation)
 
     def close(self) -> None:
         return
 
     def interrupt(self) -> None:
-        self.training.close()
+        # The supervisor is shared by every job. Controller shutdown owns
+        # global cancellation; a single interrupted call owns no process.
+        return
 
 
-class _GetTrainingStatusExecutor(
-    ToolExecutor[GetTrainingStatusAction, TrainingResultObservation]
-):
-    def __init__(self, training: TrainingSupervisor):
-        self.training = training
-
-    def __call__(
-        self,
-        action: GetTrainingStatusAction,
-        conversation: LocalConversation | None = None,
-    ) -> TrainingResultObservation:
-        return TrainingResultObservation.from_result(
-            self.training.get_training_status(action.training_id)
-        )
-
-
-class _CancelTrainingExecutor(
-    ToolExecutor[CancelTrainingAction, TrainingResultObservation]
-):
-    def __init__(self, training: TrainingSupervisor, store: MonitorStore):
-        self.training = training
+class _GetJobStatusExecutor(ToolExecutor[GetJobStatusAction, JobResultObservation]):
+    def __init__(self, supervisor: TrainingSupervisor, store: MonitorStore):
+        self.supervisor = supervisor
         self.store = store
 
     def __call__(
         self,
-        action: CancelTrainingAction,
+        action: GetJobStatusAction,
         conversation: LocalConversation | None = None,
-    ) -> TrainingResultObservation:
-        if conversation is None:
-            raise ValueError("cancel_training requires its student conversation")
-        monitor = self.store.spec(action.training_id)
-        if monitor.conversation_id != conversation.id:
-            raise PermissionError(
-                "training belongs to a different student conversation"
-            )
-        result = self.training.cancel_training(action.training_id)
+    ) -> JobResultObservation:
+        _require_owned_job(self.store, action.job_id, conversation, "get_job_status")
+        return _job_observation(
+            self.supervisor.get_training_status(action.job_id),
+            conversation,
+        )
+
+
+class _CancelJobExecutor(ToolExecutor[CancelJobAction, JobResultObservation]):
+    def __init__(self, supervisor: TrainingSupervisor, store: MonitorStore):
+        self.supervisor = supervisor
+        self.store = store
+
+    def __call__(
+        self,
+        action: CancelJobAction,
+        conversation: LocalConversation | None = None,
+    ) -> JobResultObservation:
+        _require_owned_job(self.store, action.job_id, conversation, "cancel_job")
+        result = self.supervisor.cancel_training(action.job_id)
         if result.state is TrainingState.RUNNING:
             raise RuntimeError(
-                "cancel_training did not reach a terminal state; "
-                "the training monitor remains active"
+                "cancel_job did not reach a terminal state; "
+                "the job monitor remains active"
             )
-        self.store.complete(action.training_id)
-        return TrainingResultObservation.from_result(result)
+        self.store.complete(action.job_id)
+        return _job_observation(result, conversation)
 
 
-class RunTrainingTool(ToolDefinition[RunTrainingAction, TrainingResultObservation]):
+def _require_owned_job(
+    store: MonitorStore,
+    job_id: str,
+    conversation: LocalConversation | None,
+    tool_name: str,
+) -> None:
+    if conversation is None:
+        raise ValueError(f"{tool_name} requires its parent conversation")
+    if store.spec(job_id).conversation_id != conversation.id:
+        raise PermissionError("job belongs to a different conversation")
+
+
+def _job_environment(
+    conversation: LocalConversation,
+    secret_names: Sequence[str],
+) -> tuple[dict[str, str], tuple[str, ...]]:
+    """Build a scrubbed child environment and resolve only requested W&B auth."""
+
+    environment = {
+        name: value
+        for name, value in os.environ.items()
+        if not is_secret_environment_variable(name)
+    }
+
+    registry = getattr(getattr(conversation, "state", None), "secret_registry", None)
+    redacted_values: list[str] = []
+    for name in secret_names:
+        value = registry.get_secret_value(name) if registry is not None else None
+        if not value:
+            raise RuntimeError(f"requested job credential {name} is unavailable")
+        environment[name] = value
+        redacted_values.append(value)
+    return environment, tuple(redacted_values)
+
+
+def _job_observation(
+    result: TrainingResult,
+    conversation: LocalConversation | None,
+) -> JobResultObservation:
+    registry = getattr(getattr(conversation, "state", None), "secret_registry", None)
+    mask = registry.mask_secrets_in_output if registry is not None else None
+    return JobResultObservation.from_result(result, mask=mask)
+
+
+class RunJobTool(ToolDefinition[RunJobAction, JobResultObservation]):
+    def declared_resources(self, action: Action) -> DeclaredResources:
+        return DeclaredResources(keys=(_JOB_CONTROL_RESOURCE,), declared=True)
+
     @classmethod
     def create(
         cls,
-        training: TrainingSupervisor,
+        supervisor: TrainingSupervisor,
+        monitor_store: MonitorStore,
+        role: str = "advisor",
+    ) -> Sequence[Self]:
+        return [
+            cls(
+                description=(
+                    "Start one supervised long-running process without blocking. "
+                    "Use this for training, inference, evaluation, builds, or other "
+                    "bounded jobs. Terminal-state monitoring is automatic; use "
+                    "monitor_job only to set optional W&B metric policy, and "
+                    "get_job_status for one immediate snapshot."
+                ),
+                action_type=RunJobAction,
+                observation_type=JobResultObservation,
+                annotations=ToolAnnotations(
+                    title="Run job",
+                    readOnlyHint=False,
+                    destructiveHint=False,
+                    idempotentHint=False,
+                    openWorldHint=True,
+                ),
+                executor=_RunJobExecutor(
+                    supervisor,
+                    monitor_store,
+                    role=role,
+                ),
+            )
+        ]
+
+
+class GetJobStatusTool(ToolDefinition[GetJobStatusAction, JobResultObservation]):
+    def declared_resources(self, action: Action) -> DeclaredResources:
+        return DeclaredResources(keys=(_JOB_CONTROL_RESOURCE,), declared=True)
+
+    @classmethod
+    def create(
+        cls,
+        supervisor: TrainingSupervisor,
         monitor_store: MonitorStore,
     ) -> Sequence[Self]:
         return [
             cls(
                 description=(
-                    "Start one supervised training process without blocking and "
-                    "automatically monitor its terminal state for this conversation. "
-                    "Use monitor_training only to add metric gates or staleness "
-                    "policy; use get_training_status for a bounded immediate check."
+                    "Read one immediate persisted snapshot for a supervised job."
                 ),
-                action_type=RunTrainingAction,
-                observation_type=TrainingResultObservation,
+                action_type=GetJobStatusAction,
+                observation_type=JobResultObservation,
                 annotations=ToolAnnotations(
-                    title="Run training",
-                    readOnlyHint=False,
-                    destructiveHint=False,
-                    idempotentHint=False,
-                    openWorldHint=False,
-                ),
-                executor=_RunTrainingExecutor(training, monitor_store),
-            )
-        ]
-
-
-class GetTrainingStatusTool(
-    ToolDefinition[GetTrainingStatusAction, TrainingResultObservation]
-):
-    @classmethod
-    def create(
-        cls,
-        training: TrainingSupervisor,
-    ) -> Sequence[Self]:
-        return [
-            cls(
-                description=(
-                    "Read the latest persisted result for one supervised training ID."
-                ),
-                action_type=GetTrainingStatusAction,
-                observation_type=TrainingResultObservation,
-                annotations=ToolAnnotations(
-                    title="Get training status",
+                    title="Get job status",
                     readOnlyHint=True,
                     destructiveHint=False,
                     idempotentHint=True,
                     openWorldHint=False,
                 ),
-                executor=_GetTrainingStatusExecutor(training),
+                executor=_GetJobStatusExecutor(supervisor, monitor_store),
             )
         ]
 
 
-class CancelTrainingTool(
-    ToolDefinition[CancelTrainingAction, TrainingResultObservation]
-):
+class CancelJobTool(ToolDefinition[CancelJobAction, JobResultObservation]):
+    def declared_resources(self, action: Action) -> DeclaredResources:
+        return DeclaredResources(keys=(_JOB_CONTROL_RESOURCE,), declared=True)
+
     @classmethod
     def create(
         cls,
-        training: TrainingSupervisor,
+        supervisor: TrainingSupervisor,
         monitor_store: MonitorStore,
     ) -> Sequence[Self]:
         return [
             cls(
                 description=(
-                    "Cancel one supervised training process, wait for its durable "
+                    "Cancel one supervised job, wait for its durable "
                     "terminal state, and retire its monitor. Use this after a stop "
                     "condition or hard monitor signal instead of killing processes "
                     "through the terminal."
                 ),
-                action_type=CancelTrainingAction,
-                observation_type=TrainingResultObservation,
+                action_type=CancelJobAction,
+                observation_type=JobResultObservation,
                 annotations=ToolAnnotations(
-                    title="Cancel training",
+                    title="Cancel job",
                     readOnlyHint=False,
                     destructiveHint=True,
                     idempotentHint=True,
                     openWorldHint=False,
                 ),
-                executor=_CancelTrainingExecutor(training, monitor_store),
+                executor=_CancelJobExecutor(supervisor, monitor_store),
             )
         ]
 
 
-class _MonitorTrainingExecutor(
-    ToolExecutor[MonitorTrainingAction, MonitorTrainingObservation]
-):
-    def __init__(self, training: TrainingSupervisor, store: MonitorStore):
-        self.training = training
+class _MonitorJobExecutor(ToolExecutor[MonitorJobAction, MonitorJobObservation]):
+    def __init__(self, supervisor: TrainingSupervisor, store: MonitorStore):
+        self.supervisor = supervisor
         self.store = store
 
     def __call__(
         self,
-        action: MonitorTrainingAction,
+        action: MonitorJobAction,
         conversation: LocalConversation | None = None,
-    ) -> MonitorTrainingObservation:
-        if conversation is None:
-            raise ValueError("monitor_training requires its student conversation")
-        self.training.get_training_status(action.training_id)
-        monitor = self.store.spec(action.training_id)
-        if monitor.conversation_id != conversation.id:
-            raise PermissionError(
-                "training belongs to a different student conversation"
-            )
+    ) -> MonitorJobObservation:
+        _require_owned_job(self.store, action.job_id, conversation, "monitor_job")
+        self.supervisor.get_training_status(action.job_id)
+        assert conversation is not None
         spec = TrainingMonitorSpec(
-            training_id=action.training_id,
+            training_id=action.job_id,
             conversation_id=conversation.id,
-            metric=action.metric,
+            metric=action.wandb_metric,
             direction=action.direction,
             gates=action.gates,
             poll_interval_seconds=action.poll_interval_seconds,
             stale_after_seconds=action.stale_after_seconds,
         )
         self.store.register(spec)
-        return MonitorTrainingObservation(
-            training_id=spec.training_id,
+        return MonitorJobObservation(
+            job_id=spec.training_id,
             conversation_id=str(spec.conversation_id),
         )
 
@@ -500,40 +747,41 @@ class _MonitorTrainingExecutor(
         return
 
 
-class MonitorTrainingTool(
-    ToolDefinition[MonitorTrainingAction, MonitorTrainingObservation]
-):
+class MonitorJobTool(ToolDefinition[MonitorJobAction, MonitorJobObservation]):
+    def declared_resources(self, action: Action) -> DeclaredResources:
+        return DeclaredResources(keys=(_JOB_CONTROL_RESOURCE,), declared=True)
+
     @classmethod
     def create(
         cls,
-        training: TrainingSupervisor,
+        supervisor: TrainingSupervisor,
         monitor_store: MonitorStore,
     ) -> Sequence[Self]:
         return [
             cls(
                 description=(
-                    "Upgrade one training process's automatic terminal monitor "
-                    "without model polling. Specify an optional W&B metric, "
-                    "direction, threshold/change gates, and stale timeout. Senpai "
-                    "resumes this same student conversation when the policy emits "
-                    "a signal."
+                    "Set or replace the monitoring policy for an already-running "
+                    "job. run_job automatically registers terminal-state monitoring; "
+                    "this tool adds or replaces optional W&B metric gates and "
+                    "staleness policy without disabling terminal wakes. Programmatic "
+                    "polls use no model turns."
                 ),
-                action_type=MonitorTrainingAction,
-                observation_type=MonitorTrainingObservation,
+                action_type=MonitorJobAction,
+                observation_type=MonitorJobObservation,
                 annotations=ToolAnnotations(
-                    title="Monitor training",
+                    title="Monitor job",
                     readOnlyHint=False,
                     destructiveHint=False,
                     idempotentHint=True,
-                    openWorldHint=False,
+                    openWorldHint=True,
                 ),
-                executor=_MonitorTrainingExecutor(training, monitor_store),
+                executor=_MonitorJobExecutor(supervisor, monitor_store),
             )
         ]
 
 
-class TrainingToolSet(ToolDefinition[RunTrainingAction, TrainingResultObservation]):
-    """Create the training tools around one process supervisor."""
+class JobToolSet(ToolDefinition[RunJobAction, JobResultObservation]):
+    """Create generic job tools around one process supervisor."""
 
     @classmethod
     def create(
@@ -542,24 +790,32 @@ class TrainingToolSet(ToolDefinition[RunTrainingAction, TrainingResultObservatio
         *,
         state_dir: str | Path,
         max_timeout_seconds: int | None = None,
+        role: str | None = None,
     ) -> Sequence[ToolDefinition]:
-        training, monitor_store = training_runtime(
+        role = role or os.environ.get("SENPAI_ROLE")
+        if role not in {"advisor", "student"}:
+            raise ValueError("role must be advisor or student")
+        supervisor, monitor_store = training_runtime(
             Path(conv_state.workspace.working_dir),
             Path(state_dir),
             max_timeout_seconds=max_timeout_seconds,
         )
         return (
-            *RunTrainingTool.create(
-                training=training,
+            *RunJobTool.create(
+                supervisor=supervisor,
+                monitor_store=monitor_store,
+                role=role,
+            ),
+            *GetJobStatusTool.create(
+                supervisor=supervisor,
                 monitor_store=monitor_store,
             ),
-            *GetTrainingStatusTool.create(training=training),
-            *CancelTrainingTool.create(
-                training=training,
+            *CancelJobTool.create(
+                supervisor=supervisor,
                 monitor_store=monitor_store,
             ),
-            *MonitorTrainingTool.create(
-                training=training,
+            *MonitorJobTool.create(
+                supervisor=supervisor,
                 monitor_store=monitor_store,
             ),
         )
@@ -689,7 +945,10 @@ def register_senpai_tools() -> None:
     global _TOOLS_REGISTERED
     if _TOOLS_REGISTERED:
         return
-    register_tool("senpai_training", TrainingToolSet)
+    # Keep the persisted factory identifier stable so existing OpenHands
+    # conversations can verify their saved agent specification. The concrete
+    # model-visible tools returned by this factory are job-oriented.
+    register_tool("senpai_training", JobToolSet)
     register_tool("senpai_github", GitHubWorkflowToolSet)
     register_tool("spawn_agents", SpawnAgentsTool)
     register_tool("await_agents", AwaitAgentsTool)

--- a/senpai_agent/training.py
+++ b/senpai_agent/training.py
@@ -2,13 +2,15 @@ import os
 import re
 import signal
 import subprocess
+import sys
 import threading
 import time
 import uuid
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
+from typing import Literal
 
 import psutil
 from pydantic import BaseModel, ConfigDict, Field
@@ -41,6 +43,7 @@ class TrainingSpec(BaseModel):
     argv: tuple[str, ...] = Field(min_length=1)
     cwd: Path
     timeout_seconds: int = Field(gt=0)
+    workspace_access: Literal["read_only", "mutable"] = "mutable"
 
 
 class TrainingResult(BaseModel):
@@ -56,6 +59,7 @@ class TrainingResult(BaseModel):
     log_path: str
     wandb_run_ids: tuple[str, ...] = ()
     error_tail: str = ""
+    workspace_access: Literal["read_only", "mutable"] = "mutable"
 
 
 def training_result_paths(state_dir: Path) -> Iterator[Path]:
@@ -78,6 +82,8 @@ class _ActiveTraining:
     started: float
     timeout_seconds: int
     log_path: Path
+    redacted_values: tuple[bytes, ...] = ()
+    workspace_access: Literal["read_only", "mutable"] = "mutable"
     cancelled: bool = False
     thread: threading.Thread | None = None
 
@@ -125,7 +131,13 @@ class TrainingSupervisor:
                 )
                 self._write_result(recovered)
 
-    def run_training(self, spec: TrainingSpec) -> TrainingResult:
+    def run_training(
+        self,
+        spec: TrainingSpec,
+        *,
+        env: Mapping[str, str] | None = None,
+        redacted_values: Sequence[str] = (),
+    ) -> TrainingResult:
         if isinstance(spec.argv, str) or not spec.argv:
             raise ValueError("argv must be a non-empty sequence, not a shell string")
         if (
@@ -144,47 +156,108 @@ class TrainingSupervisor:
         training_id = str(uuid.uuid4())
         log_path = self.state_dir / f"{training_id}.log"
         started = time.monotonic()
-        with log_path.open("wb") as log:
-            process = subprocess.Popen(
-                list(spec.argv),
-                cwd=cwd,
-                stdout=log,
-                stderr=subprocess.STDOUT,
-                shell=False,
-                start_new_session=True,
-            )
-        process_start_time = psutil.Process(process.pid).create_time()
-        process_group_id = process.pid
-
-        result = TrainingResult(
-            training_id=training_id,
-            state=TrainingState.RUNNING,
-            pid=process.pid,
-            process_group_id=process_group_id,
-            process_start_time=process_start_time,
-            exit_code=None,
-            elapsed_seconds=0,
-            log_path=str(log_path),
-        )
-        self._write_result(result)
-        active = _ActiveTraining(
-            process=process,
-            process_group_id=process_group_id,
-            process_start_time=process_start_time,
-            started=started,
-            timeout_seconds=spec.timeout_seconds,
-            log_path=log_path,
-        )
-        thread = threading.Thread(
-            target=self._monitor,
-            args=(training_id,),
-            name=f"senpai-training-{training_id}",
-        )
-        active.thread = thread
+        process: subprocess.Popen[bytes] | None = None
+        result_written = False
+        active_registered = False
         with self._lock:
-            self._active[training_id] = active
-            thread.start()
+            if spec.workspace_access == "mutable":
+                active_mutable = self._active_mutable_job_ids_locked()
+                if active_mutable:
+                    raise RuntimeError(
+                        "a mutable workspace job is already running: "
+                        + ", ".join(active_mutable)
+                    )
+            try:
+                log_descriptor = os.open(
+                    log_path,
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                    0o600,
+                )
+                with os.fdopen(log_descriptor, "wb") as log:
+                    process = subprocess.Popen(
+                        list(spec.argv),
+                        cwd=cwd,
+                        env=dict(env) if env is not None else None,
+                        stdin=subprocess.DEVNULL,
+                        stdout=log,
+                        stderr=subprocess.STDOUT,
+                        shell=False,
+                        start_new_session=True,
+                    )
+                process_start_time = psutil.Process(process.pid).create_time()
+                process_group_id = process.pid
+                result = TrainingResult(
+                    training_id=training_id,
+                    state=TrainingState.RUNNING,
+                    pid=process.pid,
+                    process_group_id=process_group_id,
+                    process_start_time=process_start_time,
+                    exit_code=None,
+                    elapsed_seconds=0,
+                    log_path=str(log_path),
+                    workspace_access=spec.workspace_access,
+                )
+                self._write_result(result)
+                result_written = True
+                active = _ActiveTraining(
+                    process=process,
+                    process_group_id=process_group_id,
+                    process_start_time=process_start_time,
+                    started=started,
+                    timeout_seconds=spec.timeout_seconds,
+                    log_path=log_path,
+                    redacted_values=tuple(
+                        value.encode() for value in redacted_values if value
+                    ),
+                    workspace_access=spec.workspace_access,
+                )
+                thread = threading.Thread(
+                    target=self._monitor,
+                    args=(training_id,),
+                    name=f"senpai-training-{training_id}",
+                )
+                active.thread = thread
+                self._active[training_id] = active
+                active_registered = True
+                thread.start()
+            except BaseException as error:
+                if active_registered:
+                    self._active.pop(training_id, None)
+                if process is not None and process.poll() is None:
+                    self._terminate_process_group(
+                        process,
+                        process.pid,
+                        grace_seconds=self.terminate_grace_seconds,
+                    )
+                if result_written:
+                    self._write_result(
+                        result.model_copy(
+                            update={
+                                "state": TrainingState.CANCELLED,
+                                "exit_code": process.returncode if process else None,
+                                "elapsed_seconds": time.monotonic() - started,
+                                "error_tail": (
+                                    "Job launch rolled back after "
+                                    f"{type(error).__name__}."
+                                ),
+                            }
+                        )
+                    )
+                raise
         return result
+
+    def active_mutable_job_ids(self) -> tuple[str, ...]:
+        """Return durable workspace leases held by mutable running jobs."""
+
+        with self._lock:
+            return self._active_mutable_job_ids_locked()
+
+    def _active_mutable_job_ids_locked(self) -> tuple[str, ...]:
+        return tuple(
+            training_id
+            for training_id, active in self._active.items()
+            if active.workspace_access == "mutable"
+        )
 
     def get_training_status(self, training_id: str) -> TrainingResult:
         path = self.state_dir / f"{uuid.UUID(training_id)}.json"
@@ -218,10 +291,74 @@ class TrainingSupervisor:
     def _monitor(self, training_id: str) -> None:
         with self._lock:
             active = self._active[training_id]
+        try:
+            self._monitor_process(training_id, active)
+        except BaseException as error:  # noqa: BLE001
+            try:
+                if active.process.poll() is None:
+                    self._terminate_process_group(
+                        active.process,
+                        active.process_group_id,
+                    )
+            except BaseException as terminate_error:  # noqa: BLE001
+                try:
+                    signal_process_group(active.process_group_id, signal.SIGKILL)
+                except BaseException as kill_error:  # noqa: BLE001
+                    print(
+                        "SENPAI_JOB_CLEANUP_ERROR "
+                        f"job_id={training_id} "
+                        f"terminate_error={type(terminate_error).__name__} "
+                        f"kill_error={type(kill_error).__name__}",
+                        file=sys.stderr,
+                        flush=True,
+                    )
+            try:
+                self._write_result(
+                    TrainingResult(
+                        training_id=training_id,
+                        state=TrainingState.FAILED,
+                        pid=active.process.pid,
+                        process_group_id=active.process_group_id,
+                        process_start_time=active.process_start_time,
+                        exit_code=active.process.poll(),
+                        elapsed_seconds=time.monotonic() - active.started,
+                        log_path=str(active.log_path),
+                        error_tail=(
+                            "Job supervisor failed internally "
+                            f"({type(error).__name__})."
+                        ),
+                        workspace_access=active.workspace_access,
+                    )
+                )
+            except BaseException as persistence_error:  # noqa: BLE001
+                print(
+                    "SENPAI_JOB_STATE_WRITE_ERROR "
+                    f"job_id={training_id} "
+                    f"error={type(persistence_error).__name__}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+        finally:
+            with self._lock:
+                self._active.pop(training_id, None)
+
+    def _monitor_process(
+        self,
+        training_id: str,
+        active: _ActiveTraining,
+    ) -> None:
         run_ids: dict[str, None] = {}
         published_run_ids: tuple[str, ...] = ()
         error_tail = b""
         scan_overlap = b""
+        tail_bytes = (
+            _ERROR_TAIL_BYTES
+            + max(
+                (len(value) for value in active.redacted_values),
+                default=1,
+            )
+            - 1
+        )
         deadline = active.started + active.timeout_seconds
         terminate_at = max(
             active.started,
@@ -241,6 +378,7 @@ class TrainingSupervisor:
                     error_tail,
                     scan_overlap,
                     run_ids,
+                    tail_bytes=tail_bytes,
                 )
                 discovered_run_ids = tuple(run_ids)
                 if discovered_run_ids != published_run_ids:
@@ -255,6 +393,7 @@ class TrainingSupervisor:
                             elapsed_seconds=time.monotonic() - active.started,
                             log_path=str(active.log_path),
                             wandb_run_ids=discovered_run_ids,
+                            workspace_access=active.workspace_access,
                         )
                     )
                     published_run_ids = discovered_run_ids
@@ -299,6 +438,7 @@ class TrainingSupervisor:
                 error_tail,
                 scan_overlap,
                 run_ids,
+                tail_bytes=tail_bytes,
             )
             while log.peek(1):
                 error_tail, scan_overlap = self._consume_log(
@@ -306,6 +446,7 @@ class TrainingSupervisor:
                     error_tail,
                     scan_overlap,
                     run_ids,
+                    tail_bytes=tail_bytes,
                 )
             for match in _WANDB_RUN_URL_BYTES.findall(scan_overlap):
                 run_ids.setdefault(match.decode(), None)
@@ -321,14 +462,15 @@ class TrainingSupervisor:
             log_path=str(active.log_path),
             wandb_run_ids=tuple(run_ids),
             error_tail=(
-                error_tail.decode(errors="ignore")
+                _redact_bytes(error_tail, active.redacted_values)[
+                    -_ERROR_TAIL_BYTES:
+                ].decode(errors="ignore")
                 if state is not TrainingState.FINISHED
                 else ""
             ),
+            workspace_access=active.workspace_access,
         )
         self._write_result(result)
-        with self._lock:
-            self._active.pop(training_id, None)
 
     @staticmethod
     def _consume_log(
@@ -336,6 +478,8 @@ class TrainingSupervisor:
         error_tail: bytes,
         scan_overlap: bytes,
         run_ids: dict[str, None],
+        *,
+        tail_bytes: int = _ERROR_TAIL_BYTES,
     ) -> tuple[bytes, bytes]:
         chunk = log.read(_LOG_READ_BYTES)
         if not chunk:
@@ -344,7 +488,7 @@ class TrainingSupervisor:
         for match in _WANDB_COMPLETE_RUN_URL_BYTES.findall(scan):
             run_ids.setdefault(match.decode(), None)
         scan_overlap = scan[-_WANDB_SCAN_OVERLAP_BYTES:]
-        error_tail = (error_tail + chunk)[-_ERROR_TAIL_BYTES:]
+        error_tail = (error_tail + chunk)[-tail_bytes:]
         return error_tail, scan_overlap
 
     def _terminate_process_group(
@@ -358,9 +502,7 @@ class TrainingSupervisor:
             process,
             process_group_id=process_group_id,
             grace_seconds=(
-                self.terminate_grace_seconds
-                if grace_seconds is None
-                else grace_seconds
+                self.terminate_grace_seconds if grace_seconds is None else grace_seconds
             ),
             wait_full_grace=True,
         )
@@ -418,3 +560,10 @@ class TrainingSupervisor:
         temporary = path.with_suffix(".tmp")
         temporary.write_text(result.model_dump_json(indent=2))
         temporary.replace(path)
+
+
+def _redact_bytes(content: bytes, values: Sequence[bytes]) -> bytes:
+    for value in values:
+        if value:
+            content = content.replace(value, b"<secret-hidden>")
+    return content

--- a/senpai_agent/weave_monitoring.py
+++ b/senpai_agent/weave_monitoring.py
@@ -10,7 +10,10 @@ from uuid import UUID
 from weave_openhands import finish as weave_finish
 from weave_openhands import init as weave_init
 
-from senpai_agent.secrets import GITHUB_TOKEN_ENV_NAMES
+from senpai_agent.secrets import (
+    GITHUB_TOKEN_ENV_NAMES,
+    is_secret_environment_variable,
+)
 
 _initialized = False
 _project_name: str | None = None
@@ -24,9 +27,7 @@ TRACE_SECRET_ENV_NAMES = (
 
 
 def _is_secret_env(name: str) -> bool:
-    return name in TRACE_SECRET_ENV_NAMES or name.endswith(
-        ("_API_KEY", "_TOKEN", "_PASSWORD", "_SECRET", "_CREDENTIAL")
-    )
+    return name in TRACE_SECRET_ENV_NAMES or is_secret_environment_variable(name)
 
 
 def weave_project_name(env: Mapping[str, str]) -> str | None:

--- a/senpai_agent/workspace.py
+++ b/senpai_agent/workspace.py
@@ -7,7 +7,7 @@ import os
 import re
 import subprocess
 import tempfile
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -15,7 +15,6 @@ from pydantic import SecretStr
 
 from senpai_agent.git_workflow import git_process_env
 from senpai_agent.mailbox import ControllerEvent
-
 
 _HEAD_REF = "refs/senpai/assignment/head"
 _BASE_REF = "refs/senpai/assignment/base"
@@ -123,6 +122,17 @@ class WorkspaceDivergence(RuntimeError):
         )
 
 
+class WorkspaceJobRunning(RuntimeError):
+    """An assignment checkout is deferred while a mutable job holds the tree."""
+
+    def __init__(self, job_ids: Sequence[str]):
+        self.job_ids = tuple(job_ids)
+        super().__init__(
+            "assignment checkout deferred for mutable job(s): "
+            + ", ".join(self.job_ids)
+        )
+
+
 class StudentWorkspaceReconciler:
     """Hydrate an assignment and check it out without discarding local work."""
 
@@ -132,16 +142,16 @@ class StudentWorkspaceReconciler:
         *,
         repo: str | None = None,
         token: SecretStr | None = None,
+        active_mutable_job_ids: Callable[[], Sequence[str]] | None = None,
     ):
         if token is not None and repo is None:
             raise ValueError("authenticated reconciliation requires a GitHub repo")
-        if repo is not None and (
-            len(repo.split("/")) != 2 or not all(repo.split("/"))
-        ):
+        if repo is not None and (len(repo.split("/")) != 2 or not all(repo.split("/"))):
             raise ValueError("repo must use owner/name form")
         self.workspace = workspace
         self.token = token
         self.remote = f"https://github.com/{repo}.git" if repo else "origin"
+        self.active_mutable_job_ids = active_mutable_job_ids or (lambda: ())
 
     def __call__(self, events: Sequence[ControllerEvent]) -> None:
         assignment_event = next(
@@ -154,6 +164,9 @@ class StudentWorkspaceReconciler:
         )
         if assignment_event is None:
             return
+        active_jobs = tuple(self.active_mutable_job_ids())
+        if active_jobs:
+            raise WorkspaceJobRunning(active_jobs)
 
         assignment = _Assignment.from_event(assignment_event)
         self._hydrate(assignment)
@@ -171,13 +184,16 @@ class StudentWorkspaceReconciler:
             )
 
         local_ref = f"refs/heads/{assignment.head_ref}"
-        branch_exists = self._run(
-            "show-ref",
-            "--verify",
-            "--quiet",
-            local_ref,
-            check=False,
-        ).returncode == 0
+        branch_exists = (
+            self._run(
+                "show-ref",
+                "--verify",
+                "--quiet",
+                local_ref,
+                check=False,
+            ).returncode
+            == 0
+        )
         if not branch_exists:
             self._run("checkout", "-b", assignment.head_ref, _HEAD_REF)
             return
@@ -277,12 +293,15 @@ class StudentWorkspaceReconciler:
             )
 
     def _commit_exists(self, sha: str) -> bool:
-        return self._run(
-            "cat-file",
-            "-e",
-            f"{sha}^{{commit}}",
-            check=False,
-        ).returncode == 0
+        return (
+            self._run(
+                "cat-file",
+                "-e",
+                f"{sha}^{{commit}}",
+                check=False,
+            ).returncode
+            == 0
+        )
 
     def _worktree_state(self) -> str:
         status = self._git(
@@ -309,9 +328,7 @@ class StudentWorkspaceReconciler:
             "-z",
         ).stdout
         paths = sorted(path for path in raw_paths.split("\0") if path)
-        state = [
-            f"paths={hashlib.sha256(raw_paths.encode()).hexdigest()}:{len(paths)}"
-        ]
+        state = [f"paths={hashlib.sha256(raw_paths.encode()).hexdigest()}:{len(paths)}"]
         budget = _UNTRACKED_CONTENT_BUDGET
         for relative in paths[:_UNTRACKED_FILE_LIMIT]:
             path = self.workspace / relative
@@ -322,9 +339,7 @@ class StudentWorkspaceReconciler:
                 continue
             digest = "metadata-only"
             if path.is_symlink():
-                digest = hashlib.sha256(
-                    path.readlink().as_posix().encode()
-                ).hexdigest()
+                digest = hashlib.sha256(path.readlink().as_posix().encode()).hexdigest()
             elif path.is_file() and metadata.st_size <= budget:
                 with path.open("rb") as file:
                     content = file.read(budget + 1)
@@ -374,9 +389,7 @@ class StudentWorkspaceReconciler:
         )
         if check and completed.returncode != 0:
             detail = completed.stderr.strip() or completed.stdout.strip()
-            raise RuntimeError(
-                f"git {' '.join(arguments[:2])} failed: {detail[:1000]}"
-            )
+            raise RuntimeError(f"git {' '.join(arguments[:2])} failed: {detail[:1000]}")
         return completed
 
     @staticmethod

--- a/system_instructions/ADVISOR.md
+++ b/system_instructions/ADVISOR.md
@@ -33,6 +33,10 @@ You are the principal research lead of this lab and you want to see your student
 - Do not implement experiment code or edit student experiment branches.
 - Do not run training or evaluation; the advisor image has no training stack or
   GPU.
+- Use `run_job` for advisor-side long-running processes such as submission
+  receipt watchers or bounded analysis commands. Its automatic monitor will
+  resume this conversation on terminal state; use `monitor_job` only when an
+  already-running job also has a useful W&B metric policy.
 - You may edit and commit advisor-owned research notes, baseline records, and
   programme state files when the target contract permits it.
 - Use the operation-specific typed GitHub tools. Do not mutate PRs, issues,
@@ -249,7 +253,7 @@ Publish advisor-owned commits only through `publish_advisor_branch`.
 
 ## Events
 
-A `review_ready`, `training_monitor`, human-message, or child-agent result event
+A `review_ready`, `job_monitor`, human-message, or child-agent result event
 is fresh evidence. Relate it to its PR, run, or task; decide whether it changes
 current priorities; and either act, delegate, or record a specific deferral. Do
 not stop unrelated work merely because an event arrived. The

--- a/system_instructions/SENPAI-HARNESS.md
+++ b/system_instructions/SENPAI-HARNESS.md
@@ -67,14 +67,15 @@ only when its named tool is present in your schema:
 - When present, `get_prs` returns complete Markdown for a bounded PR set. Its
   `max_inline_prs` default is five. Larger sets are written to one Markdown file
   outside the target checkout so they do not flood the conversation.
-- When present, `run_training` supervises a training process, timeout, log,
-  terminal state, and discovered W&B run IDs, and automatically registers a
-  terminal-state monitor for the current student conversation.
-  `get_training_status` returns its typed status. `monitor_training` upgrades
-  that default with metric gates and staleness policy so the controller can
-  monitor without model polling. `cancel_training` stops one supervised run
-  and retires its monitor; use it instead of killing training processes through
-  the terminal.
+- When present, `run_job` supervises one argv-based long-running process such
+  as training, inference, evaluation, a build, or a receipt watcher. It records
+  timeout, log, terminal state, and discovered W&B run IDs, and automatically
+  registers terminal-state monitoring for the current conversation.
+  `get_job_status` returns one immediate typed snapshot. `monitor_job` sets or
+  replaces optional W&B metric gates and staleness policy for an already-running
+  job without disabling terminal wakes. `cancel_job` stops the complete process
+  group and retires its monitor. Finish the turn instead of sleeping, streaming
+  logs, or polling these tools in a loop.
 - When present, `load_browser` adds the full interactive browser family on the
   next step. Call it only when browser navigation or page inspection is useful;
   loading is idempotent and persists for the conversation.

--- a/system_instructions/STUDENT.md
+++ b/system_instructions/STUDENT.md
@@ -69,21 +69,23 @@ When the advisor assigns cleanup after a winning merge, simplify the training co
 
 Ensure that you log all relevant metrics and configs to wandb, especially when adding new metrics or configs particular to an experiment. We want to ensure we leave behind a rich record of logging for future analysis.
 
-## Train and monitor
+## Run and monitor long jobs
 
 Commit the exact implementation that will run and make the worktree clean before
 launching an expensive experiment. This makes each W&B result reproducible and
 lets the controller safely suspend the conversation while the process runs.
 
-Every optimization or GPU execution must use `run_training`, including debug
-runs and wrappers that train or evaluate a model. Pass an argv list, the exact
-target working directory, and a timeout within the launch limit. Never launch training through the terminal.
+Every optimization or GPU execution must use `run_job`, including debug runs,
+inference benchmarks, evaluations, and wrappers that train a model. Pass an
+argv list, the exact target working directory, and a timeout within the launch
+limit. Never launch these long-running processes through the terminal.
 
-`run_training` registers terminal-state monitoring automatically. Use
-`monitor_training` only to add useful primary-metric gates or a stale-update
-timeout, `get_training_status` for one bounded check, and `cancel_training` for
-an early stop. Do not kill the process, stream logs, sleep, or create terminal
-polling loops; finish the turn and let the controller resume the conversation.
+`run_job` registers terminal-state monitoring automatically. Use `monitor_job`
+only to set or replace useful W&B primary-metric gates or a stale-update policy
+for an already-running job; it never disables terminal wakes. Use
+`get_job_status` for one bounded check and `cancel_job` for an early stop. Do not
+kill the process, stream logs, sleep, or create terminal polling loops; finish
+the turn and let the controller resume the conversation.
 
 Every real experiment must log the target-required artifacts to W&B. Use groups
 only when the assignment calls for related arms, and run multiple variants only

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -5,20 +5,19 @@ from types import SimpleNamespace
 from uuid import UUID
 
 import pytest
+from test_agent_markdown import HTML_HEADER
 
 import senpai_agent.controller as controller_module
 from senpai_agent.controller import (
-    ConversationRecoveryExhausted,
     Controller,
+    ConversationRecoveryExhausted,
     TurnResult,
     _full_prompt,
 )
 from senpai_agent.mailbox import ControllerEvent
 from senpai_agent.state import ConversationStateLedger, WorkspaceDivergenceLedger
 from senpai_agent.supervisor import ProgressLease, WorkerLease
-from senpai_agent.workspace import WorkspaceDivergence
-from test_agent_markdown import HTML_HEADER
-
+from senpai_agent.workspace import WorkspaceDivergence, WorkspaceJobRunning
 
 CONVERSATION_ID = UUID("00000000-0000-0000-0000-000000000001")
 
@@ -57,9 +56,9 @@ def controller(mailbox, turns, **overrides):
         turns=turns,
         conversation_id=overrides.pop("conversation_id", CONVERSATION_ID),
         full_prompt="programme",
-        sleep=lambda _seconds: None,
-        poll_interval_seconds=600,
-        jitter_seconds=0,
+        sleep=overrides.pop("sleep", lambda _seconds: None),
+        poll_interval_seconds=overrides.pop("poll_interval_seconds", 600),
+        jitter_seconds=overrides.pop("jitter_seconds", 0),
         **overrides,
     )
 
@@ -171,6 +170,77 @@ def test_empty_mailbox_does_not_start_a_model_turn():
     controller(Mailbox([(), ()]), turns, role="student").run(max_cycles=2)
 
     assert turns.calls == []
+
+
+def test_active_job_monitor_shortens_the_controller_heartbeat():
+    sleeps = []
+
+    controller(
+        Mailbox([(), ()]),
+        Turns(),
+        sleep=sleeps.append,
+        next_monitor_poll_seconds=lambda: 45,
+    ).run(max_cycles=2)
+
+    assert sleeps == [45]
+
+
+def test_idle_job_monitor_keeps_the_controller_heartbeat():
+    sleeps = []
+
+    controller(
+        Mailbox([(), ()]),
+        Turns(),
+        sleep=sleeps.append,
+        next_monitor_poll_seconds=lambda: None,
+    ).run(max_cycles=2)
+
+    assert sleeps == [600]
+
+
+@pytest.mark.parametrize(
+    ("next_poll", "expected_phase"),
+    [
+        (lambda: float("nan"), "monitor-backoff"),
+        (
+            lambda: (_ for _ in ()).throw(RuntimeError("scheduler failed")),
+            "monitor-backoff",
+        ),
+    ],
+)
+def test_invalid_monitor_schedule_uses_bounded_nonzero_backoff(
+    next_poll,
+    expected_phase,
+):
+    sleeps = []
+    phases = []
+    instance = controller(
+        Mailbox([(), ()]),
+        Turns(),
+        sleep=sleeps.append,
+        next_monitor_poll_seconds=next_poll,
+        progress=SimpleNamespace(
+            update=lambda phase, *_args, **_kwargs: phases.append(phase)
+        ),
+    )
+
+    instance.run(max_cycles=2)
+
+    assert sleeps == [5]
+    assert expected_phase in phases
+
+
+def test_due_monitor_never_creates_a_zero_sleep_hot_loop():
+    sleeps = []
+
+    controller(
+        Mailbox([(), ()]),
+        Turns(),
+        sleep=sleeps.append,
+        next_monitor_poll_seconds=lambda: 0,
+    ).run(max_cycles=2)
+
+    assert sleeps == [1]
 
 
 def test_successful_turn_repolls_immediately_and_continues_without_full_brief():
@@ -411,6 +481,7 @@ def test_controller_main_does_not_derive_reminders_from_fast_polling(
         state_dir=tmp_path,
         workspace=tmp_path,
         training_max_timeout_seconds=1800,
+        command_secrets={"WANDB_API_KEY": "wandb-key"},
         conversation_id=CONVERSATION_ID,
         timeout_seconds=3600,
         harness_file=tmp_path / "harness.md",
@@ -453,6 +524,8 @@ def test_controller_main_does_not_derive_reminders_from_fast_polling(
                 "SENPAI_ROLE": "advisor",
                 "ADVISOR_BRANCH": "main",
                 "SENPAI_POLL_INTERVAL_S": "30",
+                "WANDB_ENTITY": "acme",
+                "WANDB_PROJECT": "research",
             },
         )
         == 0
@@ -461,9 +534,7 @@ def test_controller_main_does_not_derive_reminders_from_fast_polling(
     assert created[0].event_reminder_seconds == 600
     assert created[0].full_prompt == "programme"
     assert created[0].turns.full_prompt == "programme"
-    assert created[0].system_context.endswith(
-        "# Current research brief\n\nprogramme"
-    )
+    assert created[0].system_context.endswith("# Current research brief\n\nprogramme")
 
 
 def test_repeated_turn_failures_exit_to_the_supervisor_for_a_clean_restart():
@@ -574,9 +645,7 @@ def test_preserved_workspace_divergence_is_delivered_to_the_existing_turn():
         reconcile=reconcile,
     ).run(max_cycles=1)
 
-    assert turns.calls[0][2] == frozenset(
-        {event.dedupe_key, conflict.event.dedupe_key}
-    )
+    assert turns.calls[0][2] == frozenset({event.dedupe_key, conflict.event.dedupe_key})
     assert "do not reset or discard local work" in turns.calls[0][0]
 
 
@@ -897,8 +966,8 @@ def test_restart_continues_a_conversation_after_its_first_success(tmp_path: Path
             [
                 (
                     ControllerEvent(
-                        kind="training_monitor",
-                        dedupe_key="training:finished",
+                        kind="job_monitor",
+                        dedupe_key="job:finished",
                         payload={"conversation_id": str(conversation_id)},
                     ),
                 ),
@@ -913,6 +982,40 @@ def test_restart_continues_a_conversation_after_its_first_success(tmp_path: Path
 
     assert turns.calls[0][1] == conversation_id
     assert "programme" not in turns.calls[0][0]
+
+
+def test_workspace_lease_defers_only_checkout_events_in_a_mixed_batch():
+    assignment = ControllerEvent(
+        kind="student_assignment",
+        dedupe_key="assignment:leased",
+        payload={"assignment_id": "leased"},
+    )
+    monitor = ControllerEvent(
+        kind="job_monitor",
+        dedupe_key="job:regressed",
+        payload={
+            "conversation_id": str(CONVERSATION_ID),
+            "summary": "metric regressed",
+        },
+    )
+    mailbox = Mailbox([((assignment, monitor)), (assignment,)])
+    turns = Turns()
+
+    def reconcile(events):
+        if any(event.kind == "student_assignment" for event in events):
+            raise WorkspaceJobRunning(("job-17",))
+
+    controller(
+        mailbox,
+        turns,
+        role="student",
+        reconcile=reconcile,
+    ).run(max_cycles=1)
+
+    assert len(turns.calls) == 1
+    assert turns.calls[0][2] == frozenset({monitor.dedupe_key})
+    assert "metric regressed" in turns.calls[0][0]
+    assert mailbox.acknowledged == [(monitor.dedupe_key,)]
 
 
 def test_turn_lease_uses_the_configured_hard_deadline(tmp_path: Path):

--- a/tests/test_controller_conversations.py
+++ b/tests/test_controller_conversations.py
@@ -114,8 +114,8 @@ def test_assignment_feedback_and_monitor_wake_share_the_assignment_uuid(
             },
         ),
         ControllerEvent(
-            kind="training_monitor",
-            dedupe_key="training_monitor:run-1:finished",
+            kind="job_monitor",
+            dedupe_key="job_monitor:run-1:finished",
             payload={"conversation_id": str(conversation_id)},
         ),
     )

--- a/tests/test_controller_mailboxes.py
+++ b/tests/test_controller_mailboxes.py
@@ -85,5 +85,13 @@ def test_monitor_mailbox_routes_and_acknowledges_each_signal_independently(
             first.dedupe_key: str(first_id),
             second.dedupe_key: str(second_id),
         }
+        assert {event.kind for event in events} == {"job_monitor"}
+        assert {event.payload["job_id"] for event in events} == {
+            "training-first",
+            "training-second",
+        }
+        assert {event.payload["signal"]["kind"] for event in events} == {"job_status"}
+        assert all("training_id" not in event.payload["signal"] for event in events)
+        assert all("metric" not in event.payload["signal"] for event in events)
         mailbox.acknowledge((first.dedupe_key,))
         assert [event.dedupe_key for event in mailbox.poll()] == [second.dedupe_key]

--- a/tests/test_controller_workspace.py
+++ b/tests/test_controller_workspace.py
@@ -8,7 +8,11 @@ from pydantic import SecretStr
 
 from senpai_agent.git_workflow import git_process_env
 from senpai_agent.mailbox import ControllerEvent
-from senpai_agent.workspace import StudentWorkspaceReconciler, WorkspaceDivergence
+from senpai_agent.workspace import (
+    StudentWorkspaceReconciler,
+    WorkspaceDivergence,
+    WorkspaceJobRunning,
+)
 
 
 def git(*arguments: str, cwd: Path | None = None) -> str:
@@ -73,12 +77,26 @@ def test_reconciliation_preserves_unpushed_commits_and_dirty_files(
     local_head = git("rev-parse", "HEAD", cwd=workspace)
     (workspace / "notes.txt").write_text("dirty but recoverable\n")
 
-    StudentWorkspaceReconciler(workspace)(
-        (assignment_event(assigned_head, base_sha),)
-    )
+    StudentWorkspaceReconciler(workspace)((assignment_event(assigned_head, base_sha),))
 
     assert git("rev-parse", "HEAD", cwd=workspace) == local_head
     assert (workspace / "notes.txt").read_text() == "dirty but recoverable\n"
+
+
+def test_reconciliation_does_not_touch_checkout_while_mutable_job_is_active(
+    tmp_path: Path,
+):
+    _remote, _seed, workspace, base_sha, assigned_head = assigned_workspace(tmp_path)
+    original_head = git("rev-parse", "HEAD", cwd=workspace)
+    reconciler = StudentWorkspaceReconciler(
+        workspace,
+        active_mutable_job_ids=lambda: ("job-17",),
+    )
+
+    with pytest.raises(WorkspaceJobRunning, match="job-17"):
+        reconciler((assignment_event(assigned_head, base_sha),))
+
+    assert git("rev-parse", "HEAD", cwd=workspace) == original_head
 
 
 def test_reconciliation_rejects_a_remote_head_newer_than_the_assignment(
@@ -175,20 +193,24 @@ def test_reconciliation_hydrates_exact_controller_owned_head_and_base_refs(
 ):
     _remote, _seed, workspace, base_sha, assigned_head = assigned_workspace(tmp_path)
 
-    StudentWorkspaceReconciler(workspace)(
-        (assignment_event(assigned_head, base_sha),)
-    )
+    StudentWorkspaceReconciler(workspace)((assignment_event(assigned_head, base_sha),))
 
-    assert git(
-        "rev-parse",
-        "refs/senpai/assignment/head",
-        cwd=workspace,
-    ) == assigned_head
-    assert git(
-        "rev-parse",
-        "refs/senpai/assignment/base",
-        cwd=workspace,
-    ) == base_sha
+    assert (
+        git(
+            "rev-parse",
+            "refs/senpai/assignment/head",
+            cwd=workspace,
+        )
+        == assigned_head
+    )
+    assert (
+        git(
+            "rev-parse",
+            "refs/senpai/assignment/base",
+            cwd=workspace,
+        )
+        == base_sha
+    )
 
 
 def test_reconciliation_rejects_an_unavailable_exact_base_without_mutation(
@@ -279,14 +301,12 @@ def test_reconciliation_isolates_typed_auth_from_hostile_git_configuration(
     )
     global_config = tmp_path / "hostile-global.gitconfig"
     global_config.write_text(
-        "[url \"https://attacker.invalid/global.git\"]\n"
+        '[url "https://attacker.invalid/global.git"]\n'
         "\tinsteadOf = https://github.com/acme/widgets.git\n"
         "[http]\n\tsslVerify = false\n"
     )
     system_config = tmp_path / "hostile-system.gitconfig"
-    system_config.write_text(
-        "[http]\n\tproxy = http://attacker.invalid:8080\n"
-    )
+    system_config.write_text("[http]\n\tproxy = http://attacker.invalid:8080\n")
     github_remote = "https://github.com/acme/widgets.git"
 
     def guarded_run(command, **kwargs):
@@ -313,19 +333,12 @@ def test_reconciliation_isolates_typed_auth_from_hostile_git_configuration(
             assert configuration["http.sslVerify"] == "true"
             assert configuration["http.https://github.com/.sslVerify"] == "true"
             assert configuration["http.followRedirects"] == "false"
-            assert (
-                configuration["http.https://github.com/.followRedirects"]
-                == "false"
-            )
+            assert configuration["http.https://github.com/.followRedirects"] == "false"
             assert configuration["http.extraHeader"] == ""
             encoded = configuration[
                 "http.https://github.com/.extraHeader"
-            ].removeprefix(
-                "Authorization: Basic "
-            )
-            assert base64.b64decode(encoded).decode() == (
-                "x-access-token:typed-token"
-            )
+            ].removeprefix("Authorization: Basic ")
+            assert base64.b64decode(encoded).decode() == ("x-access-token:typed-token")
             command = [*command]
             command[command.index(github_remote)] = str(remote)
             replacement_environment = git_process_env(None)

--- a/tests/test_hooks_lifecycle.py
+++ b/tests/test_hooks_lifecycle.py
@@ -5,11 +5,13 @@
 import json
 from pathlib import Path
 from types import SimpleNamespace
+from uuid import uuid4
 
 import pytest
 from openhands.sdk.plugin import Plugin
 
 from senpai_agent.hooks import hook_main
+from senpai_agent.monitor import MonitorStore, TrainingMonitorSpec
 
 PLUGIN_DIR = Path(__file__).parents[1] / "plugins" / "senpai"
 TRAINING_ID = "b81440b1-b803-471e-9fe0-6dcabd756b83"
@@ -38,9 +40,13 @@ def write_running_training(state_dir: Path, *, monitored: bool) -> None:
     training_dir.mkdir(parents=True)
     (training_dir / f"{TRAINING_ID}.json").write_text('{"state":"running"}')
     if monitored:
-        monitor_dir = training_dir / "monitors"
-        monitor_dir.mkdir()
-        (monitor_dir / f"{TRAINING_ID}.json").write_text("{}")
+        with MonitorStore(training_dir / "monitors.sqlite3") as store:
+            store.register(
+                TrainingMonitorSpec(
+                    training_id=TRAINING_ID,
+                    conversation_id=uuid4(),
+                )
+            )
 
 
 def test_pre_tool_hook_emits_a_native_denial(
@@ -84,11 +90,13 @@ def test_plugin_loads_terminal_safety_and_lifecycle_hooks():
     assert hooks["Stop"] and hooks["SessionEnd"]
 
 
-def test_student_stop_denies_unmonitored_training(
+@pytest.mark.parametrize("role", ["student", "advisor"])
+def test_roles_stop_denies_unmonitored_job(
     assignment_workspace: Path,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
+    role: str,
 ):
     state_dir = tmp_path / "state"
     write_running_training(state_dir, monitored=False)
@@ -99,7 +107,7 @@ def test_student_stop_denies_unmonitored_training(
         monkeypatch,
         capsys,
         {
-            "SENPAI_ROLE": "student",
+            "SENPAI_ROLE": role,
             "SENPAI_OPENHANDS_STATE_DIR": str(state_dir),
         },
     )
@@ -108,7 +116,7 @@ def test_student_stop_denies_unmonitored_training(
     assert TRAINING_ID in str(output["reason"])
 
 
-def test_student_stop_allows_durable_monitored_training(
+def test_student_stop_allows_sqlite_registered_monitored_job(
     assignment_workspace: Path,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_monitor_engine.py
+++ b/tests/test_monitor_engine.py
@@ -15,7 +15,6 @@ from senpai_agent.monitor import (
 )
 from senpai_agent.training import TrainingResult, TrainingState
 
-
 NOW = datetime(2026, 7, 30, tzinfo=UTC)
 
 
@@ -180,6 +179,8 @@ def test_terminal_failure_wins_over_metric_and_sample_failures(
 
 
 def test_wandb_source_returns_latest_value_and_timestamp(monkeypatch):
+    api_options = []
+
     class Run:
         def history(self, *, keys, **_options):
             if keys != ["accuracy", "_timestamp"]:
@@ -197,12 +198,83 @@ def test_wandb_source_returns_latest_value_and_timestamp(monkeypatch):
     monkeypatch.setitem(
         sys.modules,
         "wandb",
-        SimpleNamespace(Api=lambda **_options: SimpleNamespace(run=run)),
+        SimpleNamespace(
+            Api=lambda **options: (
+                api_options.append(options) or SimpleNamespace(run=run)
+            )
+        ),
     )
 
-    sample = WandbMetricSource("entity", "project").latest("run-1", "accuracy")
+    sample = WandbMetricSource(
+        "entity",
+        "project",
+        api_key="wandb-secret",
+    ).latest("run-1", "accuracy")
 
     assert sample == MetricSample(
         value=0.7,
         observed_at=datetime.fromtimestamp(200, UTC),
     )
+    assert api_options == [{"api_key": "wandb-secret", "timeout": 20}]
+
+
+def test_monitor_cycle_cap_is_fair_across_due_jobs(tmp_path: Path):
+    monitors = [monitor(f"train-{index}") for index in range(6)]
+    checked = []
+
+    class Training:
+        def get_training_status(self, training_id):
+            checked.append(training_id)
+            return result(tmp_path, training_id, TrainingState.FINISHED)
+
+    with MonitorStore(tmp_path / "monitors.sqlite3") as store:
+        for item in monitors:
+            store.register(item)
+        engine = TrainingMonitorEngine(
+            store,
+            Training(),
+            SimpleNamespace(),
+            max_polls_per_cycle=2,
+        )
+
+        engine.poll(NOW)
+        engine.poll(NOW)
+        engine.poll(NOW)
+
+    assert checked == [item.training_id for item in monitors]
+
+
+def test_monitor_cycle_stops_between_polls_when_budget_is_spent(tmp_path: Path):
+    monitors = [monitor(f"train-{index}", metric="loss") for index in range(4)]
+    clock = [0.0]
+    checked = []
+
+    class Training:
+        def get_training_status(self, training_id):
+            checked.append(training_id)
+            return result(tmp_path, training_id)
+
+    class Metrics:
+        def latest(self, _run_id, _metric):
+            clock[0] += 2
+            return MetricSample(value=0.2, observed_at=NOW)
+
+    with MonitorStore(tmp_path / "monitors.sqlite3") as store:
+        for item in monitors:
+            store.register(item)
+        engine = TrainingMonitorEngine(
+            store,
+            Training(),
+            Metrics(),
+            max_polls_per_cycle=4,
+            poll_budget_seconds=3,
+            monotonic=lambda: clock[0],
+        )
+
+        engine.poll(NOW)
+
+        assert checked == ["train-0", "train-1"]
+        assert [item.training_id for item in store.due(NOW)] == [
+            "train-2",
+            "train-3",
+        ]

--- a/tests/test_monitor_store.py
+++ b/tests/test_monitor_store.py
@@ -1,4 +1,5 @@
 import sqlite3
+import threading
 from contextlib import closing
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -17,7 +18,6 @@ from senpai_agent.monitor import (
     evaluate_monitor,
 )
 from senpai_agent.training import TrainingState
-
 
 NOW = datetime(2026, 7, 30, tzinfo=UTC)
 
@@ -46,14 +46,12 @@ SIGNAL = MonitorSignal(
 )
 
 
-def test_registration_and_stop_hook_marker_survive_reopen(tmp_path: Path):
+def test_registration_survives_reopen_in_the_authoritative_database(tmp_path: Path):
     monitor = spec()
     database = tmp_path / "monitors.sqlite3"
 
     with MonitorStore(database) as store:
         assert store.register(monitor) is True
-        marker = store.marker_dir / "train-1.json"
-        assert TrainingMonitorSpec.model_validate_json(marker.read_text()) == monitor
 
     with MonitorStore(database) as reopened:
         assert reopened.active() == [monitor]
@@ -77,6 +75,27 @@ def test_same_policy_reregistration_preserves_derived_state(tmp_path: Path):
         assert store.spec("train-1") == monitor
         assert store.previous_sample("train-1") == sample
         assert store.pending_signals() == [SIGNAL]
+
+
+def test_next_poll_delay_tracks_the_earliest_active_monitor(tmp_path: Path):
+    first = spec(training_id="first", poll_interval_seconds=60)
+    second = spec(training_id="second", poll_interval_seconds=180)
+
+    with MonitorStore(tmp_path / "monitors.sqlite3") as store:
+        assert store.seconds_until_next_poll(NOW) is None
+        store.register(first)
+        store.register(second)
+        assert store.seconds_until_next_poll(NOW) == 0
+
+        store.record_poll(first, MonitorEvaluation(), None, now=NOW)
+        store.record_poll(second, MonitorEvaluation(), None, now=NOW)
+        assert store.seconds_until_next_poll(NOW + timedelta(seconds=30)) == 30
+
+        store.complete(first.training_id)
+        assert store.seconds_until_next_poll(NOW + timedelta(seconds=30)) == 150
+
+        store.complete(second.training_id)
+        assert store.seconds_until_next_poll(NOW) is None
 
 
 def test_changed_policy_reactivates_monitor_and_clears_old_state(tmp_path: Path):
@@ -105,8 +124,6 @@ def test_changed_policy_reactivates_monitor_and_clears_old_state(tmp_path: Path)
         assert store.pending_signals() == []
         assert store.emitted("train-1") == frozenset()
         assert store.due(NOW + timedelta(minutes=5)) == [changed]
-        marker = store.marker_dir / "train-1.json"
-        assert TrainingMonitorSpec.model_validate_json(marker.read_text()) == changed
 
 
 def test_signal_is_durable_deduplicated_and_acknowledged(tmp_path: Path):
@@ -130,9 +147,7 @@ def test_signal_is_durable_deduplicated_and_acknowledged(tmp_path: Path):
 
 
 def test_first_sample_remains_the_change_gate_baseline(tmp_path: Path):
-    monitor = spec(
-        gates=(MetricGate(operator="improved_by", threshold=0.1),)
-    )
+    monitor = spec(gates=(MetricGate(operator="improved_by", threshold=0.1),))
     first = MetricSample(value=0.8, observed_at=NOW)
     later = MetricSample(value=0.75, observed_at=NOW + timedelta(minutes=1))
 
@@ -205,3 +220,81 @@ def test_legacy_schema_promotes_previous_sample_to_change_baseline(
         )
 
         assert [item.kind for item in evaluation.signals] == ["metric_gate"]
+
+
+def test_malformed_monitor_is_quarantined_without_blocking_healthy_rows(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+):
+    broken = spec(training_id="broken")
+    healthy = spec(training_id="healthy")
+
+    with MonitorStore(tmp_path / "monitors.sqlite3") as store:
+        store.register(broken)
+        store.register(healthy)
+        with store.connection:
+            store.connection.execute(
+                "UPDATE monitors SET spec_json = ? WHERE training_id = ?",
+                ("not-json", broken.training_id),
+            )
+
+        assert store.due(NOW) == [healthy]
+        assert store.active() == [healthy]
+        assert store.seconds_until_next_poll(NOW) == 0
+
+    assert "SENPAI_MONITOR_QUARANTINED job_id=broken" in capsys.readouterr().err
+
+
+def test_nonfinite_schedule_is_quarantined_without_a_zero_sleep_loop(
+    tmp_path: Path,
+):
+    broken = spec(training_id="broken")
+    healthy = spec(training_id="healthy")
+
+    with MonitorStore(tmp_path / "monitors.sqlite3") as store:
+        store.register(broken)
+        store.register(healthy)
+        store.record_poll(healthy, MonitorEvaluation(), None, now=NOW)
+        with store.connection:
+            store.connection.execute(
+                "UPDATE monitors SET next_poll_at = ? WHERE training_id = ?",
+                ("nan", broken.training_id),
+            )
+
+        assert store.seconds_until_next_poll(NOW) == 60
+        assert store.active() == [healthy]
+
+
+def test_store_operations_are_serialized_across_monitor_and_tool_threads(
+    tmp_path: Path,
+):
+    monitor = spec()
+    errors = []
+
+    with MonitorStore(tmp_path / "monitors.sqlite3") as store:
+        store.register(monitor)
+
+        def exercise_store(offset: int):
+            try:
+                for step in range(30):
+                    sample = MetricSample(
+                        value=float(offset + step),
+                        observed_at=NOW + timedelta(seconds=step),
+                    )
+                    store.record_poll(monitor, MonitorEvaluation(), sample, now=NOW)
+                    store.spec(monitor.training_id)
+                    store.previous_sample(monitor.training_id)
+                    store.emitted(monitor.training_id)
+            except Exception as error:  # noqa: BLE001
+                errors.append(error)
+
+        threads = [
+            threading.Thread(target=exercise_store, args=(index,)) for index in range(4)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert errors == []
+        assert store.active() == [monitor]

--- a/tests/test_openhands_config.py
+++ b/tests/test_openhands_config.py
@@ -2,12 +2,15 @@ import os
 from pathlib import Path
 
 import pytest
+from openhands_support import runtime_config, runtime_env
 from pydantic import SecretStr
+from test_agent_markdown import HTML_HEADER, PLAIN_HEADER
 
 import senpai_agent.openhands_runner as runner
 from senpai_agent.openhands_runner import (
     build_main_agent_context,
     find_role_file,
+    live_controller_invariant,
     parse_runner_args,
     read_role_instructions,
     resolve_config,
@@ -15,8 +18,6 @@ from senpai_agent.openhands_runner import (
     sanitized_project_skills,
     scrub_model_credentials,
 )
-from openhands_support import runtime_config, runtime_env
-from test_agent_markdown import HTML_HEADER, PLAIN_HEADER
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -51,22 +52,39 @@ def test_main_agent_context_places_harness_and_role_before_project_skills():
     context = build_main_agent_context("harness instructions", "advisor role")
 
     assert context.system_message_suffix == (
-        "# Senpai harness\n\nharness instructions\n\n"
-        "# Senpai role\n\nadvisor role\n"
+        "# Senpai harness\n\nharness instructions\n\n# Senpai role\n\nadvisor role\n"
     )
     assert context.current_datetime is None
     assert context.load_user_skills is True
     assert context.load_project_skills is False
 
 
-def test_student_charter_requires_typed_tools_for_every_training_operation():
+def test_live_advisor_invariant_is_part_of_non_condensed_system_context(tmp_path):
+    advisor = runtime_config(tmp_path, role="advisor", max_turns=100000)
+    invariant = live_controller_invariant(advisor)
+    context = build_main_agent_context("harness", "advisor", (), invariant)
+
+    assert "advisor campaign is active" in context.system_message_suffix
+    assert "no configured campaign round limit" in context.system_message_suffix
+    assert "max_turns=100000 bounds one OpenHands turn" in context.system_message_suffix
+    assert 'round label such as "FINAL ROUND"' in context.system_message_suffix
+    assert live_controller_invariant(runtime_config(tmp_path, role="student")) == ""
+    assert (
+        live_controller_invariant(runtime_config(tmp_path, role="advisor", child=True))
+        == ""
+    )
+
+
+def test_student_charter_requires_typed_tools_for_every_long_job():
     instructions = (ROOT / "system_instructions" / "STUDENT.md").read_text()
 
-    assert "must use `run_training`" in instructions
-    assert "Never launch training through the terminal" in instructions
-    assert "`monitor_training`" in instructions
-    assert "`get_training_status`" in instructions
-    assert "`cancel_training`" in instructions
+    assert "must use `run_job`" in instructions
+    assert (
+        "Never launch these long-running processes through the terminal" in instructions
+    )
+    assert "`monitor_job`" in instructions
+    assert "`get_job_status`" in instructions
+    assert "`cancel_job`" in instructions
 
 
 def test_project_instructions_and_file_agents_are_sanitized_without_mutation(
@@ -88,8 +106,12 @@ def test_project_instructions_and_file_agents_are_sanitized_without_mutation(
     skills = sanitized_project_skills(workspace)
     definitions = sanitized_agent_definitions(workspace)
 
-    assert "SPDX-" not in next(skill.content for skill in skills if skill.name == "agents")
-    assert "SPDX-" not in next(item.system_prompt for item in definitions if item.name == "review")
+    assert "SPDX-" not in next(
+        skill.content for skill in skills if skill.name == "agents"
+    )
+    assert "SPDX-" not in next(
+        item.system_prompt for item in definitions if item.name == "review"
+    )
     assert instructions.read_text(encoding="utf-8").startswith("<!--\nSPDX-")
     assert "# SPDX-" in definition.read_text(encoding="utf-8")
 

--- a/tests/test_openhands_conversation.py
+++ b/tests/test_openhands_conversation.py
@@ -5,22 +5,25 @@ from io import StringIO
 from types import SimpleNamespace
 
 import pytest
-from openhands.sdk import Agent, LLM
-from openhands.sdk.conversation import ConversationExecutionStatus
+from openhands.sdk import LLM, Agent, Tool
+from openhands.sdk.conversation import ConversationExecutionStatus, ConversationState
 from openhands.sdk.llm import Message, TextContent
+from openhands.sdk.workspace import LocalWorkspace
+from openhands_support import (
+    PLUGIN_DIR,
+    isolate_agent_discovery,
+    runtime_config,
+)
 from pydantic import SecretStr
 
 import senpai_agent.openhands_runner as runner
 from senpai_agent.openhands_runner import (
     graceful_interrupts,
     main,
+    migrate_persisted_disabled_tools,
     reject_recovered_actions,
     run_openhands,
-)
-from openhands_support import (
-    PLUGIN_DIR,
-    isolate_agent_discovery,
-    runtime_config,
+    without_legacy_think,
 )
 
 
@@ -66,6 +69,8 @@ def test_run_initializes_role_plugin_and_secrets_before_the_first_message(
     assert captured["role"] == (
         "# Senpai harness\n\nharness instructions\n\n"
         "# Senpai role\n\nadvisor role\n"
+        "\n# Live controller invariant\n\n"
+        f"{runner.live_controller_invariant(config)}\n"
     )
     assert captured["plugin"] == str(PLUGIN_DIR)
     assert captured["secrets"] == {"WANDB_API_KEY": "wandb-key"}
@@ -74,6 +79,79 @@ def test_run_initializes_role_plugin_and_secrets_before_the_first_message(
     assert captured["llm_timeout"] == 900
     assert captured["llm_num_retries"] == 1
     assert captured["closed"] is True
+
+
+def test_think_migration_preserves_history_and_job_factory_resume(tmp_path):
+    conversation_id = runner.uuid.uuid4()
+    persistence_root = tmp_path / "state"
+    persistence_dir = persistence_root / conversation_id.hex
+    workspace = LocalWorkspace(working_dir=tmp_path / "workspace")
+    llm = LLM(model="openai/gpt-4o-mini", api_key=SecretStr("test-key"))
+    job_tool = Tool(
+        name="senpai_training",
+        params={"state_dir": str(tmp_path / "jobs")},
+    )
+    old_agent = Agent(
+        llm=llm,
+        tools=[job_tool, Tool(name="think")],
+    )
+    state = ConversationState.create(
+        id=conversation_id,
+        agent=old_agent,
+        workspace=workspace,
+        persistence_dir=str(persistence_dir),
+    )
+    message = state.append_event(
+        runner.MessageEvent(
+            source="user",
+            llm_message=Message(
+                role="user",
+                content=[TextContent(text="preserve this research history")],
+            ),
+        )
+    )
+    event_files = tuple(
+        (p, p.read_bytes()) for p in (persistence_dir / "events").iterdir()
+    )
+    before = json.loads((persistence_dir / "base_state.json").read_text())
+
+    assert migrate_persisted_disabled_tools(persistence_root, conversation_id) is True
+    assert migrate_persisted_disabled_tools(persistence_root, conversation_id) is False
+
+    persisted = json.loads((persistence_dir / "base_state.json").read_text())
+    assert [tool["name"] for tool in persisted["agent"]["tools"]] == ["senpai_training"]
+    assert persisted["agent"]["tools"][0] == job_tool.model_dump(mode="json")
+    assert "ThinkTool" not in persisted["agent"]["include_default_tools"]
+    assert {key: value for key, value in persisted.items() if key != "agent"} == {
+        key: value for key, value in before.items() if key != "agent"
+    }
+    assert {
+        key: value
+        for key, value in persisted["agent"].items()
+        if key not in {"tools", "include_default_tools"}
+    } == {
+        key: value
+        for key, value in before["agent"].items()
+        if key not in {"tools", "include_default_tools"}
+    }
+    assert all(path.read_bytes() == content for path, content in event_files)
+
+    current_agent = without_legacy_think(Agent(llm=llm, tools=[job_tool]))
+    conversation = runner.LocalConversation(
+        agent=current_agent,
+        workspace=workspace,
+        persistence_dir=persistence_root,
+        conversation_id=conversation_id,
+        visualizer=None,
+    )
+    try:
+        assert [event.id for event in conversation.state.events] == [message.id]
+        assert [tool.name for tool in conversation.state.agent.tools] == [
+            "senpai_training"
+        ]
+        assert conversation.state.agent.include_default_tools == ["FinishTool"]
+    finally:
+        conversation.close()
 
 
 def test_context_reset_preserves_history_and_starts_a_fresh_active_branch(
@@ -208,9 +286,7 @@ def test_student_requests_persistent_storage_for_monitor_wake(
         def __init__(self, **kwargs):
             self.id = kwargs["conversation_id"]
             captured["delete_on_close"] = kwargs["delete_on_close"]
-            captured["tool_concurrency_limit"] = kwargs[
-                "agent"
-            ].tool_concurrency_limit
+            captured["tool_concurrency_limit"] = kwargs["agent"].tool_concurrency_limit
             self.state = SimpleNamespace(
                 execution_status=ConversationExecutionStatus.FINISHED
             )
@@ -273,9 +349,11 @@ def test_named_agent_compaction_uses_its_own_provider(tmp_path, monkeypatch):
     monkeypatch.setattr(
         runner,
         "agent_definition_to_factory",
-        lambda *_args, **_kwargs: lambda _parent_llm: Agent(
-            llm=named_llm,
-            tools=[],
+        lambda *_args, **_kwargs: (
+            lambda _parent_llm: Agent(
+                llm=named_llm,
+                tools=[],
+            )
         ),
     )
     monkeypatch.setattr(runner, "LocalConversation", FakeConversation)
@@ -377,7 +455,9 @@ def test_conversation_and_credentials_are_cleaned_up_after_failures(
 
     monkeypatch.setattr(runner, "LocalConversation", FakeConversation)
     isolate_agent_discovery(monkeypatch, runner)
-    monkeypatch.setattr(runner, "clear_github_credentials", lambda: cleared.append(True))
+    monkeypatch.setattr(
+        runner, "clear_github_credentials", lambda: cleared.append(True)
+    )
     monkeypatch.setattr(runner, "configure_delegation", delegation.append)
 
     with pytest.raises(RuntimeError, match="failed"):
@@ -418,10 +498,10 @@ def test_turn_deadline_requests_conversation_interrupt(tmp_path, monkeypatch):
     isolate_agent_discovery(monkeypatch, runner)
 
     assert (
-            run_openhands(
-                "task",
-                runtime_config(tmp_path, timeout_seconds=0.2),
-            )
+        run_openhands(
+            "task",
+            runtime_config(tmp_path, timeout_seconds=0.2),
+        )
         == 1
     )
     assert interrupted.is_set()
@@ -441,10 +521,9 @@ def test_signal_interrupts_the_conversation_and_restores_handlers(monkeypatch):
     conversation = SimpleNamespace(interrupt=lambda: calls.append("interrupt"))
     monkeypatch.setattr(runner.signal, "signal", fake_signal)
 
-    with pytest.raises(SystemExit) as raised:
-        with graceful_interrupts(conversation):
-            installed[signal.SIGTERM](signal.SIGTERM, None)
-            calls.append("handler-returned")
+    with pytest.raises(SystemExit) as raised, graceful_interrupts(conversation):
+        installed[signal.SIGTERM](signal.SIGTERM, None)
+        calls.append("handler-returned")
 
     assert raised.value.code == 128 + signal.SIGTERM
     assert "interrupt" in calls

--- a/tests/test_openhands_tools_and_agents.py
+++ b/tests/test_openhands_tools_and_agents.py
@@ -6,20 +6,22 @@ import textwrap
 from types import SimpleNamespace
 
 import pytest
-from openhands.sdk import Agent, LLM, Tool
-from openhands.sdk.tool import resolve_tool
+from openhands.sdk import LLM, Agent, Tool
 from openhands.sdk.plugin import Plugin
 from openhands.sdk.subagent import AgentDefinition, agent_definition_to_factory
+from openhands.sdk.tool import resolve_tool
 from openhands.tools.preset.default import register_default_tools
+from openhands_support import AGENT_DIR, PLUGIN_DIR, REPO_ROOT, runtime_config
 from pydantic import SecretStr
 
 from senpai_agent.openhands_runner import (
     build_main_tools,
-    depth_aware_child_definition,
     delegation_config,
+    depth_aware_child_definition,
     find_named_agent,
     resolve_plugin_dir,
     sanitized_agent_definitions,
+    without_legacy_think,
 )
 from senpai_agent.tools import (
     LoadBrowserAction,
@@ -27,7 +29,6 @@ from senpai_agent.tools import (
     SenpaiTaskTrackerTool,
     register_senpai_tools,
 )
-from openhands_support import AGENT_DIR, PLUGIN_DIR, REPO_ROOT, runtime_config
 
 
 def test_child_mode_keeps_bounded_delegation_lifecycle_tools(tmp_path):
@@ -42,13 +43,17 @@ def test_child_mode_keeps_bounded_delegation_lifecycle_tools(tmp_path):
         "cancel_agents",
     } <= names
     assert "senpai_training" not in names
+    assert "think" not in names
     assert delegation_config(config).depth == 0
 
 
 def test_browser_family_is_lazy_and_respects_disable_flag(tmp_path):
     enabled_tools = build_main_tools(runtime_config(tmp_path, enable_browser=True))
     enabled = {tool.name for tool in enabled_tools}
-    disabled = {tool.name for tool in build_main_tools(runtime_config(tmp_path, enable_browser=False))}
+    disabled = {
+        tool.name
+        for tool in build_main_tools(runtime_config(tmp_path, enable_browser=False))
+    }
     state = SimpleNamespace(agent_state={})
     resolved = resolve_tool(
         next(tool for tool in enabled_tools if tool.name == "browser_tool_set"),
@@ -116,6 +121,7 @@ def test_browser_loader_uses_runtime_tools_and_persists_activation(monkeypatch):
                 "await_agents",
                 "agent_status",
                 "cancel_agents",
+                "senpai_training",
             },
         ),
         (
@@ -147,6 +153,7 @@ def test_main_tools_replace_unsafe_defaults_with_role_scoped_boundaries(
     by_name = {tool.name: tool for tool in build_main_tools(config)}
 
     assert "terminal" not in by_name
+    assert "think" not in by_name
     assert "task_tool_set" not in by_name
     assert expected_custom <= set(by_name)
     assert by_name["senpai_terminal"].params == {"role": role}
@@ -167,11 +174,10 @@ def test_main_tools_replace_unsafe_defaults_with_role_scoped_boundaries(
         "student_names": ("student-one",) if role == "advisor" else None,
         "student_name": "student-one" if role == "student" else None,
     }
-    if role == "student":
-        assert by_name["senpai_training"].params == {
-            "state_dir": str(config.state_dir / "training"),
-            "max_timeout_seconds": 1800,
-        }
+    assert by_name["senpai_training"].params == {
+        "state_dir": str(config.state_dir / "training"),
+        "max_timeout_seconds": 1800,
+    }
 
 
 def test_native_senpai_plugin_loads_its_runtime_skills():
@@ -229,27 +235,81 @@ def test_child_definition_exposes_spawn_only_to_depth_one_generalist():
     general = AgentDefinition.load(AGENT_DIR / "general-purpose.md")
     explore = AgentDefinition.load(AGENT_DIR / "explore.md")
 
-    assert "spawn_agents" in depth_aware_child_definition(
-        general, child=False, depth=2
-    ).tools
-    assert "spawn_agents" in depth_aware_child_definition(
-        general, child=True, depth=1
-    ).tools
-    assert "spawn_agents" not in depth_aware_child_definition(
-        general, child=True, depth=2
-    ).tools
-    assert "spawn_agents" not in depth_aware_child_definition(
-        explore, child=True, depth=1
-    ).tools
+    assert (
+        "spawn_agents"
+        in depth_aware_child_definition(general, child=False, depth=2).tools
+    )
+    assert (
+        "spawn_agents"
+        in depth_aware_child_definition(general, child=True, depth=1).tools
+    )
+    assert (
+        "spawn_agents"
+        not in depth_aware_child_definition(general, child=True, depth=2).tools
+    )
+    assert (
+        "spawn_agents"
+        not in depth_aware_child_definition(explore, child=True, depth=1).tools
+    )
 
 
 def test_senpai_task_tracker_description_is_concise_and_parallel_safe(tmp_path):
     state = type("State", (), {"persistence_dir": str(tmp_path)})()
     tool = SenpaiTaskTrackerTool.create(state)[0]
+    description = " ".join(tool.description.split())
 
-    assert "genuinely parallel" in tool.description
-    assert "Limit active work to ONE" not in tool.description
+    assert "persisted task list as working memory across turns" in description
+    assert "delegated agents" in description
+    assert "long-running jobs" in description
+    assert "multiple items" in description
+    assert "For straightforward work, proceed directly" in description
+    assert "Limit active work to ONE" not in description
     assert len(tool.description) < 700
+
+
+def test_think_is_absent_from_every_root_and_child_tool_surface(tmp_path):
+    for role in ("advisor", "student"):
+        assert "think" not in {
+            tool.name for tool in build_main_tools(runtime_config(tmp_path, role=role))
+        }
+    for filename in ("general-purpose.md", "explore.md", "search.md", "bash-runner.md"):
+        assert "think" not in AgentDefinition.load(AGENT_DIR / filename).tools
+    agent = without_legacy_think(
+        Agent(
+            llm=LLM(
+                model="openai/gpt-4o-mini",
+                api_key=SecretStr("test-key"),
+            ),
+            tools=[],
+        )
+    )
+    assert "ThinkTool" not in agent.include_default_tools
+
+
+def test_operational_guidance_uses_only_the_public_job_tool_names():
+    readme = REPO_ROOT / "README.md"
+    operational_files = [readme, REPO_ROOT / "SPEC.md"]
+    operational_files.extend((REPO_ROOT / "system_instructions").glob("*.md"))
+    operational_files.extend(
+        (REPO_ROOT / "plugins" / "senpai" / "skills").glob("**/*.md")
+    )
+    operational_files.extend((REPO_ROOT / ".agents" / "agents").glob("*.md"))
+
+    stale_names = {
+        "run_training",
+        "get_training_status",
+        "monitor_training",
+        "cancel_training",
+    }
+    findings = {
+        str(path.relative_to(REPO_ROOT)): sorted(
+            name for name in stale_names if name in path.read_text()
+        )
+        for path in operational_files
+    }
+
+    assert readme in operational_files
+    assert not {path: names for path, names in findings.items() if names}
 
 
 def test_markdown_agents_register_and_construct_with_the_native_loader(tmp_path):
@@ -425,9 +485,9 @@ def test_file_agent_definitions_keep_bounded_tools_and_no_github_mutations(
 
 
 def test_advisor_research_precedes_assignment_without_idle_dispatch_priority():
-    instructions = (
-        REPO_ROOT / "system_instructions" / "ADVISOR.md"
-    ).read_text(encoding="utf-8")
+    instructions = (REPO_ROOT / "system_instructions" / "ADVISOR.md").read_text(
+        encoding="utf-8"
+    )
 
     assert "Assigning high-value work to idle students" not in instructions
     assert instructions.index("Research and synthesis needed") < instructions.index(
@@ -437,9 +497,9 @@ def test_advisor_research_precedes_assignment_without_idle_dispatch_priority():
 
 
 def test_harness_states_bounded_delegation_tree_contract():
-    instructions = (
-        REPO_ROOT / "system_instructions" / "SENPAI-HARNESS.md"
-    ).read_text(encoding="utf-8")
+    instructions = (REPO_ROOT / "system_instructions" / "SENPAI-HARNESS.md").read_text(
+        encoding="utf-8"
+    )
     normalized = " ".join(instructions.split())
 
     for required in (

--- a/tests/test_terminal_policy.py
+++ b/tests/test_terminal_policy.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from senpai_agent.hooks import terminal_policy
+from senpai_agent.hooks import supervised_job_policy, terminal_policy
 
 WORKSPACE = Path("/workspace")
 
@@ -108,7 +108,7 @@ def test_policy_denies_recognized_training_launches(command: str):
         "python train.py --help",
         "timeout 120 python train.py --help 2>&1 | grep epochs",
         "tail -n 50 training.log",
-        "for id in run-a run-b; do grep -n \"$id\" results.log; done",
+        'for id in run-a run-b; do grep -n "$id" results.log; done',
     ],
 )
 def test_policy_allows_bounded_training_inspection(command: str):
@@ -139,6 +139,50 @@ def test_help_flags_do_not_hide_training_arguments(command: str):
 )
 def test_policy_denies_foreground_polling(command: str):
     assert is_allowed(command) is False
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "python evaluate.py &",
+        "nohup python evaluate.py >/tmp/eval.log 2>&1 &",
+        "if true; then ./benchmark.sh & fi",
+    ],
+)
+def test_policy_denies_unsupervised_background_processes(command: str):
+    assert is_allowed(command) is False
+
+
+def test_background_syntax_in_literals_and_arithmetic_remains_allowed():
+    assert is_allowed("printf '%s' '&'") is True
+    assert is_allowed("echo $((flags & 1))") is True
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ("git", "push", "origin", "experiment"),
+        ("gh", "pr", "merge", "17"),
+        ("bash", "-lc", "curl -XPOST https://api.github.com/repos/acme/x"),
+        ("sh", "-c", "eval 'git push origin experiment'"),
+    ],
+)
+def test_supervised_job_policy_retains_git_and_github_guards(argv):
+    assert supervised_job_policy(argv, "student", WORKSPACE).allowed is False
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ("python", "train.py", "--epochs", "10"),
+        ("bash", "-lc", "python train.py >out 2>&1"),
+        ("python", "-c", 'print("git push origin experiment")'),
+        ("python", "script.py", ""),
+        ("sleep", "300"),
+    ],
+)
+def test_supervised_job_policy_allows_bounded_long_processes(argv):
+    assert supervised_job_policy(argv, "student", WORKSPACE).allowed is True
 
 
 def test_quoted_file_heredoc_treats_restricted_words_as_literal_data():
@@ -182,7 +226,7 @@ def test_commands_around_literal_heredocs_remain_subject_to_policy(command: str)
 def test_eval_cannot_hide_a_push_inside_a_nested_heredoc():
     command = (
         'eval "$(cat "$(echo x >/tmp/y; echo -)" <<\'EOF\'\n'
-        "git push origin experiment\nEOF\n)\""
+        'git push origin experiment\nEOF\n)"'
     )
 
     assert is_allowed(command) is False

--- a/tests/test_tools_persistence.py
+++ b/tests/test_tools_persistence.py
@@ -6,15 +6,18 @@ from openhands.sdk.event import ActionEvent, Event, ObservationEvent
 from openhands.sdk.io import InMemoryFileStore
 from openhands.sdk.llm import MessageToolCall
 
+from senpai_agent.github.tools import SubmitExperimentResultAction
 from senpai_agent.models import (
     AssignmentKey,
     ExperimentResult,
     MetricComparison,
     ResultStatus,
 )
-from senpai_agent.github.tools import SubmitExperimentResultAction
 from senpai_agent.tools import (
+    JobResultObservation,
+    JobSpec,
     MonitorTrainingAction,
+    RunJobAction,
     TrainingResultObservation,
 )
 from senpai_agent.training import TrainingState
@@ -98,6 +101,51 @@ def test_running_training_observation_survives_event_log_restore():
     assert isinstance(restored.observation, TrainingResultObservation)
     assert restored.observation.state is TrainingState.RUNNING
     assert restored.observation.exit_code is None
+
+
+def test_job_actions_and_observations_survive_event_log_restore():
+    action = RunJobAction(
+        spec=JobSpec(
+            argv=("python", "evaluate.py"),
+            cwd="/workspace",
+            timeout_seconds=600,
+        )
+    )
+    restored_action = round_trip(
+        ActionEvent(
+            thought=[],
+            action=action,
+            tool_name="run_job",
+            tool_call_id="job-action",
+            tool_call=MessageToolCall(
+                id="job-action",
+                name="run_job",
+                arguments=json.dumps(action.model_dump(mode="json")),
+                origin="completion",
+            ),
+            llm_response_id="job-response",
+        )
+    )
+    restored_observation = round_trip(
+        ObservationEvent(
+            tool_name="run_job",
+            tool_call_id="job-observation",
+            action_id="job-action",
+            observation=JobResultObservation(
+                job_id="job-17",
+                state=TrainingState.RUNNING,
+                elapsed_seconds=12.5,
+                log_path="/state/job-17.log",
+            ),
+        )
+    )
+
+    assert isinstance(restored_action, ActionEvent)
+    assert isinstance(restored_action.action, RunJobAction)
+    assert restored_action.action.spec.argv == ("python", "evaluate.py")
+    assert isinstance(restored_observation, ObservationEvent)
+    assert isinstance(restored_observation.observation, JobResultObservation)
+    assert restored_observation.observation.job_id == "job-17"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_tools_training.py
+++ b/tests/test_tools_training.py
@@ -4,16 +4,20 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from openhands.sdk.conversation import SecretRegistry
 from openhands.sdk.tool import Tool, resolve_tool
 
-from senpai_agent.monitor import MonitorStore
+from senpai_agent.monitor import MonitorStore, TrainingMonitorSpec
 from senpai_agent.tools import (
-    CancelTrainingAction,
-    CancelTrainingTool,
-    MonitorTrainingAction,
-    MonitorTrainingTool,
-    RunTrainingAction,
-    RunTrainingTool,
+    CancelJobAction,
+    CancelJobTool,
+    GetJobStatusAction,
+    GetJobStatusTool,
+    JobSpec,
+    MonitorJobAction,
+    MonitorJobTool,
+    RunJobAction,
+    RunJobTool,
     close_training_runtimes,
     register_senpai_tools,
 )
@@ -27,10 +31,20 @@ class StubTraining:
         self.launched: list[TrainingSpec] = []
         self.status_checks: list[str] = []
         self.cancelled: list[str] = []
+        self.environments: list[dict[str, str]] = []
+        self.redacted_values: list[tuple[str, ...]] = []
         self.closed = False
 
-    def run_training(self, spec: TrainingSpec) -> TrainingResult:
+    def run_training(
+        self,
+        spec: TrainingSpec,
+        *,
+        env=None,
+        redacted_values=(),
+    ) -> TrainingResult:
         self.launched.append(spec)
+        self.environments.append(dict(env or {}))
+        self.redacted_values.append(tuple(redacted_values))
         return self.result
 
     def get_training_status(self, training_id: str) -> TrainingResult:
@@ -63,13 +77,13 @@ def finished_result(tmp_path: Path) -> TrainingResult:
     )
 
 
-def test_run_training_registers_a_monitor_for_its_conversation(tmp_path: Path):
+def test_run_job_registers_a_monitor_for_its_conversation(tmp_path: Path):
     workspace = init_workspace(tmp_path)
     training = StubTraining(workspace, finished_result(tmp_path))
     monitors = MonitorStore(tmp_path / "monitors.sqlite3")
-    tool = RunTrainingTool.create(training, monitors)[0]
+    tool = RunJobTool.create(training, monitors)[0]
     conversation_id = uuid.uuid4()
-    spec = TrainingSpec(
+    spec = JobSpec(
         argv=("python", "train.py"),
         cwd=workspace,
         timeout_seconds=600,
@@ -77,12 +91,12 @@ def test_run_training_registers_a_monitor_for_its_conversation(tmp_path: Path):
 
     try:
         observation = tool.executor(
-            RunTrainingAction(spec=spec),
+            RunJobAction(spec=spec),
             SimpleNamespace(id=conversation_id),
         )
 
         assert training.launched == [spec]
-        assert observation.training_id == "training-17"
+        assert observation.job_id == "training-17"
         assert observation.wandb_run_ids == ("run-abc",)
         monitor = monitors.spec("training-17")
         assert monitor.conversation_id == conversation_id
@@ -92,43 +106,42 @@ def test_run_training_registers_a_monitor_for_its_conversation(tmp_path: Path):
         monitors.close()
 
 
-def test_run_training_requires_a_clean_worktree_before_starting(tmp_path: Path):
+def test_run_job_allows_advisor_watchers_while_workspace_is_dirty(tmp_path: Path):
     workspace = init_workspace(tmp_path)
     (workspace / "candidate.py").write_text("print('uncommitted')\n")
     training = StubTraining(workspace, finished_result(tmp_path))
     monitors = MonitorStore(tmp_path / "monitors.sqlite3")
-    tool = RunTrainingTool.create(training, monitors)[0]
+    tool = RunJobTool.create(training, monitors)[0]
 
     try:
-        with pytest.raises(RuntimeError, match="clean before training"):
-            tool.executor(
-                RunTrainingAction(
-                    spec=TrainingSpec(
-                        argv=("python", "candidate.py"),
-                        cwd=workspace,
-                        timeout_seconds=20,
-                    )
-                ),
-                SimpleNamespace(id=uuid.uuid4()),
-            )
+        spec = JobSpec(
+            argv=("python", "watch_receipt.py"),
+            cwd=workspace,
+            timeout_seconds=20,
+            workspace_access="read_only",
+        )
+        tool.executor(
+            RunJobAction(spec=spec),
+            SimpleNamespace(id=uuid.uuid4()),
+        )
 
-        assert training.launched == []
-        assert monitors.active() == []
+        assert training.launched == [spec]
+        assert len(monitors.active()) == 1
     finally:
         monitors.close()
 
 
-def test_run_training_requires_a_conversation_before_starting(tmp_path: Path):
+def test_run_job_requires_a_conversation_before_starting(tmp_path: Path):
     workspace = init_workspace(tmp_path)
     training = StubTraining(workspace, finished_result(tmp_path))
     monitors = MonitorStore(tmp_path / "monitors.sqlite3")
-    tool = RunTrainingTool.create(training, monitors)[0]
+    tool = RunJobTool.create(training, monitors)[0]
 
     try:
-        with pytest.raises(ValueError, match="student conversation"):
+        with pytest.raises(ValueError, match="parent conversation"):
             tool.executor(
-                RunTrainingAction(
-                    spec=TrainingSpec(
+                RunJobAction(
+                    spec=JobSpec(
                         argv=("python", "train.py"),
                         cwd=workspace,
                         timeout_seconds=20,
@@ -142,7 +155,167 @@ def test_run_training_requires_a_conversation_before_starting(tmp_path: Path):
         monitors.close()
 
 
-def test_monitor_training_validates_the_training_id_before_registration(
+def test_run_job_grants_only_requested_registry_secrets(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    workspace = init_workspace(tmp_path)
+    secret = "wandb-from-registry"
+    failed = finished_result(tmp_path).model_copy(
+        update={
+            "state": TrainingState.FAILED,
+            "exit_code": 1,
+            "error_tail": f"failed with {secret}",
+        }
+    )
+    training = StubTraining(workspace, failed)
+    monitors = MonitorStore(tmp_path / "monitors.sqlite3")
+    registry = SecretRegistry()
+    registry.update_secrets({"WANDB_API_KEY": secret})
+    conversation = SimpleNamespace(
+        id=uuid.uuid4(),
+        state=SimpleNamespace(secret_registry=registry),
+    )
+    monkeypatch.setenv("WANDB_API_KEY", "ambient-wandb")
+    monkeypatch.setenv("OPENAI_API_KEY", "model-secret")
+    monkeypatch.setenv("EXA_API_KEY", "exa-secret")
+    monkeypatch.setenv("GITHUB_TOKEN", "github-secret")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "aws-secret")
+    monkeypatch.setenv("CUSTOM_TOKEN", "custom-secret")
+    monkeypatch.setenv("password", "lowercase-secret")
+
+    try:
+        observation = RunJobTool.create(training, monitors)[0].executor(
+            RunJobAction(
+                spec=JobSpec(
+                    argv=("python", "evaluate.py"),
+                    cwd=workspace,
+                    timeout_seconds=20,
+                    secret_env=("WANDB_API_KEY",),
+                )
+            ),
+            conversation,
+        )
+
+        environment = training.environments[0]
+        assert environment["WANDB_API_KEY"] == secret
+        assert training.redacted_values == [(secret,)]
+        assert "PATH" in environment
+        assert {
+            "OPENAI_API_KEY",
+            "EXA_API_KEY",
+            "GITHUB_TOKEN",
+            "AWS_SESSION_TOKEN",
+            "CUSTOM_TOKEN",
+            "password",
+        }.isdisjoint(environment)
+        assert observation.error_tail == "failed with <secret-hidden>"
+    finally:
+        monitors.close()
+
+
+def test_run_job_registration_failure_cancels_only_the_new_job(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    workspace = init_workspace(tmp_path)
+    training = StubTraining(workspace, finished_result(tmp_path))
+    monitors = MonitorStore(tmp_path / "monitors.sqlite3")
+    other_id = "other-job"
+    monitors.register(
+        TrainingMonitorSpec(
+            training_id=other_id,
+            conversation_id=uuid.uuid4(),
+        )
+    )
+
+    def fail_registration(_spec):
+        raise OSError("database unavailable")
+
+    monkeypatch.setattr(monitors, "register", fail_registration)
+    try:
+        with pytest.raises(OSError, match="database unavailable"):
+            RunJobTool.create(training, monitors)[0].executor(
+                RunJobAction(
+                    spec=JobSpec(
+                        argv=("python", "evaluate.py"),
+                        cwd=workspace,
+                        timeout_seconds=20,
+                    )
+                ),
+                SimpleNamespace(id=uuid.uuid4()),
+            )
+
+        assert training.cancelled == ["training-17"]
+        assert monitors.spec(other_id).training_id == other_id
+    finally:
+        monitors.close()
+
+
+def test_run_job_preserves_registration_error_when_cleanup_also_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class FailingCleanupTraining(StubTraining):
+        def cancel_training(self, training_id: str) -> TrainingResult:
+            self.cancelled.append(training_id)
+            raise RuntimeError("cancel failed")
+
+    workspace = init_workspace(tmp_path)
+    training = FailingCleanupTraining(workspace, finished_result(tmp_path))
+    monitors = MonitorStore(tmp_path / "monitors.sqlite3")
+
+    def fail_registration(_spec):
+        raise OSError("registration failed")
+
+    monkeypatch.setattr(monitors, "register", fail_registration)
+    monkeypatch.setattr(
+        monitors,
+        "complete",
+        lambda _job_id: (_ for _ in ()).throw(RuntimeError("retire failed")),
+    )
+    try:
+        with pytest.raises(OSError, match="registration failed"):
+            RunJobTool.create(training, monitors)[0].executor(
+                RunJobAction(
+                    spec=JobSpec(
+                        argv=("python", "evaluate.py"),
+                        cwd=workspace,
+                        timeout_seconds=20,
+                    )
+                ),
+                SimpleNamespace(id=uuid.uuid4()),
+            )
+
+        assert training.cancelled == ["training-17"]
+    finally:
+        monitors.close()
+
+
+def test_student_mutable_job_requires_a_clean_checkout(tmp_path: Path):
+    workspace = init_workspace(tmp_path)
+    (workspace / "candidate.py").write_text("dirty\n")
+    training = StubTraining(workspace, finished_result(tmp_path))
+    monitors = MonitorStore(tmp_path / "monitors.sqlite3")
+
+    try:
+        with pytest.raises(RuntimeError, match="clean before run_job"):
+            RunJobTool.create(training, monitors, role="student")[0].executor(
+                RunJobAction(
+                    spec=JobSpec(
+                        argv=("python", "evaluate.py"),
+                        cwd=workspace,
+                        timeout_seconds=20,
+                    )
+                ),
+                SimpleNamespace(id=uuid.uuid4()),
+            )
+        assert training.launched == []
+    finally:
+        monitors.close()
+
+
+def test_monitor_job_validates_the_job_id_before_registration(
     tmp_path: Path,
 ):
     class MissingTraining(StubTraining):
@@ -153,33 +326,33 @@ def test_monitor_training_validates_the_training_id_before_registration(
     workspace = tmp_path / "workspace"
     training = MissingTraining(workspace, finished_result(tmp_path))
     monitors = MonitorStore(tmp_path / "monitors.sqlite3")
-    tool = MonitorTrainingTool.create(training, monitors)[0]
+    tool = MonitorJobTool.create(training, monitors)[0]
 
     try:
         with pytest.raises(KeyError, match="missing-training"):
             tool.executor(
-                MonitorTrainingAction(training_id="missing-training"),
+                MonitorJobAction(job_id="missing-training"),
                 SimpleNamespace(id=uuid.uuid4()),
             )
 
-        assert training.status_checks == ["missing-training"]
+        assert training.status_checks == []
         assert monitors.active() == []
     finally:
         monitors.close()
 
 
-def test_monitor_training_replaces_the_default_policy(tmp_path: Path):
+def test_monitor_job_replaces_the_default_policy(tmp_path: Path):
     workspace = init_workspace(tmp_path)
     training = StubTraining(workspace, finished_result(tmp_path))
     monitors = MonitorStore(tmp_path / "monitors.sqlite3")
     conversation_id = uuid.uuid4()
-    run_tool = RunTrainingTool.create(training, monitors)[0]
-    monitor_tool = MonitorTrainingTool.create(training, monitors)[0]
+    run_tool = RunJobTool.create(training, monitors)[0]
+    monitor_tool = MonitorJobTool.create(training, monitors)[0]
 
     try:
         run_tool.executor(
-            RunTrainingAction(
-                spec=TrainingSpec(
+            RunJobAction(
+                spec=JobSpec(
                     argv=("python", "train.py"),
                     cwd=workspace,
                     timeout_seconds=20,
@@ -187,18 +360,18 @@ def test_monitor_training_replaces_the_default_policy(tmp_path: Path):
             ),
             SimpleNamespace(id=conversation_id),
         )
-        action = MonitorTrainingAction(
-            training_id="training-17",
-            metric="validation/loss",
+        action = MonitorJobAction(
+            job_id="training-17",
+            wandb_metric="validation/loss",
             direction="min",
             stale_after_seconds=300,
         )
-        with pytest.raises(PermissionError, match="different student conversation"):
+        with pytest.raises(PermissionError, match="different conversation"):
             monitor_tool.executor(action, SimpleNamespace(id=uuid.uuid4()))
         monitor_tool.executor(action, SimpleNamespace(id=conversation_id))
 
         monitor = monitors.spec("training-17")
-        assert training.status_checks == ["training-17", "training-17"]
+        assert training.status_checks == ["training-17"]
         assert monitor.metric == "validation/loss"
         assert monitor.direction == "min"
         assert monitor.stale_after_seconds == 300
@@ -206,14 +379,49 @@ def test_monitor_training_replaces_the_default_policy(tmp_path: Path):
         monitors.close()
 
 
-def test_cancel_training_retires_its_monitor(tmp_path: Path):
+def test_get_job_status_is_scoped_to_the_owning_conversation(tmp_path: Path):
     workspace = init_workspace(tmp_path)
     training = StubTraining(workspace, finished_result(tmp_path))
     monitors = MonitorStore(tmp_path / "monitors.sqlite3")
     conversation_id = uuid.uuid4()
-    RunTrainingTool.create(training, monitors)[0].executor(
-        RunTrainingAction(
-            spec=TrainingSpec(
+    RunJobTool.create(training, monitors)[0].executor(
+        RunJobAction(
+            spec=JobSpec(
+                argv=("python", "evaluate.py"),
+                cwd=workspace,
+                timeout_seconds=20,
+            )
+        ),
+        SimpleNamespace(id=conversation_id),
+    )
+
+    try:
+        status = GetJobStatusTool.create(training, monitors)[0].executor
+        with pytest.raises(PermissionError, match="different conversation"):
+            status(
+                GetJobStatusAction(job_id="training-17"),
+                SimpleNamespace(id=uuid.uuid4()),
+            )
+
+        observation = status(
+            GetJobStatusAction(job_id="training-17"),
+            SimpleNamespace(id=conversation_id),
+        )
+
+        assert observation.job_id == "training-17"
+        assert observation.state is TrainingState.FINISHED
+    finally:
+        monitors.close()
+
+
+def test_cancel_job_retires_its_monitor(tmp_path: Path):
+    workspace = init_workspace(tmp_path)
+    training = StubTraining(workspace, finished_result(tmp_path))
+    monitors = MonitorStore(tmp_path / "monitors.sqlite3")
+    conversation_id = uuid.uuid4()
+    RunJobTool.create(training, monitors)[0].executor(
+        RunJobAction(
+            spec=JobSpec(
                 argv=("python", "train.py"),
                 cwd=workspace,
                 timeout_seconds=20,
@@ -223,15 +431,15 @@ def test_cancel_training_retires_its_monitor(tmp_path: Path):
     )
 
     try:
-        cancel = CancelTrainingTool.create(training, monitors)[0].executor
-        with pytest.raises(PermissionError, match="different student conversation"):
+        cancel = CancelJobTool.create(training, monitors)[0].executor
+        with pytest.raises(PermissionError, match="different conversation"):
             cancel(
-                CancelTrainingAction(training_id="training-17"),
+                CancelJobAction(job_id="training-17"),
                 SimpleNamespace(id=uuid.uuid4()),
             )
 
         observation = cancel(
-            CancelTrainingAction(training_id="training-17"),
+            CancelJobAction(job_id="training-17"),
             SimpleNamespace(id=conversation_id),
         )
 
@@ -242,7 +450,7 @@ def test_cancel_training_retires_its_monitor(tmp_path: Path):
         monitors.close()
 
 
-def test_cancel_training_keeps_monitor_when_cancellation_is_not_terminal(
+def test_cancel_job_keeps_monitor_when_cancellation_is_not_terminal(
     tmp_path: Path,
 ):
     class NonTerminalCancellation(StubTraining):
@@ -254,9 +462,9 @@ def test_cancel_training_keeps_monitor_when_cancellation_is_not_terminal(
     training = NonTerminalCancellation(workspace, finished_result(tmp_path))
     monitors = MonitorStore(tmp_path / "monitors.sqlite3")
     conversation_id = uuid.uuid4()
-    RunTrainingTool.create(training, monitors)[0].executor(
-        RunTrainingAction(
-            spec=TrainingSpec(
+    RunJobTool.create(training, monitors)[0].executor(
+        RunJobAction(
+            spec=JobSpec(
                 argv=("python", "train.py"),
                 cwd=workspace,
                 timeout_seconds=20,
@@ -266,38 +474,40 @@ def test_cancel_training_keeps_monitor_when_cancellation_is_not_terminal(
     )
 
     try:
-        cancel = CancelTrainingTool.create(training, monitors)[0].executor
+        cancel = CancelJobTool.create(training, monitors)[0].executor
 
         with pytest.raises(RuntimeError, match="did not reach a terminal state"):
             cancel(
-                CancelTrainingAction(training_id="training-17"),
+                CancelJobAction(job_id="training-17"),
                 SimpleNamespace(id=conversation_id),
             )
 
         assert training.cancelled == ["training-17"]
-        assert [monitor.training_id for monitor in monitors.active()] == [
-            "training-17"
-        ]
+        assert [monitor.training_id for monitor in monitors.active()] == ["training-17"]
     finally:
         monitors.close()
 
 
-def test_interrupting_run_training_closes_its_runtime(tmp_path: Path):
+def test_interrupting_run_job_does_not_close_its_shared_runtime(tmp_path: Path):
     training = StubTraining(tmp_path, finished_result(tmp_path))
     monitors = MonitorStore(tmp_path / "monitors.sqlite3")
 
     try:
-        RunTrainingTool.create(training, monitors)[0].executor.interrupt()
+        RunJobTool.create(training, monitors)[0].executor.interrupt()
 
-        assert training.closed is True
+        assert training.closed is False
     finally:
         monitors.close()
 
 
-def test_registered_training_tools_share_one_runtime(tmp_path: Path):
+def test_registered_job_tools_share_one_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     state = SimpleNamespace(workspace=SimpleNamespace(working_dir=workspace))
+    monkeypatch.setenv("SENPAI_ROLE", "advisor")
     register_senpai_tools()
 
     tools = resolve_tool(
@@ -308,26 +518,70 @@ def test_registered_training_tools_share_one_runtime(tmp_path: Path):
 
     try:
         assert set(by_name) == {
-            "cancel_training",
-            "run_training",
-            "get_training_status",
-            "monitor_training",
+            "cancel_job",
+            "run_job",
+            "get_job_status",
+            "monitor_job",
         }
+        assert "already-running job" in by_name["monitor_job"].description
+        assert "without disabling terminal wakes" in by_name["monitor_job"].description
+        assert "upgrade" not in by_name["monitor_job"].description.lower()
         assert (
-            by_name["run_training"].executor.training
-            is by_name["get_training_status"].executor.training
+            by_name["run_job"].executor.supervisor
+            is by_name["get_job_status"].executor.supervisor
         )
         assert (
-            by_name["run_training"].executor.training
-            is by_name["monitor_training"].executor.training
+            by_name["run_job"].executor.supervisor
+            is by_name["monitor_job"].executor.supervisor
         )
         assert (
-            by_name["run_training"].executor.training
-            is by_name["cancel_training"].executor.training
+            by_name["run_job"].executor.supervisor
+            is by_name["cancel_job"].executor.supervisor
         )
         assert (
-            by_name["run_training"].executor.monitor_store
-            is by_name["monitor_training"].executor.store
+            by_name["run_job"].executor.monitor_store
+            is by_name["monitor_job"].executor.store
         )
     finally:
         close_training_runtimes()
+
+
+@pytest.mark.parametrize("interval", [4, float("nan"), float("inf")])
+def test_monitor_job_requires_a_finite_interval_of_at_least_five_seconds(
+    interval: float,
+):
+    with pytest.raises(ValueError):
+        MonitorJobAction(job_id="job-17", poll_interval_seconds=interval)
+
+
+def test_job_control_tools_declare_one_serialized_runtime_resource(tmp_path: Path):
+    workspace = init_workspace(tmp_path)
+    training = StubTraining(workspace, finished_result(tmp_path))
+    monitors = MonitorStore(tmp_path / "monitors.sqlite3")
+    tools = (
+        RunJobTool.create(training, monitors)[0],
+        GetJobStatusTool.create(training, monitors)[0],
+        CancelJobTool.create(training, monitors)[0],
+        MonitorJobTool.create(training, monitors)[0],
+    )
+    actions = (
+        RunJobAction(
+            spec=JobSpec(
+                argv=("python", "evaluate.py"),
+                cwd=workspace,
+                timeout_seconds=20,
+            )
+        ),
+        GetJobStatusAction(job_id="job-17"),
+        CancelJobAction(job_id="job-17"),
+        MonitorJobAction(job_id="job-17"),
+    )
+
+    try:
+        resources = [
+            tool.declared_resources(action) for tool, action in zip(tools, actions)
+        ]
+        assert all(resource.keys == ("senpai-job-control",) for resource in resources)
+        assert all(resource.declared for resource in resources)
+    finally:
+        monitors.close()

--- a/tests/test_training_lifecycle.py
+++ b/tests/test_training_lifecycle.py
@@ -1,8 +1,7 @@
+import sys
 from pathlib import Path
 
 import pytest
-
-from senpai_agent.training import TrainingState, TrainingSupervisor
 from training_test_support import (
     assert_process_stopped,
     make_supervisor,
@@ -10,6 +9,8 @@ from training_test_support import (
     wait_for_path,
     wait_for_terminal,
 )
+
+from senpai_agent.training import TrainingSpec, TrainingState, TrainingSupervisor
 
 
 def test_finished_training_persists_its_result_and_log(tmp_path: Path):
@@ -118,6 +119,83 @@ def test_supervisor_close_cancels_active_training(tmp_path: Path):
     assert supervisor.get_training_status(running.training_id).state is (
         TrainingState.CANCELLED
     )
+
+
+def test_mutable_workspace_lease_is_exclusive_and_released_on_cancel(
+    tmp_path: Path,
+):
+    workspace, supervisor = make_supervisor(
+        tmp_path,
+        terminate_grace_seconds=0.1,
+    )
+    running = run_python(
+        supervisor,
+        workspace,
+        "import time; time.sleep(60)",
+        timeout_seconds=60,
+    )
+
+    with pytest.raises(RuntimeError, match="mutable workspace job"):
+        run_python(supervisor, workspace, "print('blocked')")
+
+    supervisor.cancel_training(running.training_id)
+    replacement = run_python(supervisor, workspace, "print('released')")
+    assert wait_for_terminal(supervisor, replacement.training_id).state is (
+        TrainingState.FINISHED
+    )
+
+
+def test_internal_monitor_failure_stops_process_and_releases_workspace_lease(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    workspace, supervisor = make_supervisor(
+        tmp_path,
+        terminate_grace_seconds=0.1,
+    )
+    running = run_python(
+        supervisor,
+        workspace,
+        "import time; time.sleep(60)",
+        timeout_seconds=60,
+    )
+
+    def fail_state_write(_result):
+        raise OSError("injected state write failure")
+
+    monkeypatch.setattr(supervisor, "_write_result", fail_state_write)
+    supervisor.close()
+
+    assert supervisor.active_mutable_job_ids() == ()
+    assert_process_stopped(running.pid)
+
+
+def test_failed_job_tail_redacts_secret_across_tail_boundary(tmp_path: Path):
+    workspace, supervisor = make_supervisor(tmp_path)
+    secret = "boundary-secret-value"
+    running = supervisor.run_training(
+        TrainingSpec(
+            argv=(
+                sys.executable,
+                "-c",
+                (
+                    "import sys; sys.stdout.write(sys.argv[1] + 'x' * 8190); "
+                    "raise SystemExit(1)"
+                ),
+                secret,
+            ),
+            cwd=workspace,
+            timeout_seconds=20,
+        ),
+        redacted_values=(secret,),
+    )
+
+    terminal = wait_for_terminal(supervisor, running.training_id)
+
+    assert terminal.state is TrainingState.FAILED
+    assert secret not in terminal.error_tail
+    assert "boundary-secret" not in terminal.error_tail
+    assert Path(terminal.log_path).stat().st_mode & 0o077 == 0
 
 
 def test_cancel_training_stops_one_run_and_is_idempotent(tmp_path: Path):


### PR DESCRIPTION
## Summary

- replace the model-facing training-only surface with generic `run_job`, `get_job_status`, `monitor_job`, and `cancel_job` tools for advisor and student roots
- automatically monitor terminal process state without model polling, with optional W&B metric gates and staleness wakes
- make process launch, monitor ownership, workspace reconciliation, cancellation, and recovery durable and failure-atomic
- remove the legacy `think` scratchpad while atomically migrating persisted conversations and preserving their event history
- keep `task_tracker` optional, concise, and explicitly safe for parallel work
- add a non-condensed advisor invariant so invented round labels or compacted summaries cannot end a live campaign

This is stacked on #3472 because the AWS/native deployments use that branch.

## Operational safety

- structured argv only; supervised commands retain terminal/GitHub policy checks
- one mutable workspace job at a time, while passive read-only watchers may coexist
- controller checkout events defer cleanly while a mutable job owns the worktree
- child environments scrub ambient credentials and grant only an explicitly requested registered W&B key
- logs are private; model-visible error tails are secret-redacted
- monitor polling is bounded, fair, thread-safe, deduplicated, and isolated per job/signal

## Verification

- `984 passed, 6 skipped, 23 subtests passed`
- `uv lock --check`
- shell syntax checks
- Ruff on every touched Python/test file
- `git diff --check`
- two independent read-only reviews; no remaining blockers
