### PR TITLE
Make OpenHands event delivery crash-idempotent

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ flowchart LR
 
 1. The advisor creates a falsifiable assignment with the exact required research-base SHA, baseline metrics, expected mechanism, implementation scope, and stopping rules.
 2. `create_assignment` creates the student branch and draft PR, embeds a typed assignment record, and applies the routing labels.
-3. The assigned student receives one OpenHands conversation for that assignment revision. New PR comments and reviews are injected into that conversation, including while a turn is active.
+3. The assigned student receives one OpenHands conversation for that assignment revision. New PR comments and reviews are queued durably even while a turn is active, then delivered in the next bounded turn.
 4. The student commits the exact implementation, launches supervised training, and records every referenced run in W&B.
 5. The student calls `submit_experiment_result`; the tool validates and publishes the branch before changing the PR to `status:review`.
 6. The advisor compares the evidence, then uses the corresponding operation-specific tool to merge a reproducible winner, close a useful negative result, request a new revision, or send non-revision feedback.
@@ -343,7 +343,7 @@ flowchart LR
     S --> WB
 ```
 
-There is no Senpai RPC service or cross-node database. GitHub PR labels, typed comments, reviews, and human-tagged Issues are the only advisor/student communication protocol; W&B is the shared experiment store. Role-local SQLite stores local event queues and deduplication plus training-monitor policies; it is never shared across nodes.
+There is no Senpai RPC service or cross-node database. GitHub PR labels, typed comments, reviews, and human-tagged Issues are the only advisor/student communication protocol; W&B is the shared experiment store. Role-local SQLite stores the ordered delivery inbox and its receipts plus training-monitor policies; it is never shared across nodes.
 
 Each role runs a small Python supervisor around the deterministic controller:
 
@@ -366,7 +366,8 @@ The controller owns cadence, durable events, conversation selection, verified Gi
 - A student uses one UUID per assignment revision; feedback, monitor events, and child-task results resume that exact conversation.
 - Still-actionable GitHub state is re-delivered on the configured reminder cadence, which defaults to at least ten minutes even when GitHub is polled more frequently. Immediate post-turn polls deliver changed state but not timed reminders, so a successful research-only turn cannot enter a no-sleep reminder loop. `research_base_changed` is keyed by assignment, revision, PR head, and the exact required/current base pair; each identity or base movement requires a new decision. Merge repeats the live-base check immediately before its mutation, while external base writers still require strict up-to-date branch protection or a merge queue for an atomic guarantee.
 - Each model request gets one bounded 15-minute attempt. Foreground terminal calls return control within ten minutes for explicit continuation, the whole turn retains its one-hour hard lease, and two consecutive failed turns exit to the supervisor for a clean worker restart. Restart backoff grows across failed workers to a five-minute ceiling; only a successfully acknowledged turn resets that streak, not process uptime or idle sleep.
-- Events injected into an active conversation are acknowledged only after that turn exits cleanly. A typed context-window or malformed-history failure gets one fresh model-visible branch under the same conversation UUID and original turn deadline; the raw trace and workspace remain intact. If that clean recovery also fails, the work stays unacknowledged and is retried after at least ten minutes rather than entering a restart loop.
+- Every controller prompt, GitHub event, monitor signal, and child result follows one durable `pending -> delivered -> processed` inbox. A provider failure resumes the already-delivered turn without resending it, and a crash after inference performs mailbox acknowledgement without another model call. New events wait behind an unresolved turn in the same conversation; normal drains are FIFO and bounded to 16 events or 64 KiB, while ready conversations take fair turns.
+- A typed context-window or malformed-history failure gets one fresh model-visible branch under the same conversation UUID and original turn deadline; the raw trace and workspace remain intact. The reset and its canonical recovery copy are durable across crashes. If that clean recovery also fails, the work stays unacknowledged and is retried after at least ten minutes rather than entering a restart loop.
 - On restart, an incomplete persisted tool action is rejected rather than replayed implicitly. A checked-out assignment branch that was deliberately rebased or extended locally is preserved and surfaced to its existing student conversation for explicit reconciliation.
 - The complete OpenHands event log remains locally searchable. Senpai does not prune conversation directories; operators own retention.
 - Student state may be ephemeral because the branch, PR, typed result, W&B runs, and Weave trace are the durable handoff.

--- a/senpai_agent/advisor.py
+++ b/senpai_agent/advisor.py
@@ -12,6 +12,8 @@ from typing import Protocol, Self
 from openhands.sdk.conversation import ConversationExecutionStatus, ConversationState
 from pydantic import BaseModel, ConfigDict, Field
 
+from senpai_agent.inbox import PersistentInbox
+
 
 class AdvisorEvent(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
@@ -28,6 +30,17 @@ class AdvisorEvent(BaseModel):
             f"# Senpai event: {self.kind}\n\n"
             f"Observed at (UTC): {observed_at}\n\n"
             f"```json\n{payload}\n```"
+        )
+
+    def to_inbox_message(self) -> str:
+        payload = {
+            key: value
+            for key, value in self.payload.items()
+            if key != "parent_conversation_id"
+        }
+        return (
+            f"## {self.kind}\n\n"
+            f"{json.dumps(payload, sort_keys=True, separators=(',', ':'))}"
         )
 
 
@@ -51,9 +64,20 @@ class AdvisorEventStore:
 
     def enqueue(self, event: AdvisorEvent) -> bool:
         with self._lock:
+            row = self._connection.execute(
+                "SELECT event_json FROM advisor_events WHERE dedupe_key = ?",
+                (event.dedupe_key,),
+            ).fetchone()
+            if row is not None:
+                existing = AdvisorEvent.model_validate_json(row[0])
+                if existing.kind != event.kind or existing.payload != event.payload:
+                    raise RuntimeError(
+                        f"event {event.dedupe_key!r} was reused with a different payload"
+                    )
+                return False
             cursor = self._connection.execute(
                 """
-                INSERT OR IGNORE INTO advisor_events (dedupe_key, event_json)
+                INSERT INTO advisor_events (dedupe_key, event_json)
                 VALUES (?, ?)
                 """,
                 (event.dedupe_key, event.model_dump_json()),
@@ -200,11 +224,22 @@ class AdvisorEventPump:
         *,
         poll_interval: float = 0.5,
         parent_conversation_id: str | None = None,
+        inbox: PersistentInbox | None = None,
+        conversation_id: str | uuid.UUID | None = None,
     ):
         self._store = store
         self._conversation = conversation
         self._poll_interval = poll_interval
         self._parent_conversation_id = parent_conversation_id
+        self._inbox = inbox
+        if inbox is not None:
+            if conversation_id is None:
+                raise ValueError("inbox event pump requires a conversation ID")
+            self._conversation_id = str(uuid.UUID(str(conversation_id)))
+        else:
+            self._conversation_id = str(
+                conversation_id or getattr(conversation, "id", "local")
+            )
         self._delivered_event_keys: set[str] = set()
         self._stop = threading.Event()
         self._error: BaseException | None = None
@@ -224,6 +259,8 @@ class AdvisorEventPump:
             self._stop.set()
 
     def _deliver_if_safe(self) -> int:
+        if self._inbox is not None:
+            return self._transfer_to_inbox()
         state = getattr(self._conversation, "state", None)
         if state is None:
             # Lightweight message adapters have no tool-action state to guard.
@@ -245,6 +282,24 @@ class AdvisorEventPump:
                 parent_conversation_id=self._parent_conversation_id,
             )
 
+    def _transfer_to_inbox(self) -> int:
+        pending = self._store.pending()
+        if self._parent_conversation_id is not None:
+            pending = [
+                event
+                for event in pending
+                if event.payload.get("parent_conversation_id")
+                == self._parent_conversation_id
+            ]
+        for event in pending:
+            self._inbox.enqueue(
+                self._conversation_id,
+                event.dedupe_key,
+                event.to_inbox_message(),
+            )
+            self._store.acknowledge(event.dedupe_key)
+        return len(pending)
+
     def __enter__(self) -> Self:
         self._thread.start()
         return self
@@ -258,7 +313,7 @@ class AdvisorEventPump:
         self._stop.set()
         self._thread.join()
         # Failed turns may abandon their active branch; replay those events instead.
-        if exc_type is None and self._error is None:
+        if self._inbox is None and exc_type is None and self._error is None:
             state = getattr(self._conversation, "state", None)
             if (
                 state is None

--- a/senpai_agent/controller.py
+++ b/senpai_agent/controller.py
@@ -24,6 +24,7 @@ from senpai_agent.advisor import (
     compose_system_instructions,
 )
 from senpai_agent.github.mailbox import ActiveGitHubWatcher, GitHubMailbox
+from senpai_agent.inbox import DeliveryState, InboxTurn, PersistentInbox
 from senpai_agent.mailbox import (
     CompositeMailbox,
     ControllerEvent,
@@ -87,6 +88,8 @@ class TurnRunner(Protocol):
         conversation_id: UUID,
         event_keys: frozenset[str],
         visible_event_keys: frozenset[str] = frozenset(),
+        inbox: PersistentInbox,
+        inbox_turn_id: str,
     ) -> TurnResult: ...
 
 
@@ -143,6 +146,8 @@ class OpenHandsTurnRunner:
         conversation_id: UUID,
         event_keys: frozenset[str],
         visible_event_keys: frozenset[str] = frozenset(),
+        inbox: PersistentInbox | None = None,
+        inbox_turn_id: str | None = None,
     ) -> TurnResult:
         from senpai_agent.openhands_runner import local_event_db_path, run_openhands
 
@@ -151,10 +156,20 @@ class OpenHandsTurnRunner:
             conversation_id=conversation_id,
         )
         turn_deadline = time.monotonic() + config.timeout_seconds
+        if (inbox is None) != (inbox_turn_id is None):
+            raise ValueError("inbox and inbox turn ID must be provided together")
+
+        def inbox_options() -> dict[str, object]:
+            if inbox is None or inbox_turn_id is None:
+                return {}
+            return {
+                "inbox": inbox,
+                "inbox_turn_id": inbox_turn_id,
+            }
 
         def run_turn() -> int:
             try:
-                return run_openhands(prompt, config)
+                return run_openhands(prompt, config, **inbox_options())
             except Exception as error:
                 if not _is_context_history_failure(error):
                     raise
@@ -183,6 +198,7 @@ class OpenHandsTurnRunner:
                         _context_recovery_prompt(self.full_prompt, prompt),
                         recovery_config,
                         reset_context=True,
+                        **inbox_options(),
                     )
                 except Exception as recovery_error:
                     if _is_context_history_failure(recovery_error):
@@ -266,6 +282,7 @@ class Controller:
         full_prompt: str,
         system_context: str = "",
         conversation_state: ConversationStateLedger | None = None,
+        inbox: PersistentInbox | None = None,
         workspace_divergence_state: WorkspaceDivergenceLedger | None = None,
         conversation_for_events: (
             Callable[[Sequence[ControllerEvent]], Sequence[ConversationBatch]] | None
@@ -308,6 +325,7 @@ class Controller:
         self.full_prompt = full_prompt.strip()
         self.system_context = system_context.strip()
         self.conversation_state = conversation_state
+        self.inbox = inbox or PersistentInbox()
         self.workspace_divergence_state = workspace_divergence_state
         self.sleep = sleep
         self.poll_interval_seconds = poll_interval_seconds
@@ -320,151 +338,82 @@ class Controller:
         if self.event_reminder_seconds <= 0:
             raise ValueError("event reminder interval must be positive")
         self._started: set[UUID] = set()
-        self._visible: dict[str, float] = {}
+        resumed_at = time.monotonic()
+        self._visible: dict[str, float] = {
+            key: resumed_at for key in self.inbox.acknowledged_event_keys()
+        }
         self._deferred_until: dict[str, float] = {}
+        self._deferred_conversations: dict[UUID, float] = {}
         self._workspace_divergence: dict[UUID, str] = {}
 
     def run(self, *, max_cycles: int | None = None) -> None:
         self._wait_for_start_gates()
         cycles = 0
-        turn_failures = 0
+        turn_failures: dict[UUID, int] = {}
         while max_cycles is None or cycles < max_cycles:
-            self._publish_progress("poll")
-            events = self._new_events(self.mailbox.poll())
-            turn_failed = False
-            while events:
-                batches = self._event_batches(events)
-                events = ()
-                for batch in batches:
-                    batch_events = batch.events
-                    conversation_id = batch.conversation_id
-                    workspace_divergence: WorkspaceDivergence | None = None
-                    try:
-                        if self.reconcile is not None:
-                            self._publish_progress("reconcile")
-                            try:
-                                self.reconcile(batch_events)
-                            except WorkspaceDivergence as conflict:
-                                workspace_divergence = conflict
-                                print(
-                                    f"SENPAI_WORKSPACE_DIVERGENCE {conflict}",
-                                    file=sys.stderr,
-                                    flush=True,
-                                )
-                                if (
-                                    self._workspace_divergence_key(conversation_id)
-                                    == conflict.event.dedupe_key
-                                ):
-                                    batch_events = tuple(
-                                        event
-                                        for event in batch_events
-                                        if event.kind != "student_assignment"
-                                    )
-                                    if not batch_events:
-                                        print(
-                                            "SENPAI_WORKSPACE_DIVERGENCE_SUPPRESSED "
-                                            f"conversation_id={conversation_id} "
-                                            f"event_key={conflict.event.dedupe_key}",
-                                            file=sys.stderr,
-                                            flush=True,
-                                        )
-                                        continue
-                                batch_events = (*batch_events, conflict.event)
-                            else:
-                                if any(
-                                    event.kind == "student_assignment"
-                                    for event in batch_events
-                                ):
-                                    self._clear_workspace_divergence(conversation_id)
-                        continuing = self._has_started(conversation_id)
-                        refresh_system_context = (
-                            continuing
-                            and self.conversation_state is not None
-                            and not self.conversation_state.is_context_current(
-                                conversation_id,
-                                self.system_context,
-                            )
-                        )
-                        prompt = self._prompt(
-                            batch_events,
-                            continuing=continuing,
-                            refresh_system_context=refresh_system_context,
-                        )
-                        self._publish_progress(
-                            "openhands-turn",
-                            self.turn_timeout_seconds,
-                        )
-                        batch_event_keys = frozenset(
-                            event.dedupe_key for event in batch_events
-                        )
-                        result = self.turns.run(
-                            prompt,
-                            conversation_id=conversation_id,
-                            event_keys=batch_event_keys,
-                            visible_event_keys=(
-                                frozenset(self._visible) | batch_event_keys
-                            ),
-                        )
-                    except ConversationRecoveryExhausted as error:
-                        retry_delay = max(self.poll_interval_seconds, 600)
-                        retry_at = time.monotonic() + retry_delay
-                        deferred_keys = tuple(
-                            event.dedupe_key for event in batch_events
-                        )
-                        for key in deferred_keys:
-                            self._visible.pop(key, None)
-                            self._deferred_until[key] = retry_at
-                        print(
-                            "SENPAI_TURN_DEFERRED "
-                            f"conversation_id={conversation_id} "
-                            f"event_keys={','.join(deferred_keys)} "
-                            f"retry_after_seconds={retry_delay:g} "
-                            f"error={error}",
-                            file=sys.stderr,
-                            flush=True,
-                        )
-                        continue
-                    except Exception as error:  # noqa: BLE001
-                        turn_failures += 1
-                        for event in batch_events:
-                            self._visible.pop(event.dedupe_key, None)
-                        print(
-                            f"SENPAI_TURN_EXCEPTION {type(error).__name__}: {error}",
-                            file=sys.stderr,
-                            flush=True,
-                        )
-                        if turn_failures >= self.max_consecutive_turn_failures:
-                            raise RuntimeError(
-                                "controller exceeded its consecutive turn-failure "
-                                f"limit ({self.max_consecutive_turn_failures})"
-                            ) from error
-                        turn_failed = True
-                        continue
-                    if result.exit_code == 0:
-                        self._mark_success(conversation_id)
-                        acknowledged = (
-                            *(event.dedupe_key for event in batch_events),
-                            *sorted(result.delivered_event_keys),
-                        )
-                        self.mailbox.acknowledge(
-                            tuple(dict.fromkeys(acknowledged))
-                        )
-                        if workspace_divergence is not None:
-                            self._record_workspace_divergence(
-                                conversation_id,
-                                workspace_divergence.event.dedupe_key,
-                            )
-                        self._publish_progress(
-                            "turn-complete",
-                            completed_turn=True,
-                        )
-                        delivered_at = time.monotonic()
-                        for key in acknowledged:
-                            self._visible[key] = delivered_at
-                        continue
-                    turn_failures += 1
-                    for event in batch_events:
-                        self._visible.pop(event.dedupe_key, None)
+            self._acknowledge_processed_turns()
+            self._poll_into_inbox()
+            cycle_had_failure = False
+            failed_conversations: set[UUID] = set()
+            served_conversations: set[UUID] = set()
+            while True:
+                turn = self._next_ready_turn(
+                    failed_conversations | served_conversations
+                )
+                if turn is None and served_conversations:
+                    served_conversations.clear()
+                    turn = self._next_ready_turn(failed_conversations)
+                if turn is None:
+                    break
+                conversation_id = UUID(turn.conversation_id)
+                try:
+                    self._publish_progress(
+                        "openhands-turn",
+                        self.turn_timeout_seconds,
+                    )
+                    result = self.turns.run(
+                        turn.prompt.body,
+                        conversation_id=conversation_id,
+                        event_keys=frozenset(turn.event_keys),
+                        visible_event_keys=(
+                            frozenset(self._visible) | frozenset(turn.event_keys)
+                        ),
+                        inbox=self.inbox,
+                        inbox_turn_id=turn.turn_id,
+                    )
+                except ConversationRecoveryExhausted as error:
+                    retry_delay = max(self.poll_interval_seconds, 600)
+                    retry_at = time.monotonic() + retry_delay
+                    self._deferred_conversations[conversation_id] = retry_at
+                    print(
+                        "SENPAI_TURN_DEFERRED "
+                        f"conversation_id={conversation_id} "
+                        f"event_keys={','.join(turn.event_keys)} "
+                        f"retry_after_seconds={retry_delay:g} "
+                        f"error={error}",
+                        file=sys.stderr,
+                        flush=True,
+                    )
+                    continue
+                except Exception as error:  # noqa: BLE001
+                    failures = turn_failures.get(conversation_id, 0) + 1
+                    turn_failures[conversation_id] = failures
+                    print(
+                        f"SENPAI_TURN_EXCEPTION {type(error).__name__}: {error}",
+                        file=sys.stderr,
+                        flush=True,
+                    )
+                    if failures >= self.max_consecutive_turn_failures:
+                        raise RuntimeError(
+                            "controller exceeded its consecutive turn-failure "
+                            f"limit ({self.max_consecutive_turn_failures})"
+                        ) from error
+                    failed_conversations.add(conversation_id)
+                    cycle_had_failure = True
+                    continue
+                if result.exit_code != 0:
+                    failures = turn_failures.get(conversation_id, 0) + 1
+                    turn_failures[conversation_id] = failures
                     print(
                         "SENPAI_TURN_ERROR "
                         f"exit_code={result.exit_code} "
@@ -472,44 +421,182 @@ class Controller:
                         file=sys.stderr,
                         flush=True,
                     )
-                    if turn_failures >= self.max_consecutive_turn_failures:
+                    if failures >= self.max_consecutive_turn_failures:
                         raise RuntimeError(
                             "controller exceeded its consecutive turn-failure "
                             f"limit ({self.max_consecutive_turn_failures})"
                         )
-                    turn_failed = True
-                if turn_failed:
-                    delay = min(
-                        self.poll_interval_seconds,
-                        2 ** min(turn_failures, 8),
-                    )
-                    self._sleep("turn-backoff", delay)
-                    break
-                turn_failures = 0
-                # Post-turn reconciliation avoids waiting one heartbeat for work
-                # that appeared while OpenHands was reasoning.
-                try:
-                    self._publish_progress("poll")
-                    events = self._new_events(
-                        self.mailbox.poll(),
-                        allow_reminders=False,
-                    )
-                except Exception as error:  # noqa: BLE001
-                    print(
-                        f"SENPAI_POST_TURN_POLL_ERROR {type(error).__name__}: {error}",
-                        file=sys.stderr,
-                        flush=True,
-                    )
-                    events = ()
+                    failed_conversations.add(conversation_id)
+                    cycle_had_failure = True
+                    continue
+
+                self._assert_processed(turn.turn_id)
+                self._acknowledge_processed_turns()
+                turn_failures.pop(conversation_id, None)
+                served_conversations.add(conversation_id)
+                self._poll_into_inbox(allow_reminders=False)
             cycles += 1
             if max_cycles is not None and cycles >= max_cycles:
                 return
-            if turn_failed:
+            if cycle_had_failure:
+                longest_streak = max(
+                    (turn_failures[value] for value in failed_conversations),
+                    default=1,
+                )
+                delay = min(
+                    self.poll_interval_seconds,
+                    2 ** min(longest_streak, 8),
+                )
+                self._sleep("turn-backoff", delay)
                 continue
             self._sleep(
                 "sleep",
                 self.poll_interval_seconds + random.uniform(0, self.jitter_seconds),
             )
+
+    def _poll_into_inbox(self, *, allow_reminders: bool = True) -> None:
+        self._publish_progress("poll")
+        try:
+            polled = self.mailbox.poll()
+        except Exception as error:  # noqa: BLE001
+            if allow_reminders:
+                raise
+            print(
+                f"SENPAI_POST_TURN_POLL_ERROR {type(error).__name__}: {error}",
+                file=sys.stderr,
+                flush=True,
+            )
+            return
+        events = self._new_events(
+            polled,
+            allow_reminders=allow_reminders,
+        )
+        self._enqueue_events(events)
+
+    def _enqueue_events(self, events: Sequence[ControllerEvent]) -> None:
+        for batch in self._event_batches(events):
+            batch_events = batch.events
+            conversation_id = batch.conversation_id
+            if self.reconcile is not None:
+                self._publish_progress("reconcile")
+                try:
+                    self.reconcile(batch_events)
+                except WorkspaceDivergence as conflict:
+                    print(
+                        f"SENPAI_WORKSPACE_DIVERGENCE {conflict}",
+                        file=sys.stderr,
+                        flush=True,
+                    )
+                    if (
+                        self._workspace_divergence_key(conversation_id)
+                        == conflict.event.dedupe_key
+                    ):
+                        batch_events = tuple(
+                            event
+                            for event in batch_events
+                            if event.kind != "student_assignment"
+                        )
+                        if not batch_events:
+                            print(
+                                "SENPAI_WORKSPACE_DIVERGENCE_SUPPRESSED "
+                                f"conversation_id={conversation_id} "
+                                f"event_key={conflict.event.dedupe_key}",
+                                file=sys.stderr,
+                                flush=True,
+                            )
+                            continue
+                    batch_events = (*batch_events, conflict.event)
+                else:
+                    if any(
+                        event.kind == "student_assignment" for event in batch_events
+                    ):
+                        self._clear_workspace_divergence(conversation_id)
+            for event in batch_events:
+                self.inbox.enqueue(
+                    conversation_id,
+                    event.dedupe_key,
+                    event.to_prompt(),
+                )
+
+    def _next_ready_turn(
+        self,
+        excluded: set[UUID] | frozenset[UUID] = frozenset(),
+    ) -> InboxTurn | None:
+        now = time.monotonic()
+        self._deferred_conversations = {
+            conversation_id: retry_at
+            for conversation_id, retry_at in self._deferred_conversations.items()
+            if now < retry_at
+        }
+        for value in self.inbox.ready_conversation_ids():
+            conversation_id = UUID(value)
+            if (
+                conversation_id in excluded
+                or conversation_id in self._deferred_conversations
+            ):
+                continue
+            continuing = self._has_started(conversation_id)
+            refresh_system_context = (
+                continuing
+                and self.conversation_state is not None
+                and not self.conversation_state.is_context_current(
+                    conversation_id,
+                    self.system_context,
+                )
+            )
+            turn = self.inbox.next_turn(
+                conversation_id,
+                self._prompt(
+                    (),
+                    continuing=continuing,
+                    refresh_system_context=refresh_system_context,
+                ),
+                legacy_prompt_identity=(
+                    f"initial:{self.full_prompt}"
+                    if not continuing
+                    else (
+                        f"system-context:{self.system_context}"
+                        if refresh_system_context
+                        else None
+                    )
+                ),
+            )
+            if turn is not None:
+                return turn
+        return None
+
+    def _assert_processed(self, turn_id: str) -> None:
+        turn = self.inbox.turn(turn_id)
+        if turn.superseded_by is not None:
+            turn = self.inbox.turn(turn.superseded_by)
+        if turn.state is not DeliveryState.PROCESSED:
+            raise RuntimeError(
+                "turn runner returned success without a processed inbox receipt: "
+                f"{turn.turn_id}"
+            )
+
+    def _acknowledge_processed_turns(self) -> None:
+        for turn in self.inbox.processed_turns():
+            keys = tuple(dict.fromkeys(turn.acknowledgement_keys))
+            if keys:
+                self._publish_progress("acknowledge")
+                self.mailbox.acknowledge(keys)
+            conversation_id = UUID(turn.conversation_id)
+            self._mark_success(conversation_id)
+            divergence = next(
+                (
+                    key
+                    for key in turn.event_keys
+                    if key.startswith("workspace_diverged:")
+                ),
+                None,
+            )
+            if divergence is not None:
+                self._record_workspace_divergence(conversation_id, divergence)
+            self.inbox.acknowledge(turn.turn_id)
+            for key in turn.event_keys:
+                self._visible[key] = time.monotonic()
+            self._publish_progress("turn-complete", completed_turn=True)
 
     def _event_batches(
         self,
@@ -617,22 +704,21 @@ class Controller:
 
     def _prompt(
         self,
-        events: Sequence[ControllerEvent],
+        _events: Sequence[ControllerEvent],
         *,
         continuing: bool,
         refresh_system_context: bool = False,
     ) -> str:
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-        event_prompt = "\n\n".join(event.to_prompt() for event in events)
         if not continuing:
             return (
                 f"{self.full_prompt}\n\nCurrent time (UTC): {now}\n\n"
-                f"# Current GitHub state\n\n{event_prompt}"
+                "# Current GitHub state\n\n"
+                "Actionable events follow as separately tracked messages."
             )
         prompt = (
             f"Continue the {self.role} loop. Current time (UTC): {now}. "
-            "GitHub now contains the following actionable state:\n\n"
-            f"{event_prompt}"
+            "Actionable GitHub events follow as separately tracked messages."
         )
         if refresh_system_context:
             prompt += (
@@ -804,6 +890,10 @@ def controller_main(
         f"{system_context.strip()}\n\n"
         f"# Current research brief\n\n{full_prompt}"
     )
+    inbox = PersistentInbox(
+        runner_config.state_dir / "delivery-inbox.sqlite3",
+        legacy_path=runner_config.state_dir / "pending-message-deliveries.json",
+    )
     turns = OpenHandsTurnRunner(
         runner_config,
         full_prompt=full_prompt,
@@ -821,6 +911,7 @@ def controller_main(
         conversation_state=ConversationStateLedger(
             runner_config.state_dir / "conversation-state.json"
         ),
+        inbox=inbox,
         workspace_divergence_state=(
             WorkspaceDivergenceLedger(
                 runner_config.state_dir / "workspace-divergence.json"
@@ -883,6 +974,7 @@ def controller_main(
     finally:
         for signum, handler in previous_handlers.items():
             signal.signal(signum, handler)
+        inbox.close()
         close_training_runtimes()
         finish_weave_monitoring()
     return 0

--- a/senpai_agent/inbox.py
+++ b/senpai_agent/inbox.py
@@ -1,0 +1,1174 @@
+"""Durable exactly-once delivery between Senpai and OpenHands."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import threading
+import uuid
+from collections.abc import Sequence
+from contextlib import nullcontext
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from types import TracebackType
+from typing import Self
+from uuid import UUID
+
+
+MAX_EVENTS_PER_TURN = 16
+MAX_EVENT_BYTES_PER_TURN = 64 * 1024
+_SENDER_PREFIX = "senpai-delivery:"
+
+
+class DeliveryState(StrEnum):
+    PENDING = "pending"
+    DELIVERED = "delivered"
+    PROCESSED = "processed"
+
+
+@dataclass(frozen=True, slots=True)
+class InboxMessage:
+    delivery_id: str
+    sender: str
+    body: str
+    state: DeliveryState
+    event_key: str | None
+    requires_ack: bool
+
+
+@dataclass(frozen=True, slots=True)
+class InboxTurn:
+    turn_id: str
+    conversation_id: str
+    state: DeliveryState
+    messages: tuple[InboxMessage, ...]
+    superseded_by: str | None = None
+    recovery_of: str | None = None
+    legacy_prompt_delivery_id: str | None = None
+    context_reset_completed: bool = True
+    acknowledged: bool = False
+
+    @property
+    def context_reset_required(self) -> bool:
+        return self.recovery_of is not None and not self.context_reset_completed
+
+    @property
+    def prompt(self) -> InboxMessage:
+        return self.messages[0]
+
+    @property
+    def events(self) -> tuple[InboxMessage, ...]:
+        return self.messages[1:]
+
+    @property
+    def event_keys(self) -> tuple[str, ...]:
+        return tuple(
+            message.event_key
+            for message in self.events
+            if message.event_key is not None
+        )
+
+    @property
+    def acknowledgement_keys(self) -> tuple[str, ...]:
+        return tuple(
+            message.event_key
+            for message in self.events
+            if message.event_key is not None and message.requires_ack
+        )
+
+
+class PersistentInbox:
+    """Persist event order, turn membership, and monotonic delivery receipts."""
+
+    def __init__(
+        self,
+        path: Path | None = None,
+        *,
+        legacy_path: Path | None = None,
+    ):
+        self.path = path
+        if path is not None:
+            path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.RLock()
+        self._connection = sqlite3.connect(
+            str(path) if path is not None else ":memory:",
+            check_same_thread=False,
+        )
+        self._connection.row_factory = sqlite3.Row
+        self._connection.execute("PRAGMA journal_mode=WAL")
+        self._connection.execute("PRAGMA busy_timeout=5000")
+        self._connection.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS inbox_turns (
+                turn_id TEXT PRIMARY KEY,
+                conversation_id TEXT NOT NULL,
+                state TEXT NOT NULL CHECK (
+                    state IN ('pending', 'delivered', 'processed')
+                ),
+                recovery_of TEXT,
+                superseded_by TEXT,
+                legacy_prompt_delivery_id TEXT,
+                context_reset_completed INTEGER NOT NULL DEFAULT 1,
+                acknowledged INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                processed_at TEXT,
+                acknowledged_at TEXT
+            );
+
+            CREATE TABLE IF NOT EXISTS inbox_messages (
+                sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+                conversation_id TEXT NOT NULL,
+                event_key TEXT,
+                body TEXT NOT NULL,
+                body_sha256 TEXT NOT NULL,
+                delivery_id TEXT NOT NULL UNIQUE,
+                sender TEXT NOT NULL UNIQUE,
+                state TEXT NOT NULL CHECK (
+                    state IN ('pending', 'delivered', 'processed')
+                ),
+                requires_ack INTEGER NOT NULL,
+                legacy INTEGER NOT NULL DEFAULT 0,
+                turn_id TEXT,
+                position INTEGER,
+                FOREIGN KEY (turn_id) REFERENCES inbox_turns(turn_id)
+            );
+
+            CREATE INDEX IF NOT EXISTS inbox_pending_by_conversation
+            ON inbox_messages(conversation_id, state, turn_id, sequence);
+
+            CREATE INDEX IF NOT EXISTS inbox_turns_by_conversation
+            ON inbox_turns(conversation_id, acknowledged, superseded_by, created_at);
+
+            CREATE TABLE IF NOT EXISTS legacy_deliveries (
+                conversation_id TEXT NOT NULL,
+                event_key TEXT NOT NULL,
+                delivery_id TEXT NOT NULL UNIQUE,
+                claimed INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (conversation_id, event_key)
+            );
+            """
+        )
+        turn_columns = {
+            str(row[1])
+            for row in self._connection.execute("PRAGMA table_info(inbox_turns)")
+        }
+        if "legacy_prompt_delivery_id" not in turn_columns:
+            self._connection.execute(
+                "ALTER TABLE inbox_turns ADD COLUMN legacy_prompt_delivery_id TEXT"
+            )
+        if "context_reset_completed" not in turn_columns:
+            self._connection.execute(
+                """
+                ALTER TABLE inbox_turns
+                ADD COLUMN context_reset_completed INTEGER NOT NULL DEFAULT 1
+                """
+            )
+            self._connection.execute(
+                """
+                UPDATE inbox_turns
+                SET context_reset_completed = 0
+                WHERE recovery_of IS NOT NULL AND state != 'processed'
+                """
+            )
+        message_columns = {
+            str(row[1])
+            for row in self._connection.execute("PRAGMA table_info(inbox_messages)")
+        }
+        if "legacy" not in message_columns:
+            self._connection.execute(
+                """
+                ALTER TABLE inbox_messages
+                ADD COLUMN legacy INTEGER NOT NULL DEFAULT 0
+                """
+            )
+        if legacy_path is not None and legacy_path.is_file():
+            self._import_legacy_deliveries(legacy_path)
+        self._connection.commit()
+
+    def enqueue(
+        self,
+        conversation_id: UUID | str,
+        event_key: str,
+        body: str,
+        *,
+        requires_ack: bool = True,
+    ) -> bool:
+        if not event_key:
+            raise ValueError("event key must not be empty")
+        if not body:
+            raise ValueError("event body must not be empty")
+        conversation = str(conversation_id)
+        with self._transaction() as database:
+            existing = database.execute(
+                """
+                SELECT message.sequence, message.body, message.requires_ack
+                FROM inbox_messages AS message
+                LEFT JOIN inbox_turns AS turn ON turn.turn_id = message.turn_id
+                WHERE message.conversation_id = ?
+                  AND message.event_key = ?
+                  AND (
+                      message.turn_id IS NULL
+                      OR (
+                          turn.acknowledged = 0
+                          AND turn.superseded_by IS NULL
+                      )
+                  )
+                ORDER BY message.sequence DESC
+                LIMIT 1
+                """,
+                (conversation, event_key),
+            ).fetchone()
+            if existing is not None:
+                if existing["body"] != body:
+                    raise RuntimeError(
+                        f"event {event_key!r} was reused with a different payload"
+                    )
+                if requires_ack and not existing["requires_ack"]:
+                    database.execute(
+                        "UPDATE inbox_messages SET requires_ack = 1 WHERE sequence = ?",
+                        (existing["sequence"],),
+                    )
+                return False
+            legacy = database.execute(
+                """
+                SELECT delivery_id
+                FROM legacy_deliveries
+                WHERE conversation_id = ? AND event_key = ? AND claimed = 0
+                """,
+                (conversation, event_key),
+            ).fetchone()
+            delivery_id = (
+                str(legacy["delivery_id"])
+                if legacy is not None
+                else str(uuid.uuid4())
+            )
+            database.execute(
+                """
+                INSERT INTO inbox_messages (
+                    conversation_id,
+                    event_key,
+                    body,
+                    body_sha256,
+                    delivery_id,
+                    sender,
+                    state,
+                    requires_ack,
+                    legacy
+                ) VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, ?)
+                """,
+                (
+                    conversation,
+                    event_key,
+                    body,
+                    _digest(body),
+                    delivery_id,
+                    _sender(delivery_id),
+                    int(requires_ack),
+                    int(legacy is not None),
+                ),
+            )
+            if legacy is not None:
+                database.execute(
+                    """
+                    UPDATE legacy_deliveries
+                    SET claimed = 1
+                    WHERE conversation_id = ? AND event_key = ?
+                    """,
+                    (conversation, event_key),
+                )
+            return True
+
+    def next_turn(
+        self,
+        conversation_id: UUID | str,
+        prompt: str,
+        *,
+        max_events: int = MAX_EVENTS_PER_TURN,
+        max_bytes: int = MAX_EVENT_BYTES_PER_TURN,
+        legacy_prompt_identity: str | None = None,
+    ) -> InboxTurn | None:
+        if not prompt:
+            raise ValueError("turn prompt must not be empty")
+        if max_events <= 0 or max_bytes <= 0:
+            raise ValueError("turn limits must be positive")
+        conversation = str(conversation_id)
+        with self._transaction() as database:
+            active = database.execute(
+                """
+                SELECT turn_id
+                FROM inbox_turns
+                WHERE conversation_id = ?
+                  AND acknowledged = 0
+                  AND superseded_by IS NULL
+                  AND state != 'processed'
+                ORDER BY rowid
+                LIMIT 1
+                """,
+                (conversation,),
+            ).fetchone()
+            if active is not None:
+                return self._turn(database, active["turn_id"])
+
+            waiting_for_ack = database.execute(
+                """
+                SELECT 1
+                FROM inbox_turns
+                WHERE conversation_id = ?
+                  AND acknowledged = 0
+                  AND superseded_by IS NULL
+                  AND state = 'processed'
+                LIMIT 1
+                """,
+                (conversation,),
+            ).fetchone()
+            if waiting_for_ack is not None:
+                return None
+
+            pending = database.execute(
+                """
+                SELECT sequence, body, delivery_id, legacy
+                FROM inbox_messages
+                WHERE conversation_id = ?
+                  AND state = 'pending'
+                  AND turn_id IS NULL
+                ORDER BY legacy DESC, sequence
+                """,
+                (conversation,),
+            ).fetchall()
+            selected: list[sqlite3.Row] = []
+            selected_bytes = 0
+            legacy_batch = bool(pending and pending[0]["legacy"])
+            for row in pending:
+                if bool(row["legacy"]) != legacy_batch:
+                    break
+                size = len(row["body"].encode("utf-8"))
+                if selected and (
+                    len(selected) >= max_events or selected_bytes + size > max_bytes
+                ):
+                    break
+                selected.append(row)
+                selected_bytes += size
+                if len(selected) >= max_events:
+                    break
+            if not selected:
+                return None
+
+            turn_id = str(uuid.uuid4())
+            legacy_prompt_delivery_id = (
+                _legacy_prompt_delivery_id(
+                    tuple(
+                        str(row["delivery_id"])
+                        for row in pending
+                        if bool(row["legacy"])
+                    ),
+                    identity=legacy_prompt_identity,
+                )
+                if legacy_batch
+                else None
+            )
+            database.execute(
+                """
+                INSERT INTO inbox_turns (
+                    turn_id,
+                    conversation_id,
+                    state,
+                    legacy_prompt_delivery_id
+                ) VALUES (?, ?, 'pending', ?)
+                """,
+                (turn_id, conversation, legacy_prompt_delivery_id),
+            )
+            prompt_id = str(uuid.uuid4())
+            database.execute(
+                """
+                INSERT INTO inbox_messages (
+                    conversation_id,
+                    event_key,
+                    body,
+                    body_sha256,
+                    delivery_id,
+                    sender,
+                    state,
+                    requires_ack,
+                    turn_id,
+                    position
+                ) VALUES (?, NULL, ?, ?, ?, ?, 'pending', 0, ?, 0)
+                """,
+                (
+                    conversation,
+                    prompt,
+                    _digest(prompt),
+                    prompt_id,
+                    _sender(prompt_id),
+                    turn_id,
+                ),
+            )
+            for position, row in enumerate(selected, start=1):
+                database.execute(
+                    """
+                    UPDATE inbox_messages
+                    SET turn_id = ?, position = ?
+                    WHERE sequence = ?
+                    """,
+                    (turn_id, position, row["sequence"]),
+                )
+            return self._turn(database, turn_id)
+
+    def adopt_legacy_prompt(
+        self,
+        turn_id: str,
+        body: str,
+        *,
+        sender: str | None = None,
+    ) -> InboxTurn:
+        with self._transaction() as database:
+            turn = self._turn(database, turn_id)
+            delivery_id = turn.legacy_prompt_delivery_id
+            if delivery_id is None and sender is None:
+                return turn
+            prompt = turn.prompt
+            if prompt.state is not DeliveryState.PENDING:
+                if prompt.body != body or (sender is not None and prompt.sender != sender):
+                    raise RuntimeError(
+                        f"legacy prompt for turn {turn_id} conflicts with its receipt"
+                    )
+                return turn
+            adopted_sender = sender or _sender(str(delivery_id))
+            adopted_id = (
+                str(delivery_id)
+                if sender is None or adopted_sender == _sender(str(delivery_id))
+                else f"legacy-prompt:{adopted_sender.removeprefix(_SENDER_PREFIX)}"
+            )
+            self._adopt_legacy_message_row(
+                database,
+                prompt.delivery_id,
+                body,
+                delivery_id=adopted_id,
+                sender=adopted_sender,
+            )
+            return self._turn(database, turn_id)
+
+    def prepare_legacy_turn(
+        self,
+        turn_id: str,
+        branch: Sequence[object],
+    ) -> InboxTurn:
+        """Adopt one already-visible #3472 delivery batch without replaying it."""
+
+        with self._transaction() as database:
+            turn = self._turn(database, turn_id)
+            if not turn.events or not all(
+                self._is_legacy_message(database, message.delivery_id)
+                for message in turn.events
+            ):
+                return turn
+
+            rows = database.execute(
+                """
+                SELECT message.*
+                FROM inbox_messages AS message
+                LEFT JOIN inbox_turns AS owner ON owner.turn_id = message.turn_id
+                WHERE message.conversation_id = ?
+                  AND message.legacy = 1
+                  AND (
+                      message.turn_id IS NULL
+                      OR (
+                          owner.acknowledged = 0
+                          AND owner.superseded_by IS NULL
+                      )
+                  )
+                ORDER BY message.sequence
+                """,
+                (turn.conversation_id,),
+            ).fetchall()
+            legacy_by_sender = {str(row["sender"]): row for row in rows}
+            branch_senders = [getattr(event, "sender", None) for event in branch]
+            positions: dict[str, list[int]] = {}
+            for index, sender_value in enumerate(branch_senders):
+                if isinstance(sender_value, str):
+                    positions.setdefault(sender_value, []).append(index)
+            for sender_value in legacy_by_sender:
+                if len(positions.get(sender_value, ())) > 1:
+                    raise RuntimeError(
+                        f"duplicate sender {sender_value!r} on active branch"
+                    )
+
+            selected_positions = [
+                positions[message.sender][0]
+                for message in turn.events
+                if message.sender in positions
+            ]
+            prompt_index = self._legacy_prompt_index(
+                turn,
+                branch_senders,
+                frozenset(legacy_by_sender),
+                selected_positions,
+            )
+            if prompt_index is None:
+                return turn
+
+            prompt_event = branch[prompt_index]
+            prompt_sender = str(branch_senders[prompt_index])
+            prompt = turn.prompt
+            prompt_id = turn.legacy_prompt_delivery_id
+            if prompt_id is None or _sender(prompt_id) != prompt_sender:
+                prompt_id = (
+                    "legacy-prompt:"
+                    f"{prompt_sender.removeprefix(_SENDER_PREFIX)}"
+                )
+            self._adopt_legacy_message_row(
+                database,
+                prompt.delivery_id,
+                _event_body(prompt_event),
+                delivery_id=prompt_id,
+                sender=prompt_sender,
+            )
+
+            next_prompt = next(
+                (
+                    index
+                    for index in range(prompt_index + 1, len(branch))
+                    if isinstance(branch_senders[index], str)
+                    and str(branch_senders[index]).startswith(_SENDER_PREFIX)
+                    and branch_senders[index] not in legacy_by_sender
+                ),
+                len(branch),
+            )
+            for index in range(prompt_index + 1, next_prompt):
+                row = legacy_by_sender.get(str(branch_senders[index]))
+                if row is None:
+                    continue
+                if row["turn_id"] not in (None, turn_id):
+                    raise RuntimeError(
+                        f"legacy delivery {row['delivery_id']} belongs to another turn"
+                    )
+                self._adopt_legacy_message_row(
+                    database,
+                    str(row["delivery_id"]),
+                    _event_body(branch[index]),
+                )
+                database.execute(
+                    """
+                    UPDATE inbox_messages
+                    SET turn_id = ?
+                    WHERE delivery_id = ?
+                    """,
+                    (turn_id, row["delivery_id"]),
+                )
+
+            turn_rows = database.execute(
+                """
+                SELECT sequence, delivery_id
+                FROM inbox_messages
+                WHERE turn_id = ? AND event_key IS NOT NULL
+                ORDER BY sequence
+                """,
+                (turn_id,),
+            ).fetchall()
+            for position, row in enumerate(turn_rows, start=1):
+                database.execute(
+                    "UPDATE inbox_messages SET position = ? WHERE delivery_id = ?",
+                    (position, row["delivery_id"]),
+                )
+            return self._turn(database, turn_id)
+
+    def turn(self, turn_id: str) -> InboxTurn:
+        with self._lock:
+            return self._turn(self._connection, turn_id)
+
+    def active_turn(self, conversation_id: UUID | str) -> InboxTurn | None:
+        with self._lock:
+            row = self._connection.execute(
+                """
+                SELECT turn_id
+                FROM inbox_turns
+                WHERE conversation_id = ?
+                  AND acknowledged = 0
+                  AND superseded_by IS NULL
+                  AND state != 'processed'
+                ORDER BY rowid
+                LIMIT 1
+                """,
+                (str(conversation_id),),
+            ).fetchone()
+            return None if row is None else self._turn(self._connection, row[0])
+
+    def record_pending(self, delivery_id: str) -> InboxMessage:
+        with self._lock:
+            message = self._message_by_delivery(self._connection, delivery_id)
+            if message.state is not DeliveryState.PENDING:
+                raise ValueError(
+                    f"cannot move backwards from {message.state.value} to pending"
+                )
+            return message
+
+    def record_delivered(self, delivery_id: str, body: str) -> InboxMessage:
+        with self._transaction() as database:
+            row = self._message_row(database, delivery_id)
+            _verify_body(row, body)
+            state = DeliveryState(row["state"])
+            if state is DeliveryState.PENDING:
+                database.execute(
+                    "UPDATE inbox_messages SET state = 'delivered' WHERE delivery_id = ?",
+                    (delivery_id,),
+                )
+                if row["turn_id"] is not None:
+                    self._refresh_turn_state(database, row["turn_id"])
+            return self._message_by_delivery(database, delivery_id)
+
+    def record_processed(self, turn_id: str) -> InboxTurn:
+        with self._transaction() as database:
+            turn = self._turn(database, turn_id)
+            if turn.state is DeliveryState.PROCESSED:
+                return turn
+            if any(message.state is DeliveryState.PENDING for message in turn.messages):
+                raise ValueError("cannot process a turn before every message is delivered")
+            database.execute(
+                """
+                UPDATE inbox_messages
+                SET state = 'processed'
+                WHERE turn_id = ? AND state = 'delivered'
+                """,
+                (turn_id,),
+            )
+            database.execute(
+                """
+                UPDATE inbox_turns
+                SET state = 'processed', processed_at = CURRENT_TIMESTAMP
+                WHERE turn_id = ?
+                """,
+                (turn_id,),
+            )
+            return self._turn(database, turn_id)
+
+    def processed_turns(self) -> tuple[InboxTurn, ...]:
+        with self._lock:
+            rows = self._connection.execute(
+                """
+                SELECT turn_id
+                FROM inbox_turns
+                WHERE state = 'processed'
+                  AND acknowledged = 0
+                  AND superseded_by IS NULL
+                ORDER BY rowid
+                """
+            ).fetchall()
+            return tuple(self._turn(self._connection, row[0]) for row in rows)
+
+    def acknowledge(self, turn_id: str) -> None:
+        with self._transaction() as database:
+            turn = self._turn(database, turn_id)
+            if turn.state is not DeliveryState.PROCESSED:
+                raise ValueError("cannot acknowledge a turn before it is processed")
+            database.execute(
+                """
+                UPDATE inbox_turns
+                SET acknowledged = 1, acknowledged_at = CURRENT_TIMESTAMP
+                WHERE turn_id = ?
+                """,
+                (turn_id,),
+            )
+
+    def reset_turn(self, turn_id: str, prompt: str) -> InboxTurn:
+        if not prompt:
+            raise ValueError("recovery prompt must not be empty")
+        with self._transaction() as database:
+            original = self._turn(database, turn_id)
+            if original.superseded_by is not None:
+                return self._turn(database, original.superseded_by)
+            if original.state is DeliveryState.PROCESSED:
+                return original
+
+            recovery_id = str(uuid.uuid4())
+            database.execute(
+                """
+                INSERT INTO inbox_turns (
+                    turn_id,
+                    conversation_id,
+                    state,
+                    recovery_of,
+                    context_reset_completed
+                ) VALUES (?, ?, 'pending', ?, 0)
+                """,
+                (recovery_id, original.conversation_id, turn_id),
+            )
+            prompt_id = str(uuid.uuid4())
+            database.execute(
+                """
+                INSERT INTO inbox_messages (
+                    conversation_id,
+                    event_key,
+                    body,
+                    body_sha256,
+                    delivery_id,
+                    sender,
+                    state,
+                    requires_ack,
+                    turn_id,
+                    position
+                ) VALUES (?, NULL, ?, ?, ?, ?, 'pending', 0, ?, 0)
+                """,
+                (
+                    original.conversation_id,
+                    prompt,
+                    _digest(prompt),
+                    prompt_id,
+                    _sender(prompt_id),
+                    recovery_id,
+                ),
+            )
+            for position, message in enumerate(original.events, start=1):
+                delivery_id = str(uuid.uuid4())
+                database.execute(
+                    """
+                    INSERT INTO inbox_messages (
+                        conversation_id,
+                        event_key,
+                        body,
+                        body_sha256,
+                        delivery_id,
+                        sender,
+                        state,
+                        requires_ack,
+                        turn_id,
+                        position
+                    ) VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?)
+                    """,
+                    (
+                        original.conversation_id,
+                        message.event_key,
+                        message.body,
+                        _digest(message.body),
+                        delivery_id,
+                        _sender(delivery_id),
+                        int(message.requires_ack),
+                        recovery_id,
+                        position,
+                    ),
+                )
+            database.execute(
+                "UPDATE inbox_turns SET superseded_by = ? WHERE turn_id = ?",
+                (recovery_id, turn_id),
+            )
+            return self._turn(database, recovery_id)
+
+    def record_context_reset(self, turn_id: str) -> InboxTurn:
+        with self._transaction() as database:
+            turn = self._turn(database, turn_id)
+            if turn.recovery_of is None:
+                raise ValueError("only a recovery turn can record a context reset")
+            database.execute(
+                """
+                UPDATE inbox_turns
+                SET context_reset_completed = 1
+                WHERE turn_id = ?
+                """,
+                (turn_id,),
+            )
+            return self._turn(database, turn_id)
+
+    def pending_count(self, conversation_id: UUID | str | None = None) -> int:
+        where = "state = 'pending' AND turn_id IS NULL"
+        parameters: tuple[object, ...] = ()
+        if conversation_id is not None:
+            where += " AND conversation_id = ?"
+            parameters = (str(conversation_id),)
+        with self._lock:
+            row = self._connection.execute(
+                f"SELECT COUNT(*) FROM inbox_messages WHERE {where}",
+                parameters,
+            ).fetchone()
+            return int(row[0])
+
+    def ready_conversation_ids(self) -> tuple[str, ...]:
+        with self._lock:
+            rows = self._connection.execute(
+                """
+                SELECT conversation_id, MIN(sequence) AS first_sequence
+                FROM inbox_messages
+                WHERE turn_id IS NULL OR turn_id IN (
+                    SELECT turn_id
+                    FROM inbox_turns
+                    WHERE acknowledged = 0 AND superseded_by IS NULL
+                )
+                GROUP BY conversation_id
+                ORDER BY first_sequence
+                """
+            ).fetchall()
+            return tuple(str(row[0]) for row in rows)
+
+    def acknowledged_event_keys(self) -> frozenset[str]:
+        with self._lock:
+            rows = self._connection.execute(
+                """
+                SELECT DISTINCT message.event_key
+                FROM inbox_messages AS message
+                JOIN inbox_turns AS turn ON turn.turn_id = message.turn_id
+                WHERE turn.acknowledged = 1
+                  AND message.event_key IS NOT NULL
+                """
+            ).fetchall()
+            return frozenset(str(row[0]) for row in rows)
+
+    def close(self) -> None:
+        with self._lock:
+            self._connection.close()
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        _exc: BaseException | None,
+        _traceback: TracebackType | None,
+    ) -> None:
+        self.close()
+
+    def _turn(self, database: sqlite3.Connection, turn_id: str) -> InboxTurn:
+        row = database.execute(
+            "SELECT * FROM inbox_turns WHERE turn_id = ?",
+            (turn_id,),
+        ).fetchone()
+        if row is None:
+            raise KeyError(f"unknown inbox turn {turn_id}")
+        messages = database.execute(
+            """
+            SELECT *
+            FROM inbox_messages
+            WHERE turn_id = ?
+            ORDER BY position
+            """,
+            (turn_id,),
+        ).fetchall()
+        return InboxTurn(
+            turn_id=turn_id,
+            conversation_id=str(row["conversation_id"]),
+            state=DeliveryState(row["state"]),
+            messages=tuple(_message(message) for message in messages),
+            superseded_by=row["superseded_by"],
+            recovery_of=row["recovery_of"],
+            legacy_prompt_delivery_id=row["legacy_prompt_delivery_id"],
+            context_reset_completed=bool(row["context_reset_completed"]),
+            acknowledged=bool(row["acknowledged"]),
+        )
+
+    def _message_row(
+        self,
+        database: sqlite3.Connection,
+        delivery_id: str,
+    ) -> sqlite3.Row:
+        row = database.execute(
+            "SELECT * FROM inbox_messages WHERE delivery_id = ?",
+            (delivery_id,),
+        ).fetchone()
+        if row is None:
+            raise KeyError(f"unknown delivery {delivery_id}")
+        return row
+
+    def _message_by_delivery(
+        self,
+        database: sqlite3.Connection,
+        delivery_id: str,
+    ) -> InboxMessage:
+        return _message(self._message_row(database, delivery_id))
+
+    def _adopt_legacy_message_row(
+        self,
+        database: sqlite3.Connection,
+        current_delivery_id: str,
+        body: str,
+        *,
+        delivery_id: str | None = None,
+        sender: str | None = None,
+    ) -> None:
+        row = self._message_row(database, current_delivery_id)
+        if row["event_key"] is not None and not row["legacy"]:
+            raise RuntimeError(
+                f"native delivery {current_delivery_id} cannot adopt legacy payload"
+            )
+        if DeliveryState(row["state"]) is not DeliveryState.PENDING:
+            _verify_body(row, body)
+            if sender is not None and row["sender"] != sender:
+                raise RuntimeError(
+                    f"delivery {current_delivery_id} sender mismatch"
+                )
+            return
+        adopted_id = delivery_id or str(row["delivery_id"])
+        adopted_sender = sender or str(row["sender"])
+        database.execute(
+            """
+            UPDATE inbox_messages
+            SET body = ?,
+                body_sha256 = ?,
+                delivery_id = ?,
+                sender = ?,
+                legacy = 1
+            WHERE delivery_id = ?
+            """,
+            (
+                body,
+                _digest(body),
+                adopted_id,
+                adopted_sender,
+                current_delivery_id,
+            ),
+        )
+
+    def _is_legacy_message(
+        self,
+        database: sqlite3.Connection,
+        delivery_id: str,
+    ) -> bool:
+        return bool(self._message_row(database, delivery_id)["legacy"])
+
+    @staticmethod
+    def _legacy_prompt_index(
+        turn: InboxTurn,
+        branch_senders: Sequence[object],
+        legacy_senders: frozenset[str],
+        selected_positions: Sequence[int],
+    ) -> int | None:
+        if turn.legacy_prompt_delivery_id is not None:
+            exact_sender = _sender(turn.legacy_prompt_delivery_id)
+            exact = [
+                index
+                for index, value in enumerate(branch_senders)
+                if value == exact_sender
+            ]
+            if len(exact) > 1:
+                raise RuntimeError(
+                    f"duplicate sender {exact_sender!r} on active branch"
+                )
+            if exact:
+                return exact[0]
+        if not selected_positions:
+            return None
+        first_event = min(selected_positions)
+        return next(
+            (
+                index
+                for index in range(first_event - 1, -1, -1)
+                if isinstance(branch_senders[index], str)
+                and str(branch_senders[index]).startswith(_SENDER_PREFIX)
+                and branch_senders[index] not in legacy_senders
+            ),
+            None,
+        )
+
+    def _refresh_turn_state(
+        self,
+        database: sqlite3.Connection,
+        turn_id: str,
+    ) -> None:
+        pending = database.execute(
+            """
+            SELECT 1 FROM inbox_messages
+            WHERE turn_id = ? AND state = 'pending'
+            LIMIT 1
+            """,
+            (turn_id,),
+        ).fetchone()
+        if pending is None:
+            database.execute(
+                """
+                UPDATE inbox_turns
+                SET state = 'delivered'
+                WHERE turn_id = ? AND state = 'pending'
+                """,
+                (turn_id,),
+            )
+
+    def _transaction(self):
+        return _Transaction(self._connection, self._lock)
+
+    def _import_legacy_deliveries(self, path: Path) -> None:
+        value = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(value, dict):
+            raise RuntimeError(f"invalid pending delivery ledger: {path}")
+        for conversation_id, deliveries in value.items():
+            if not isinstance(conversation_id, str) or not isinstance(deliveries, dict):
+                raise RuntimeError(f"invalid pending delivery ledger: {path}")
+            UUID(conversation_id)
+            for event_key, delivery_id in deliveries.items():
+                if not isinstance(event_key, str) or not isinstance(delivery_id, str):
+                    raise RuntimeError(f"invalid pending delivery ledger: {path}")
+                UUID(delivery_id)
+                existing = self._connection.execute(
+                    """
+                    SELECT delivery_id
+                    FROM legacy_deliveries
+                    WHERE conversation_id = ? AND event_key = ?
+                    """,
+                    (conversation_id, event_key),
+                ).fetchone()
+                if existing is not None and existing["delivery_id"] != delivery_id:
+                    raise RuntimeError(
+                        f"legacy delivery {event_key!r} changed identity"
+                    )
+                self._connection.execute(
+                    """
+                    INSERT OR IGNORE INTO legacy_deliveries (
+                        conversation_id,
+                        event_key,
+                        delivery_id
+                    ) VALUES (?, ?, ?)
+                    """,
+                    (conversation_id, event_key, delivery_id),
+                )
+
+
+class _Transaction:
+    def __init__(self, database: sqlite3.Connection, lock: threading.RLock):
+        self.database = database
+        self.lock = lock
+
+    def __enter__(self) -> sqlite3.Connection:
+        self.lock.acquire()
+        self.database.execute("BEGIN IMMEDIATE")
+        return self.database
+
+    def __exit__(self, exc_type, _exc, _traceback) -> None:
+        try:
+            if exc_type is None:
+                self.database.commit()
+            else:
+                self.database.rollback()
+        finally:
+            self.lock.release()
+
+
+def deliver_turn_messages(
+    conversation: object,
+    inbox: PersistentInbox,
+    turn_id: str,
+) -> InboxTurn:
+    """Append one turn's messages exactly once on the active branch."""
+
+    turn = inbox.turn(turn_id)
+    if turn.state is DeliveryState.PROCESSED:
+        return turn
+    state = getattr(conversation, "state", None)
+    guard = state if hasattr(state, "__enter__") else nullcontext()
+    with guard:
+        branch = _active_branch(conversation)
+        turn = inbox.prepare_legacy_turn(turn_id, branch)
+        if turn.legacy_prompt_delivery_id is not None:
+            legacy_sender = _sender(turn.legacy_prompt_delivery_id)
+            legacy_prompts = [
+                event
+                for event in branch
+                if getattr(event, "sender", None) == legacy_sender
+            ]
+            if len(legacy_prompts) > 1:
+                raise RuntimeError(
+                    f"duplicate sender {legacy_sender!r} on active branch"
+                )
+            if legacy_prompts:
+                turn = inbox.adopt_legacy_prompt(
+                    turn_id,
+                    _event_body(legacy_prompts[0]),
+                )
+        by_sender: dict[str, list[object]] = {}
+        for event in branch:
+            sender = getattr(event, "sender", None)
+            if isinstance(sender, str):
+                by_sender.setdefault(sender, []).append(event)
+
+        for message in turn.messages:
+            existing = by_sender.get(message.sender, [])
+            if len(existing) > 1:
+                raise RuntimeError(
+                    f"duplicate sender {message.sender!r} on active branch"
+                )
+            if existing:
+                body = _event_body(existing[0])
+                if body != message.body:
+                    raise RuntimeError(
+                        f"delivery {message.delivery_id} payload mismatch on active branch"
+                    )
+            else:
+                conversation.send_message(message.body, sender=message.sender)
+            inbox.record_delivered(message.delivery_id, message.body)
+    return inbox.turn(turn_id)
+
+
+def turn_has_finished_response(conversation: object, turn: InboxTurn) -> bool:
+    branch = _active_branch(conversation)
+    positions = {
+        getattr(event, "sender", None): index for index, event in enumerate(branch)
+    }
+    try:
+        last_delivery = max(positions[message.sender] for message in turn.messages)
+    except KeyError:
+        return False
+    return any(_is_agent_event(event) for event in branch[last_delivery + 1 :])
+
+
+def _active_branch(conversation: object) -> Sequence[object]:
+    state = getattr(conversation, "state", None)
+    active_branch = getattr(state, "active_branch", None)
+    return () if active_branch is None else tuple(active_branch())
+
+
+def _event_body(event: object) -> str:
+    for attribute in ("message", "prompt"):
+        value = getattr(event, attribute, None)
+        if isinstance(value, str):
+            return value
+    llm_message = getattr(event, "llm_message", None)
+    if llm_message is not None:
+        parts = [
+            getattr(content, "text", "")
+            for content in getattr(llm_message, "content", ())
+            if getattr(content, "text", "")
+        ]
+        if parts:
+            return "\n".join(parts)
+    raise RuntimeError("delivery sender exists without a verifiable message payload")
+
+
+def _is_agent_event(event: object) -> bool:
+    if getattr(event, "source", None) == "agent":
+        return True
+    if getattr(event, "sender", None) == "agent":
+        return True
+    return getattr(getattr(event, "llm_message", None), "role", None) == "assistant"
+
+
+def _message(row: sqlite3.Row) -> InboxMessage:
+    return InboxMessage(
+        delivery_id=str(row["delivery_id"]),
+        sender=str(row["sender"]),
+        body=str(row["body"]),
+        state=DeliveryState(row["state"]),
+        event_key=row["event_key"],
+        requires_ack=bool(row["requires_ack"]),
+    )
+
+
+def _verify_body(row: sqlite3.Row, body: str) -> None:
+    if row["body"] != body or row["body_sha256"] != _digest(body):
+        raise RuntimeError(f"delivery {row['delivery_id']} payload mismatch")
+
+
+def _digest(body: str) -> str:
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
+def _sender(delivery_id: str) -> str:
+    digest = hashlib.sha256(delivery_id.encode("utf-8")).hexdigest()
+    return f"{_SENDER_PREFIX}{digest}"
+
+
+def _legacy_prompt_delivery_id(
+    delivery_ids: Sequence[str],
+    *,
+    identity: str | None = None,
+) -> str:
+    prompt_identity = identity or "turn:" + "|".join(sorted(delivery_ids))
+    return (
+        "controller-prompt:"
+        f"{hashlib.sha256(prompt_identity.encode()).hexdigest()}"
+    )

--- a/senpai_agent/mailbox.py
+++ b/senpai_agent/mailbox.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import sys
-import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -20,9 +19,14 @@ class ControllerEvent:
     payload: dict[str, object]
 
     def to_prompt(self) -> str:
+        payload = {
+            key: value
+            for key, value in self.payload.items()
+            if key != "parent_conversation_id"
+        }
         return (
             f"## {self.kind}\n\n"
-            f"{json.dumps(self.payload, sort_keys=True, separators=(',', ':'))}"
+            f"{json.dumps(payload, sort_keys=True, separators=(',', ':'))}"
         )
 
 
@@ -60,7 +64,7 @@ class CompositeMailbox:
 
 
 class LocalAdvisorMailbox:
-    """Wake an idle advisor so its event pump can drain local child results."""
+    """Deliver durable local child results directly to the advisor inbox."""
 
     def __init__(self, store_path: Path):
         self.store_path = store_path
@@ -68,30 +72,23 @@ class LocalAdvisorMailbox:
     def poll(self) -> tuple[ControllerEvent, ...]:
         with AdvisorEventStore(self.store_path) as store:
             pending = store.pending()
-        if not pending:
-            return ()
-        identity = "|".join(event.dedupe_key for event in pending)
-        return (
+        return tuple(
             ControllerEvent(
-                kind="local_events_pending",
-                dedupe_key=f"local_events:{uuid.uuid5(uuid.NAMESPACE_URL, identity)}",
-                payload={
-                    "count": len(pending),
-                    "kinds": sorted({event.kind for event in pending}),
-                    "delivery": (
-                        "The OpenHands event pump will inject these events at "
-                        "the next safe conversation boundary."
-                    ),
-                },
-            ),
+                kind=event.kind,
+                dedupe_key=event.dedupe_key,
+                payload=event.payload,
+            )
+            for event in pending
         )
 
-    def acknowledge(self, _dedupe_keys: Sequence[str]) -> None:
-        return
+    def acknowledge(self, dedupe_keys: Sequence[str]) -> None:
+        with AdvisorEventStore(self.store_path) as store:
+            for key in dedupe_keys:
+                store.acknowledge(key)
 
 
 class LocalStudentMailbox:
-    """Wake the student conversation that dispatched a finished child."""
+    """Deliver local child results directly to their parent conversations."""
 
     def __init__(self, store_path: Path):
         self.store_path = store_path
@@ -99,32 +96,19 @@ class LocalStudentMailbox:
     def poll(self) -> tuple[ControllerEvent, ...]:
         with AdvisorEventStore(self.store_path) as store:
             pending = store.pending()
-        if not pending:
-            return ()
-        parent_id = pending[0].payload.get("parent_conversation_id")
-        if not isinstance(parent_id, str):
-            raise RuntimeError("student child event has no parent conversation")
-        matching = [
-            event
-            for event in pending
-            if event.payload.get("parent_conversation_id") == parent_id
-        ]
-        identity = "|".join(event.dedupe_key for event in matching)
-        return (
+        for event in pending:
+            if not isinstance(event.payload.get("parent_conversation_id"), str):
+                raise RuntimeError("student child event has no parent conversation")
+        return tuple(
             ControllerEvent(
-                kind="local_events_pending",
-                dedupe_key=f"local_events:{uuid.uuid5(uuid.NAMESPACE_URL, identity)}",
-                payload={
-                    "conversation_id": parent_id,
-                    "count": len(matching),
-                    "kinds": sorted({event.kind for event in matching}),
-                    "delivery": (
-                        "The OpenHands event pump will inject these events at "
-                        "the next safe conversation boundary."
-                    ),
-                },
-            ),
+                kind=event.kind,
+                dedupe_key=event.dedupe_key,
+                payload=event.payload,
+            )
+            for event in pending
         )
 
-    def acknowledge(self, _dedupe_keys: Sequence[str]) -> None:
-        return
+    def acknowledge(self, dedupe_keys: Sequence[str]) -> None:
+        with AdvisorEventStore(self.store_path) as store:
+            for key in dedupe_keys:
+                store.acknowledge(key)

--- a/senpai_agent/openhands_runner.py
+++ b/senpai_agent/openhands_runner.py
@@ -34,6 +34,12 @@ from senpai_agent.delegation import (
     configure_delegation,
     record_delegated_task_result,
 )
+from senpai_agent.inbox import (
+    DeliveryState,
+    PersistentInbox,
+    deliver_turn_messages,
+    turn_has_finished_response,
+)
 from senpai_agent.secrets import (
     GITHUB_TOKEN_ENV_NAMES,
     GITHUB_TOKEN_FD_ENV,
@@ -1218,7 +1224,11 @@ def run_openhands(
     config: RunnerConfig,
     *,
     reset_context: bool = False,
+    inbox: PersistentInbox | None = None,
+    inbox_turn_id: str | None = None,
 ) -> int:
+    if (inbox is None) != (inbox_turn_id is None):
+        raise ValueError("inbox and inbox_turn_id must be provided together")
     started_at = time.time()
     run_deadline = min(
         started_at + config.timeout_seconds,
@@ -1298,6 +1308,7 @@ def run_openhands(
     scrub_github_credentials(os.environ)
     conversation = None
     cleanup_error: BaseException | None = None
+    active_inbox_turn_id = inbox_turn_id
     try:
         llm = LLM(
             model=config.model,
@@ -1378,7 +1389,32 @@ def run_openhands(
             prompt_cache_key=conversation_prompt_cache_key(config),
         )
         reject_recovered_actions(conversation)
-        if reset_context:
+        if inbox is not None and active_inbox_turn_id is not None:
+            if reset_context:
+                recovery = inbox.reset_turn(active_inbox_turn_id, prompt)
+                active_inbox_turn_id = recovery.turn_id
+            active_turn = inbox.turn(active_inbox_turn_id)
+            if active_turn.context_reset_required:
+                active_branch = tuple(conversation.state.active_branch())
+                active_senders = {
+                    getattr(event, "sender", None) for event in active_branch
+                }
+                recovery_started = any(
+                    message.sender in active_senders
+                    for message in active_turn.messages
+                )
+                if active_branch and not recovery_started:
+                    preserved_events = len(conversation.state.events)
+                    conversation.navigate_to(None)
+                    print(
+                        "OPENHANDS_CONTEXT_RESET "
+                        f"conversation_id={config.conversation_id} "
+                        f"preserved_events={preserved_events}",
+                        file=sys.stderr,
+                        flush=True,
+                    )
+                inbox.record_context_reset(active_inbox_turn_id)
+        elif reset_context:
             preserved_events = len(conversation.state.events)
             conversation.navigate_to(None)
             print(
@@ -1388,30 +1424,59 @@ def run_openhands(
                 file=sys.stderr,
                 flush=True,
             )
+        inference_required = True
         try:
             # send_message performs OpenHands' lazy tool initialization.
-            conversation.send_message(prompt)
+            if inbox is None or active_inbox_turn_id is None:
+                conversation.send_message(prompt)
+            else:
+                turn = inbox.turn(active_inbox_turn_id)
+                if turn.state is DeliveryState.PROCESSED:
+                    inference_required = False
+                else:
+                    turn = deliver_turn_messages(
+                        conversation,
+                        inbox,
+                        active_inbox_turn_id,
+                    )
+                    if (
+                        conversation.state.execution_status
+                        == ConversationExecutionStatus.FINISHED
+                        and turn_has_finished_response(conversation, turn)
+                    ):
+                        inbox.record_processed(active_inbox_turn_id)
+                        inference_required = False
         finally:
             clear_github_credentials()
             configure_delegation(None)
-        with graceful_interrupts(conversation):
-            if not config.child:
-                with (
-                    AdvisorEventStore(local_event_db_path(config)) as event_store,
-                    AdvisorEventPump(
-                        event_store,
-                        conversation,
-                        parent_conversation_id=(
-                            str(config.conversation_id)
-                            if config.role == "student"
-                            else None
+        if inference_required:
+            with graceful_interrupts(conversation):
+                if not config.child:
+                    with (
+                        AdvisorEventStore(local_event_db_path(config)) as event_store,
+                        AdvisorEventPump(
+                            event_store,
+                            conversation,
+                            parent_conversation_id=(
+                                str(config.conversation_id)
+                                if config.role == "student"
+                                else None
+                            ),
+                            inbox=inbox,
+                            conversation_id=config.conversation_id,
                         ),
-                    ),
-                ):
+                    ):
+                        run_conversation(conversation, run_deadline - time.time())
+                else:
                     run_conversation(conversation, run_deadline - time.time())
-            else:
-                run_conversation(conversation, run_deadline - time.time())
         status = conversation.state.execution_status
+        if (
+            inference_required
+            and inbox is not None
+            and active_inbox_turn_id is not None
+            and status == ConversationExecutionStatus.FINISHED
+        ):
+            inbox.record_processed(active_inbox_turn_id)
         child_result = (
             final_agent_result(conversation)
             if config.child and status == ConversationExecutionStatus.FINISHED

--- a/senpai_agent/state.py
+++ b/senpai_agent/state.py
@@ -185,8 +185,11 @@ class StudentConversationSelector:
         )
 
     def _conversation_for(self, event: ControllerEvent) -> UUID:
-        if event.kind in {"local_events_pending", "training_monitor"}:
+        if event.kind == "training_monitor":
             return UUID(str(event.payload["conversation_id"]))
+        parent_id = event.payload.get("parent_conversation_id")
+        if isinstance(parent_id, str):
+            return UUID(parent_id)
         if event.kind in {"student_assignment", "student_pr_feedback"}:
             return self.registry.for_assignment(
                 str(event.payload["assignment_id"]),

--- a/tests/test_advisor_runtime.py
+++ b/tests/test_advisor_runtime.py
@@ -18,6 +18,8 @@ from senpai_agent.advisor import (
     deliver_pending_events,
 )
 from senpai_agent.delegation import AgentStatusAction, AgentStatusObservation
+from senpai_agent.inbox import PersistentInbox
+from senpai_agent.mailbox import ControllerEvent
 
 
 class ConversationStateStub:
@@ -93,6 +95,8 @@ def test_event_store_deduplicates_and_survives_reopen(tmp_path: Path):
         assert store.enqueue(event) is True
         assert store.pending_count() == 1
         assert store.enqueue(event) is False
+        with pytest.raises(RuntimeError, match="reused with a different payload"):
+            store.enqueue(event.model_copy(update={"payload": {"pr": 999}}))
 
     with AdvisorEventStore(database) as reopened:
         pending = reopened.pending()
@@ -252,14 +256,19 @@ def test_event_pump_injects_new_events_while_conversation_is_running(
         assert store.pending() == []
 
 
-def test_failed_turn_replays_delivered_child_result_on_the_next_pump(
+def test_event_pump_queues_into_the_controller_inbox_without_mid_turn_injection(
     tmp_path: Path,
 ):
+    """
+    Requirement: controller and event-pump messages use one durable inbox.
+    Interface: AdvisorEventPump, PersistentInbox, and the active conversation.
+    """
     event = AdvisorEvent(
         kind="agent_result",
         dedupe_key="agent_result:task-1",
         payload={"task_id": "task-1"},
     )
+    conversation_id = "00000000-0000-0000-0000-000000000017"
 
     class Conversation:
         def __init__(self):
@@ -273,31 +282,39 @@ def test_failed_turn_replays_delivered_child_result_on_the_next_pump(
 
     with AdvisorEventStore(tmp_path / "events.sqlite3") as store:
         store.enqueue(event)
-        failed_conversation = Conversation()
-
-        with pytest.raises(RuntimeError, match="context failed"):
-            with AdvisorEventPump(
-                store,
-                failed_conversation,
-                poll_interval=0.01,
-            ):
-                assert failed_conversation.received.wait(1)
-                time.sleep(0.03)
-                assert failed_conversation.messages == [event.to_user_message()]
-                raise RuntimeError("context failed")
-
-        assert store.pending() == [event]
-
-        recovered_conversation = Conversation()
+        conversation = Conversation()
+        inbox = PersistentInbox(tmp_path / "inbox.sqlite3")
+        inbox.enqueue(conversation_id, "controller:event", "controller event")
+        active = inbox.next_turn(conversation_id, "controller prompt")
+        assert active is not None
+        for message in active.messages:
+            inbox.record_delivered(message.delivery_id, message.body)
         with AdvisorEventPump(
             store,
-            recovered_conversation,
+            conversation,
             poll_interval=0.01,
+            inbox=inbox,
+            conversation_id=conversation_id,
         ):
-            assert recovered_conversation.received.wait(1)
+            deadline = time.monotonic() + 1
+            while store.pending() and time.monotonic() < deadline:
+                time.sleep(0.01)
 
-        assert recovered_conversation.messages == [event.to_user_message()]
+        assert conversation.messages == []
         assert store.pending() == []
+        retry = inbox.next_turn(conversation_id, "retry prompt")
+        assert retry is not None and retry.turn_id == active.turn_id
+        assert [message.body for message in retry.events] == ["controller event"]
+        assert inbox.pending_count(conversation_id) == 1
+
+        inbox.record_processed(active.turn_id)
+        inbox.acknowledge(active.turn_id)
+        next_turn = inbox.next_turn(conversation_id, "next prompt")
+        assert next_turn is not None
+        assert [message.body for message in next_turn.events] == [
+            event.to_inbox_message()
+        ]
+        assert next_turn.acknowledgement_keys == (event.dedupe_key,)
 
 
 def test_non_finished_turn_leaves_delivered_child_result_pending(
@@ -427,3 +444,20 @@ def test_advisor_cli_reports_the_pending_event_count(
         == 0
     )
     assert capsys.readouterr().out.strip() == "1"
+
+
+def test_inbox_rendering_excludes_transport_only_parent_conversation_id():
+    """Watcher and controller paths must render one payload for one event key."""
+    payload = {"assignment_id": "a-17", "revision_id": "r-2"}
+    controller_event = ControllerEvent(
+        kind="student_pr_feedback",
+        dedupe_key="feedback:17",
+        payload=payload,
+    )
+    watcher_event = AdvisorEvent(
+        kind=controller_event.kind,
+        dedupe_key=controller_event.dedupe_key,
+        payload={**payload, "parent_conversation_id": "conversation-17"},
+    )
+
+    assert watcher_event.to_inbox_message() == controller_event.to_prompt()

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,5 +1,6 @@
 import time
 from base64 import b64encode
+from collections import Counter
 from pathlib import Path
 from types import SimpleNamespace
 from uuid import UUID
@@ -13,6 +14,7 @@ from senpai_agent.controller import (
     TurnResult,
     _full_prompt,
 )
+from senpai_agent.inbox import PersistentInbox, deliver_turn_messages
 from senpai_agent.mailbox import ControllerEvent
 from senpai_agent.state import ConversationStateLedger, WorkspaceDivergenceLedger
 from senpai_agent.supervisor import ProgressLease, WorkerLease
@@ -49,6 +51,8 @@ class Turns:
         conversation_id,
         event_keys,
         visible_event_keys=frozenset(),
+        inbox,
+        inbox_turn_id,
     ):
         self.calls.append(
             (prompt, conversation_id, event_keys, visible_event_keys)
@@ -56,6 +60,11 @@ class Turns:
         outcome = self.outcomes.pop(0) if self.outcomes else TurnResult(exit_code=0)
         if isinstance(outcome, Exception):
             raise outcome
+        if outcome.exit_code == 0:
+            turn = inbox.turn(inbox_turn_id)
+            for message in turn.messages:
+                inbox.record_delivered(message.delivery_id, message.body)
+            inbox.record_processed(inbox_turn_id)
         return outcome
 
 
@@ -204,24 +213,128 @@ def test_post_turn_poll_at_reminder_boundary_only_delivers_new_state(
     ]
 
 
-@pytest.mark.parametrize(
-    "failure",
-    [TurnResult(exit_code=19), RuntimeError("SDK transport failed")],
-    ids=["nonzero-exit", "exception"],
-)
-def test_failed_turn_retries_the_same_unacknowledged_event_with_full_brief(failure):
-    event = review_event()
-    mailbox = Mailbox([(event,), (event,), ()])
-    turns = Turns([failure, TurnResult(exit_code=0)])
+def test_failed_turn_resumes_without_admitting_new_events(tmp_path: Path):
+    """
+    Requirement: an unresolved turn is resumed before newly observed work.
+    Interface: Controller turns and mailbox acknowledgements across retries.
+    """
+    first = review_event(17)
+    later = review_event(18)
+    mailbox = Mailbox([(first,), (first, later), ()])
+    turns = Turns([TurnResult(exit_code=19), TurnResult(exit_code=0)])
+    inbox = PersistentInbox(tmp_path / "inbox.sqlite3")
 
-    controller(mailbox, turns).run(max_cycles=2)
+    controller(mailbox, turns, inbox=inbox).run(max_cycles=2)
 
-    assert [call[2] for call in turns.calls] == [
-        frozenset({event.dedupe_key}),
-        frozenset({event.dedupe_key}),
+    assert [call[2] for call in turns.calls[:2]] == [
+        frozenset({first.dedupe_key}),
+        frozenset({first.dedupe_key}),
     ]
-    assert all("programme" in call[0] for call in turns.calls)
+    assert later.dedupe_key not in turns.calls[1][2]
+    assert [call[2] for call in turns.calls] == [
+        frozenset({first.dedupe_key}),
+        frozenset({first.dedupe_key}),
+        frozenset({later.dedupe_key}),
+    ]
+    assert mailbox.acknowledged == [
+        (first.dedupe_key,),
+        (later.dedupe_key,),
+    ]
+
+
+def test_108_events_survive_four_failed_inferences_without_visible_replay(
+    tmp_path: Path,
+):
+    events = tuple(review_event(index) for index in range(108))
+
+    class Conversation:
+        def __init__(self):
+            self.events = []
+            self.sent = []
+            self.state = SimpleNamespace(active_branch=lambda: list(self.events))
+
+        def send_message(self, message, sender=None):
+            self.sent.append(message)
+            self.events.append(SimpleNamespace(message=message, sender=sender))
+
+    class RetryingTurns:
+        def __init__(self):
+            self.calls = 0
+            self.conversation = Conversation()
+
+        def run(
+            self,
+            _prompt,
+            *,
+            conversation_id,
+            event_keys,
+            visible_event_keys=frozenset(),
+            inbox,
+            inbox_turn_id,
+        ):
+            del conversation_id, event_keys, visible_event_keys
+            self.calls += 1
+            deliver_turn_messages(self.conversation, inbox, inbox_turn_id)
+            if self.calls <= 4:
+                return TurnResult(exit_code=1)
+            inbox.record_processed(inbox_turn_id)
+            return TurnResult(exit_code=0)
+
+    turns = RetryingTurns()
+    Controller(
+        role="advisor",
+        mailbox=Mailbox([events]),
+        turns=turns,
+        conversation_id=CONVERSATION_ID,
+        full_prompt="programme",
+        inbox=PersistentInbox(tmp_path / "inbox.sqlite3"),
+        sleep=lambda _seconds: None,
+        poll_interval_seconds=600,
+        jitter_seconds=0,
+        max_consecutive_turn_failures=5,
+    ).run(max_cycles=5)
+
+    visible = Counter(turns.conversation.sent)
+    assert turns.calls == 11
+    assert all(visible[event.to_prompt()] == 1 for event in events)
+
+
+def test_processed_turn_retries_mailbox_acknowledgement_without_inference(
+    tmp_path: Path,
+):
+    """
+    Requirement: post-inference recovery performs acknowledgement only.
+    Interface: persistent inbox, Controller, mailbox, and TurnRunner calls.
+    """
+    event = review_event()
+    path = tmp_path / "inbox.sqlite3"
+
+    class FailingAckMailbox(Mailbox):
+        def acknowledge(self, _dedupe_keys):
+            raise RuntimeError("mailbox acknowledgement failed")
+
+    first_turns = Turns()
+    with pytest.raises(RuntimeError, match="mailbox acknowledgement failed"):
+        controller(
+            FailingAckMailbox([(event,)]),
+            first_turns,
+            inbox=PersistentInbox(path),
+        ).run(max_cycles=1)
+
+    assert len(first_turns.calls) == 1
+    assert len(PersistentInbox(path).processed_turns()) == 1
+
+    mailbox = Mailbox([(), ()])
+    turns = Turns()
+    controller(
+        mailbox,
+        turns,
+        inbox=PersistentInbox(path),
+    ).run(max_cycles=1)
+
+    assert turns.calls == []
     assert mailbox.acknowledged == [(event.dedupe_key,)]
+    assert PersistentInbox(path).processed_turns() == ()
 
 
 def test_level_trigger_is_quiet_while_visible_and_wakes_after_reappearing():
@@ -278,6 +391,52 @@ def test_still_actionable_event_is_redelivered_after_one_poll_interval(
     ]
 
 
+def test_restart_waits_one_reminder_interval_before_redelivery(
+    tmp_path: Path,
+    monkeypatch,
+):
+    event = review_event()
+    path = tmp_path / "inbox.sqlite3"
+    clock = [0.0]
+    monkeypatch.setattr(controller_module.time, "monotonic", lambda: clock[0])
+
+    class PersistentMailbox(Mailbox):
+        def poll(self):
+            self.calls += 1
+            return (event,)
+
+    Controller(
+        role="advisor",
+        mailbox=PersistentMailbox([]),
+        turns=Turns(),
+        conversation_id=CONVERSATION_ID,
+        full_prompt="programme",
+        inbox=PersistentInbox(path),
+        sleep=lambda _seconds: None,
+        poll_interval_seconds=30,
+        jitter_seconds=0,
+        event_reminder_seconds=30,
+    ).run(max_cycles=1)
+
+    restarted_turns = Turns()
+    Controller(
+        role="advisor",
+        mailbox=PersistentMailbox([]),
+        turns=restarted_turns,
+        conversation_id=CONVERSATION_ID,
+        full_prompt="programme",
+        inbox=PersistentInbox(path),
+        sleep=lambda seconds: clock.__setitem__(0, clock[0] + seconds),
+        poll_interval_seconds=30,
+        jitter_seconds=0,
+        event_reminder_seconds=30,
+    ).run(max_cycles=2)
+
+    assert [call[2] for call in restarted_turns.calls] == [
+        frozenset({event.dedupe_key})
+    ]
+
+
 def test_older_visible_event_does_not_lose_its_reminder_to_another_turn(
     monkeypatch,
 ):
@@ -299,12 +458,16 @@ def test_older_visible_event_does_not_lose_its_reminder_to_another_turn(
             conversation_id,
             event_keys,
             visible_event_keys=frozenset(),
+            inbox,
+            inbox_turn_id,
         ):
             result = super().run(
                 prompt,
                 conversation_id=conversation_id,
                 event_keys=event_keys,
                 visible_event_keys=visible_event_keys,
+                inbox=inbox,
+                inbox_turn_id=inbox_turn_id,
             )
             if (
                 event_keys == frozenset({newer.dedupe_key})
@@ -609,7 +772,6 @@ def test_preserved_workspace_divergence_is_delivered_to_the_existing_turn():
     assert turns.calls[0][2] == frozenset(
         {event.dedupe_key, conflict.event.dedupe_key}
     )
-    assert "do not reset or discard local work" in turns.calls[0][0]
 
 
 def student_assignment_event():
@@ -811,7 +973,7 @@ def test_failed_workspace_divergence_turn_is_retried():
     assert len(turns.calls) == 2
 
 
-def test_successful_turn_acknowledges_and_suppresses_mid_turn_feedback():
+def test_feedback_polled_after_a_turn_is_processed_in_the_next_turn():
     assignment = ControllerEvent(
         kind="student_assignment",
         dedupe_key="student_assignment:assignment-17:revision-2",
@@ -840,9 +1002,13 @@ def test_successful_turn_acknowledges_and_suppresses_mid_turn_feedback():
 
     controller(mailbox, turns, role="student").run(max_cycles=1)
 
-    assert len(turns.calls) == 1
+    assert [call[2] for call in turns.calls] == [
+        frozenset({assignment.dedupe_key}),
+        frozenset({feedback.dedupe_key}),
+    ]
     assert mailbox.acknowledged == [
-        (assignment.dedupe_key, feedback.dedupe_key),
+        (assignment.dedupe_key,),
+        (feedback.dedupe_key,),
     ]
 
 

--- a/tests/test_controller_conversations.py
+++ b/tests/test_controller_conversations.py
@@ -35,11 +35,19 @@ class Turns:
         conversation_id,
         event_keys,
         visible_event_keys=frozenset(),
+        inbox,
+        inbox_turn_id,
     ):
         self.calls.append(
             (prompt, conversation_id, event_keys, visible_event_keys)
         )
-        return TurnResult(exit_code=next(self.exit_codes, 0))
+        result = TurnResult(exit_code=next(self.exit_codes, 0))
+        if result.exit_code == 0:
+            turn = inbox.turn(inbox_turn_id)
+            for message in turn.messages:
+                inbox.record_delivered(message.delivery_id, message.body)
+            inbox.record_processed(inbox_turn_id)
+        return result
 
 
 def run_student_controller(tmp_path: Path, mailbox, turns):
@@ -70,7 +78,7 @@ def test_assignment_registry_persists_one_uuid_per_revision(tmp_path: Path):
     assert reopened.for_assignment("assignment-1", "revision-3") != first
 
 
-def test_local_child_wake_targets_only_the_oldest_pending_parent(tmp_path: Path):
+def test_local_child_events_are_delivered_directly_to_each_parent(tmp_path: Path):
     first_parent = UUID("00000000-0000-0000-0000-000000000011")
     second_parent = UUID("00000000-0000-0000-0000-000000000012")
     store_path = tmp_path / "student-events.sqlite3"
@@ -95,9 +103,21 @@ def test_local_child_wake_targets_only_the_oldest_pending_parent(tmp_path: Path)
         AssignmentConversationRegistry(tmp_path / "students.json")
     )(events)
 
-    assert len(events) == 1
-    assert events[0].payload["count"] == 1
-    assert batches[0].conversation_id == first_parent
+    assert [event.dedupe_key for event in events] == [
+        "agent_result:first",
+        "agent_result:second",
+    ]
+    assert [batch.conversation_id for batch in batches] == [
+        first_parent,
+        second_parent,
+    ]
+    assert "parent_conversation_id" not in events[0].to_prompt()
+
+    mailbox = LocalStudentMailbox(store_path)
+    mailbox.acknowledge((events[0].dedupe_key,))
+    assert [event.dedupe_key for event in mailbox.poll()] == [
+        "agent_result:second"
+    ]
 
 
 def test_assignment_feedback_and_monitor_wake_share_the_assignment_uuid(
@@ -147,9 +167,12 @@ def test_controller_partitions_and_acknowledges_events_by_conversation(
         payload={"conversation_id": str(first), "summary": "first only"},
     )
     second_event = ControllerEvent(
-        kind="local_events_pending",
+        kind="agent_result",
         dedupe_key="child:second",
-        payload={"conversation_id": str(second), "summary": "second only"},
+        payload={
+            "parent_conversation_id": str(second),
+            "summary": "second only",
+        },
     )
     mailbox = Mailbox((first_event, second_event))
     turns = Turns()
@@ -157,10 +180,10 @@ def test_controller_partitions_and_acknowledges_events_by_conversation(
     run_student_controller(tmp_path, mailbox, turns)
 
     assert [call[1] for call in turns.calls] == [first, second]
-    assert "first only" in turns.calls[0][0]
-    assert "second only" not in turns.calls[0][0]
-    assert "second only" in turns.calls[1][0]
-    assert "first only" not in turns.calls[1][0]
+    assert [call[2] for call in turns.calls] == [
+        frozenset({first_event.dedupe_key}),
+        frozenset({second_event.dedupe_key}),
+    ]
     assert mailbox.acknowledged == [
         (first_event.dedupe_key,),
         (second_event.dedupe_key,),
@@ -187,3 +210,27 @@ def test_failed_conversation_does_not_ack_or_starve_another(tmp_path: Path):
 
     assert [call[1] for call in turns.calls] == [first, second]
     assert mailbox.acknowledged == [(second_event.dedupe_key,)]
+
+
+def test_bounded_backlog_yields_to_another_ready_conversation(tmp_path: Path):
+    first = UUID("00000000-0000-0000-0000-000000000085")
+    second = UUID("00000000-0000-0000-0000-000000000086")
+    backlog = tuple(
+        ControllerEvent(
+            kind="agent_result",
+            dedupe_key=f"first:{index}",
+            payload={"parent_conversation_id": str(first), "index": index},
+        )
+        for index in range(20)
+    )
+    other = ControllerEvent(
+        kind="agent_result",
+        dedupe_key="second:0",
+        payload={"parent_conversation_id": str(second)},
+    )
+    turns = Turns()
+
+    run_student_controller(tmp_path, Mailbox((*backlog, other)), turns)
+
+    assert [call[1] for call in turns.calls] == [first, second, first]
+    assert [len(call[2]) for call in turns.calls] == [16, 1, 4]

--- a/tests/test_controller_github_feedback.py
+++ b/tests/test_controller_github_feedback.py
@@ -128,11 +128,19 @@ class Turns:
         conversation_id,
         event_keys,
         visible_event_keys=frozenset(),
+        inbox,
+        inbox_turn_id,
     ):
         self.calls.append(
             (prompt, conversation_id, event_keys, visible_event_keys)
         )
-        return TurnResult(exit_code=next(self.exit_codes, 0))
+        result = TurnResult(exit_code=next(self.exit_codes, 0))
+        if result.exit_code == 0:
+            turn = inbox.turn(inbox_turn_id)
+            for message in turn.messages:
+                inbox.record_delivered(message.delivery_id, message.body)
+            inbox.record_processed(inbox_turn_id)
+        return result
 
 
 def run_student_controller(tmp_path: Path, mailbox, turns):

--- a/tests/test_inbox_delivery.py
+++ b/tests/test_inbox_delivery.py
@@ -1,0 +1,443 @@
+import hashlib
+import json
+from collections import Counter
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import UUID
+
+import pytest
+
+from senpai_agent.inbox import (
+    DeliveryState,
+    PersistentInbox,
+    deliver_turn_messages,
+    turn_has_finished_response,
+)
+
+
+CONVERSATION_ID = UUID("00000000-0000-0000-0000-000000000017")
+
+
+class Conversation:
+    def __init__(self, events=()):
+        self.events = list(events)
+        self.sent: list[tuple[str, str]] = []
+        self.state = SimpleNamespace(active_branch=lambda: list(self.events))
+
+    def send_message(self, message: str, sender: str | None = None) -> None:
+        assert sender is not None
+        self.sent.append((message, sender))
+        self.events.append(SimpleNamespace(message=message, sender=sender))
+
+
+def event_message(index: int, size: int = 0) -> str:
+    return f"event-{index}:" + ("x" * size)
+
+
+def delivery_sender(delivery_id: str) -> str:
+    return "senpai-delivery:" + hashlib.sha256(delivery_id.encode()).hexdigest()
+
+
+def test_delivery_state_is_durable_and_monotonic_across_restarts(tmp_path: Path):
+    """
+    Requirement: each model-visible message moves pending -> delivered -> processed.
+    Interface: the persistent inbox reopened by a restarted Senpai process.
+    """
+    path = tmp_path / "inbox.sqlite3"
+    inbox = PersistentInbox(path)
+    assert inbox.enqueue(CONVERSATION_ID, "event:1", "first event") is True
+    turn = inbox.next_turn(CONVERSATION_ID, "controller prompt")
+    assert turn is not None
+    assert [message.state for message in turn.messages] == [
+        DeliveryState.PENDING,
+        DeliveryState.PENDING,
+    ]
+
+    event = turn.events[0]
+    inbox.record_delivered(event.delivery_id, event.body)
+    reopened = PersistentInbox(path)
+    resumed = reopened.next_turn(CONVERSATION_ID, "different retry prompt")
+    assert resumed is not None
+    assert resumed.turn_id == turn.turn_id
+    assert resumed.prompt.body == "controller prompt"
+    assert resumed.events[0].state is DeliveryState.DELIVERED
+
+    with pytest.raises(ValueError, match="cannot move backwards"):
+        reopened.record_pending(event.delivery_id)
+
+    reopened.record_delivered(resumed.prompt.delivery_id, resumed.prompt.body)
+    reopened.record_processed(turn.turn_id)
+    processed = PersistentInbox(path).turn(turn.turn_id)
+    assert processed.state is DeliveryState.PROCESSED
+    assert all(
+        message.state is DeliveryState.PROCESSED for message in processed.messages
+    )
+
+
+def test_stable_sender_verifies_payload_after_crash_between_append_and_receipt(
+    tmp_path: Path,
+):
+    """
+    Requirement: recovery recognizes an already-appended message and verifies it.
+    Interface: the sender and body visible on the active OpenHands branch.
+    """
+    inbox = PersistentInbox(tmp_path / "inbox.sqlite3")
+    inbox.enqueue(CONVERSATION_ID, "event:1", "canonical event")
+    turn = inbox.next_turn(CONVERSATION_ID, "canonical prompt")
+    assert turn is not None
+
+    appended_before_crash = [
+        SimpleNamespace(message=message.body, sender=message.sender)
+        for message in turn.messages
+    ]
+    conversation = Conversation(appended_before_crash)
+    deliver_turn_messages(conversation, PersistentInbox(inbox.path), turn.turn_id)
+
+    assert conversation.sent == []
+    assert PersistentInbox(inbox.path).turn(turn.turn_id).state is (
+        DeliveryState.DELIVERED
+    )
+
+    tampered = Conversation(
+        [SimpleNamespace(message="changed payload", sender=turn.events[0].sender)]
+    )
+    with pytest.raises(RuntimeError, match="payload mismatch"):
+        deliver_turn_messages(tampered, PersistentInbox(inbox.path), turn.turn_id)
+
+
+def test_crash_before_append_reuses_turn_and_appends_each_message_once(tmp_path: Path):
+    """
+    Requirement: a crash before append retries the same durable delivery normally.
+    Interface: persistent turn identity and model-visible conversation messages.
+    """
+    path = tmp_path / "inbox.sqlite3"
+    inbox = PersistentInbox(path)
+    inbox.enqueue(CONVERSATION_ID, "event:1", "first event")
+    before_crash = inbox.next_turn(CONVERSATION_ID, "controller prompt")
+    assert before_crash is not None
+
+    after_restart = PersistentInbox(path).next_turn(
+        CONVERSATION_ID,
+        "new prompt that must not replace the active turn",
+    )
+    assert after_restart is not None
+    assert after_restart.turn_id == before_crash.turn_id
+    assert [message.sender for message in after_restart.messages] == [
+        message.sender for message in before_crash.messages
+    ]
+
+    conversation = Conversation()
+    deliver_turn_messages(conversation, PersistentInbox(path), after_restart.turn_id)
+    deliver_turn_messages(conversation, PersistentInbox(path), after_restart.turn_id)
+    assert [message for message, _sender in conversation.sent] == [
+        "controller prompt",
+        "first event",
+    ]
+
+
+def test_fifo_drain_is_bounded_by_event_count_and_bytes(tmp_path: Path):
+    """
+    Requirement: each inference turn receives at most 16 events or 64 KiB.
+    Interface: events returned by the persistent inbox in FIFO order.
+    """
+    inbox = PersistentInbox(tmp_path / "inbox.sqlite3")
+    for index in range(20):
+        inbox.enqueue(CONVERSATION_ID, f"event:{index}", event_message(index))
+
+    first = inbox.next_turn(CONVERSATION_ID, "first prompt")
+    assert first is not None
+    assert [event.event_key for event in first.events] == [
+        f"event:{index}" for index in range(16)
+    ]
+    deliver_turn_messages(Conversation(), inbox, first.turn_id)
+    inbox.record_processed(first.turn_id)
+    inbox.acknowledge(first.turn_id)
+
+    second = inbox.next_turn(CONVERSATION_ID, "second prompt")
+    assert second is not None
+    assert [event.event_key for event in second.events] == [
+        f"event:{index}" for index in range(16, 20)
+    ]
+
+    large_conversation = UUID("00000000-0000-0000-0000-000000000064")
+    inbox.enqueue(large_conversation, "oversized", event_message(0, 70 * 1024))
+    inbox.enqueue(large_conversation, "next", "small")
+    oversized = inbox.next_turn(large_conversation, "large prompt")
+    assert oversized is not None
+    assert [event.event_key for event in oversized.events] == ["oversized"]
+
+
+def test_new_events_wait_behind_an_unresolved_delivery(tmp_path: Path):
+    """
+    Requirement: retries never admit newly observed events into an unresolved turn.
+    Interface: next_turn while a delivered turn has not been processed.
+    """
+    inbox = PersistentInbox(tmp_path / "inbox.sqlite3")
+    inbox.enqueue(CONVERSATION_ID, "event:first", "first")
+    first = inbox.next_turn(CONVERSATION_ID, "first prompt")
+    assert first is not None
+    deliver_turn_messages(Conversation(), inbox, first.turn_id)
+
+    inbox.enqueue(CONVERSATION_ID, "event:later", "later")
+    retry = inbox.next_turn(CONVERSATION_ID, "retry prompt")
+    assert retry is not None
+    assert retry.turn_id == first.turn_id
+    assert [event.event_key for event in retry.events] == ["event:first"]
+    assert inbox.pending_count(CONVERSATION_ID) == 1
+
+
+def test_context_reset_preserves_old_turn_and_requeues_one_canonical_copy(
+    tmp_path: Path,
+):
+    """
+    Requirement: context reset preserves audit history and creates one recovery copy.
+    Interface: reset_turn plus the active and historical persistent turns.
+    """
+    inbox = PersistentInbox(tmp_path / "inbox.sqlite3")
+    inbox.enqueue(CONVERSATION_ID, "event:1", "canonical event")
+    old = inbox.next_turn(CONVERSATION_ID, "old branch prompt")
+    assert old is not None
+    deliver_turn_messages(Conversation(), inbox, old.turn_id)
+
+    recovery = inbox.reset_turn(old.turn_id, "fresh branch prompt")
+    repeated = PersistentInbox(inbox.path).reset_turn(
+        old.turn_id,
+        "a second reset request must not create another copy",
+    )
+
+    assert recovery.turn_id == repeated.turn_id
+    assert recovery.turn_id != old.turn_id
+    assert recovery.prompt.body == "fresh branch prompt"
+    assert [event.body for event in recovery.events] == ["canonical event"]
+    assert recovery.events[0].delivery_id != old.events[0].delivery_id
+    assert inbox.turn(old.turn_id).superseded_by == recovery.turn_id
+    assert inbox.turn(old.turn_id).state is DeliveryState.DELIVERED
+
+
+def test_deliberate_reminder_gets_a_fresh_delivery_identity(tmp_path: Path):
+    """
+    Requirement: a later reminder is a new message, not a replay of an old attempt.
+    Interface: enqueueing the same event after processing and acknowledgement.
+    """
+    inbox = PersistentInbox(tmp_path / "inbox.sqlite3")
+    inbox.enqueue(CONVERSATION_ID, "event:1", "still actionable")
+    first = inbox.next_turn(CONVERSATION_ID, "first prompt")
+    assert first is not None
+    deliver_turn_messages(Conversation(), inbox, first.turn_id)
+    inbox.record_processed(first.turn_id)
+    inbox.acknowledge(first.turn_id)
+
+    assert inbox.enqueue(CONVERSATION_ID, "event:1", "still actionable") is True
+    reminder = inbox.next_turn(CONVERSATION_ID, "reminder prompt")
+    assert reminder is not None
+    assert reminder.events[0].delivery_id != first.events[0].delivery_id
+    assert reminder.events[0].sender != first.events[0].sender
+
+
+def test_108_events_and_four_failed_resumes_leave_one_visible_copy_per_event(
+    tmp_path: Path,
+):
+    """
+    Requirement: repeated failed inference cannot multiply model-visible events.
+    Interface: persistent bounded turns delivered into one OpenHands conversation.
+    """
+    path = tmp_path / "inbox.sqlite3"
+    inbox = PersistentInbox(path)
+    for index in range(108):
+        inbox.enqueue(CONVERSATION_ID, f"event:{index}", event_message(index))
+
+    conversation = Conversation()
+    first = inbox.next_turn(CONVERSATION_ID, "prompt-0")
+    assert first is not None
+    for _failure in range(4):
+        deliver_turn_messages(conversation, PersistentInbox(path), first.turn_id)
+        resumed = PersistentInbox(path).next_turn(CONVERSATION_ID, "changed retry")
+        assert resumed is not None and resumed.turn_id == first.turn_id
+
+    deliver_turn_messages(conversation, inbox, first.turn_id)
+    inbox.record_processed(first.turn_id)
+    inbox.acknowledge(first.turn_id)
+
+    turn_number = 1
+    while inbox.pending_count(CONVERSATION_ID):
+        turn = inbox.next_turn(CONVERSATION_ID, f"prompt-{turn_number}")
+        assert turn is not None
+        deliver_turn_messages(conversation, inbox, turn.turn_id)
+        inbox.record_processed(turn.turn_id)
+        inbox.acknowledge(turn.turn_id)
+        turn_number += 1
+
+    visible = Counter(message for message, _sender in conversation.sent)
+    assert all(visible[event_message(index)] == 1 for index in range(108))
+
+
+@pytest.mark.parametrize(
+    "prompt_identity",
+    (
+        "initial:full historical prompt",
+        "system-context:historical system context",
+        "turn:00000000-0000-0000-0000-000000000117",
+    ),
+)
+def test_legacy_pr3472_delivery_is_adopted_without_replay(
+    tmp_path: Path,
+    prompt_identity: str,
+):
+    """All old prompt modes and verbose pump payloads survive the cutover."""
+    event_key = "review_ready:17:abc"
+    event_body = "canonical compact event"
+    historical_event_body = "# Senpai event: review_ready\n\nverbose historical body"
+    legacy_event_id = "00000000-0000-0000-0000-000000000117"
+    legacy_path = tmp_path / "pending-message-deliveries.json"
+    legacy_value = {
+        str(CONVERSATION_ID): {event_key: legacy_event_id},
+    }
+    legacy_path.write_text(json.dumps(legacy_value), encoding="utf-8")
+
+    inbox = PersistentInbox(
+        tmp_path / "inbox.sqlite3",
+        legacy_path=legacy_path,
+    )
+    inbox.enqueue(CONVERSATION_ID, event_key, event_body)
+    turn = inbox.next_turn(
+        CONVERSATION_ID,
+        "new controller prompt",
+        legacy_prompt_identity=prompt_identity,
+    )
+    assert turn is not None
+
+    legacy_prompt_id = (
+        "controller-prompt:"
+        + hashlib.sha256(prompt_identity.encode()).hexdigest()
+    )
+
+    branch = [
+        SimpleNamespace(
+            message="old controller prompt",
+            sender=delivery_sender(legacy_prompt_id),
+        ),
+        SimpleNamespace(
+            message=historical_event_body,
+            sender=delivery_sender(legacy_event_id),
+        ),
+        SimpleNamespace(message="completed answer", sender="agent"),
+    ]
+    conversation = Conversation(branch)
+
+    recovered = deliver_turn_messages(conversation, inbox, turn.turn_id)
+
+    assert conversation.sent == []
+    assert recovered.prompt.delivery_id == legacy_prompt_id
+    assert recovered.prompt.body == "old controller prompt"
+    assert recovered.events[0].body == historical_event_body
+    assert turn_has_finished_response(conversation, recovered)
+    inbox.record_processed(turn.turn_id)
+    inbox.acknowledge(turn.turn_id)
+
+    assert inbox.enqueue(CONVERSATION_ID, event_key, event_body) is True
+    reminder = inbox.next_turn(CONVERSATION_ID, "later reminder")
+    assert reminder is not None
+    assert reminder.events[0].delivery_id != legacy_event_id
+    assert json.loads(legacy_path.read_text(encoding="utf-8")) == legacy_value
+
+
+def test_unappended_legacy_backlog_obeys_normal_count_and_byte_limits(
+    tmp_path: Path,
+):
+    """Migrating the old JSON ledger cannot recreate one oversized injection."""
+    legacy_path = tmp_path / "pending-message-deliveries.json"
+    legacy_path.write_text(
+        json.dumps(
+            {
+                str(CONVERSATION_ID): {
+                    f"event:{index}": str(UUID(int=1000 + index))
+                    for index in range(20)
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    inbox = PersistentInbox(tmp_path / "inbox.sqlite3", legacy_path=legacy_path)
+    for index in range(20):
+        inbox.enqueue(CONVERSATION_ID, f"event:{index}", event_message(index))
+
+    turn = inbox.next_turn(CONVERSATION_ID, "bounded migration prompt")
+    assert turn is not None
+    assert len(turn.events) == 16
+
+    conversation = Conversation()
+    deliver_turn_messages(conversation, inbox, turn.turn_id)
+    assert len(conversation.sent) == 17
+    assert inbox.pending_count(CONVERSATION_ID) == 4
+
+    byte_conversation = UUID(int=65)
+    byte_ledger = tmp_path / "byte-pending-message-deliveries.json"
+    byte_ledger.write_text(
+        json.dumps(
+            {
+                str(byte_conversation): {
+                    "large": str(UUID(int=2000)),
+                    "next": str(UUID(int=2001)),
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    byte_inbox = PersistentInbox(
+        tmp_path / "byte-inbox.sqlite3",
+        legacy_path=byte_ledger,
+    )
+    byte_inbox.enqueue(
+        byte_conversation,
+        "large",
+        event_message(0, 70 * 1024),
+    )
+    byte_inbox.enqueue(byte_conversation, "next", "small")
+    oversized = byte_inbox.next_turn(byte_conversation, "byte limit")
+    assert oversized is not None
+    assert [event.event_key for event in oversized.events] == ["large"]
+
+
+def test_already_visible_legacy_batch_is_absorbed_without_replay(tmp_path: Path):
+    """Old model-visible events are reconciled together without a new injection."""
+    legacy_path = tmp_path / "pending-message-deliveries.json"
+    deliveries = {
+        f"event:{index}": str(UUID(int=3000 + index)) for index in range(20)
+    }
+    legacy_path.write_text(
+        json.dumps({str(CONVERSATION_ID): deliveries}),
+        encoding="utf-8",
+    )
+    inbox = PersistentInbox(tmp_path / "inbox.sqlite3", legacy_path=legacy_path)
+    for index in range(20):
+        inbox.enqueue(CONVERSATION_ID, f"event:{index}", event_message(index))
+    selected = inbox.next_turn(CONVERSATION_ID, "new bounded prompt")
+    assert selected is not None
+    assert len(selected.events) == 16
+
+    old_prompt_id = "controller-prompt:historical-batch"
+    branch = [
+        SimpleNamespace(
+            message="old batch prompt",
+            sender=delivery_sender(old_prompt_id),
+        ),
+        *(
+            SimpleNamespace(
+                message=f"historical-{index}",
+                sender=delivery_sender(deliveries[f"event:{index}"]),
+            )
+            for index in range(20)
+        ),
+        SimpleNamespace(message="completed answer", sender="agent"),
+    ]
+    conversation = Conversation(branch)
+
+    recovered = deliver_turn_messages(conversation, inbox, selected.turn_id)
+
+    assert conversation.sent == []
+    assert len(recovered.events) == 20
+    assert [event.body for event in recovered.events] == [
+        f"historical-{index}" for index in range(20)
+    ]
+    assert inbox.pending_count(CONVERSATION_ID) == 0
+    assert turn_has_finished_response(conversation, recovered)

--- a/tests/test_openhands_conversation.py
+++ b/tests/test_openhands_conversation.py
@@ -9,6 +9,7 @@ from openhands.sdk.conversation import ConversationExecutionStatus
 from openhands.sdk.llm import Message, TextContent
 
 import senpai_agent.openhands_runner as runner
+from senpai_agent.inbox import DeliveryState, PersistentInbox
 from senpai_agent.openhands_runner import (
     graceful_interrupts,
     main,
@@ -129,6 +130,330 @@ def test_context_reset_preserves_history_and_starts_a_fresh_active_branch(
         "close",
     ]
     assert calls[1] == ("navigate", None)
+
+
+def test_provider_timeout_resumes_inference_without_resending_the_turn(
+    tmp_path,
+    monkeypatch,
+):
+    """
+    Requirement: a timed-out provider turn resumes with arun on its existing branch.
+    Interface: run_openhands, the persistent inbox, and model-visible messages.
+    """
+    history = []
+    sent = []
+    arun_calls = []
+    statuses = [
+        ConversationExecutionStatus.PAUSED,
+        ConversationExecutionStatus.FINISHED,
+    ]
+
+    class FakeConversation:
+        def __init__(self, **kwargs):
+            self.id = kwargs["conversation_id"]
+            self.state = SimpleNamespace(
+                active_branch=lambda: list(history),
+                events=history,
+                execution_status=ConversationExecutionStatus.IDLE,
+            )
+
+        def send_message(self, message, sender=None):
+            sent.append((message, sender))
+            history.append(SimpleNamespace(message=message, sender=sender))
+
+        async def arun(self):
+            arun_calls.append(1)
+            self.state.execution_status = statuses.pop(0)
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(runner, "LocalConversation", FakeConversation)
+    monkeypatch.setattr(
+        runner.ConversationState,
+        "get_unmatched_actions",
+        lambda _events: [],
+    )
+    isolate_agent_discovery(monkeypatch, runner)
+    config = runtime_config(tmp_path)
+    inbox = PersistentInbox(tmp_path / "inbox.sqlite3")
+    inbox.enqueue(config.conversation_id, "event:1", "first event")
+    turn = inbox.next_turn(config.conversation_id, "controller prompt")
+    assert turn is not None
+
+    assert run_openhands(
+        "unused retry prompt",
+        config,
+        inbox=inbox,
+        inbox_turn_id=turn.turn_id,
+    ) == 1
+    assert run_openhands(
+        "another unused retry prompt",
+        config,
+        inbox=PersistentInbox(inbox.path),
+        inbox_turn_id=turn.turn_id,
+    ) == 0
+
+    assert [message for message, _sender in sent] == [
+        "controller prompt",
+        "first event",
+    ]
+    assert len(arun_calls) == 2
+    assert PersistentInbox(inbox.path).turn(turn.turn_id).state is (
+        DeliveryState.PROCESSED
+    )
+
+
+def test_processed_turn_recovers_without_append_or_inference(tmp_path, monkeypatch):
+    """
+    Requirement: a processed turn is acknowledgement-only after restart.
+    Interface: run_openhands against a reopened persistent inbox.
+    """
+    calls = []
+
+    class FakeConversation:
+        def __init__(self, **kwargs):
+            self.id = kwargs["conversation_id"]
+            self.state = SimpleNamespace(
+                active_branch=lambda: [],
+                events=[],
+                execution_status=ConversationExecutionStatus.FINISHED,
+            )
+
+        def send_message(self, *_args, **_kwargs):
+            calls.append("send")
+
+        async def arun(self):
+            calls.append("arun")
+
+        def close(self):
+            calls.append("close")
+
+    monkeypatch.setattr(runner, "LocalConversation", FakeConversation)
+    monkeypatch.setattr(
+        runner.ConversationState,
+        "get_unmatched_actions",
+        lambda _events: [],
+    )
+    isolate_agent_discovery(monkeypatch, runner)
+    config = runtime_config(tmp_path)
+    inbox = PersistentInbox(tmp_path / "inbox.sqlite3")
+    inbox.enqueue(config.conversation_id, "event:1", "first event")
+    turn = inbox.next_turn(config.conversation_id, "controller prompt")
+    assert turn is not None
+    for message in turn.messages:
+        inbox.record_delivered(message.delivery_id, message.body)
+    inbox.record_processed(turn.turn_id)
+
+    assert run_openhands(
+        "unused",
+        config,
+        inbox=PersistentInbox(inbox.path),
+        inbox_turn_id=turn.turn_id,
+    ) == 0
+    assert calls == ["close"]
+
+
+def test_finished_branch_repairs_processing_receipt_without_inference(
+    tmp_path,
+    monkeypatch,
+):
+    """
+    Requirement: a crash after inference is recovered from durable conversation state.
+    Interface: active branch, persistent inbox, send count, and arun count.
+    """
+    calls = []
+    config = runtime_config(tmp_path)
+    inbox = PersistentInbox(tmp_path / "inbox.sqlite3")
+    inbox.enqueue(config.conversation_id, "event:1", "first event")
+    turn = inbox.next_turn(config.conversation_id, "controller prompt")
+    assert turn is not None
+    for message in turn.messages:
+        inbox.record_delivered(message.delivery_id, message.body)
+    branch = [
+        SimpleNamespace(message=message.body, sender=message.sender)
+        for message in turn.messages
+    ]
+    branch.append(SimpleNamespace(message="completed answer", sender="agent"))
+
+    class FakeConversation:
+        def __init__(self, **kwargs):
+            self.id = kwargs["conversation_id"]
+            self.state = SimpleNamespace(
+                active_branch=lambda: list(branch),
+                events=branch,
+                execution_status=ConversationExecutionStatus.FINISHED,
+            )
+
+        def send_message(self, *_args, **_kwargs):
+            calls.append("send")
+
+        async def arun(self):
+            calls.append("arun")
+
+        def close(self):
+            calls.append("close")
+
+    monkeypatch.setattr(runner, "LocalConversation", FakeConversation)
+    monkeypatch.setattr(
+        runner.ConversationState,
+        "get_unmatched_actions",
+        lambda _events: [],
+    )
+    isolate_agent_discovery(monkeypatch, runner)
+
+    assert run_openhands(
+        "unused",
+        config,
+        inbox=PersistentInbox(inbox.path),
+        inbox_turn_id=turn.turn_id,
+    ) == 0
+    assert calls == ["close"]
+    assert PersistentInbox(inbox.path).turn(turn.turn_id).state is (
+        DeliveryState.PROCESSED
+    )
+
+
+def test_context_reset_preserves_old_branch_and_requeues_once(tmp_path, monkeypatch):
+    """
+    Requirement: reset keeps the old trace and creates one canonical recovery copy.
+    Interface: OpenHands branch navigation, sends, arun calls, and persistent inbox.
+    """
+    config = runtime_config(tmp_path)
+    inbox = PersistentInbox(tmp_path / "inbox.sqlite3")
+    inbox.enqueue(config.conversation_id, "event:1", "first event")
+    old_turn = inbox.next_turn(config.conversation_id, "old controller prompt")
+    assert old_turn is not None
+    old_branch = [
+        SimpleNamespace(message=message.body, sender=message.sender)
+        for message in old_turn.messages
+    ]
+    for message in old_turn.messages:
+        inbox.record_delivered(message.delivery_id, message.body)
+
+    active = list(old_branch)
+    archived = list(old_branch)
+    calls = []
+    statuses = [
+        ConversationExecutionStatus.PAUSED,
+        ConversationExecutionStatus.FINISHED,
+    ]
+
+    class FakeConversation:
+        def __init__(self, **kwargs):
+            self.id = kwargs["conversation_id"]
+            self.state = SimpleNamespace(
+                active_branch=lambda: list(active),
+                events=archived,
+                execution_status=ConversationExecutionStatus.ERROR,
+            )
+
+        def navigate_to(self, event_id):
+            calls.append(("navigate", event_id))
+            active.clear()
+
+        def send_message(self, message, sender=None):
+            calls.append(("send", message))
+            event = SimpleNamespace(message=message, sender=sender)
+            active.append(event)
+            archived.append(event)
+
+        async def arun(self):
+            calls.append(("arun", None))
+            self.state.execution_status = statuses.pop(0)
+
+        def close(self):
+            calls.append(("close", None))
+
+    monkeypatch.setattr(runner, "LocalConversation", FakeConversation)
+    monkeypatch.setattr(
+        runner.ConversationState,
+        "get_unmatched_actions",
+        lambda _events: [],
+    )
+    isolate_agent_discovery(monkeypatch, runner)
+
+    for _attempt in range(2):
+        run_openhands(
+            "fresh recovery prompt",
+            config,
+            reset_context=True,
+            inbox=PersistentInbox(inbox.path),
+            inbox_turn_id=old_turn.turn_id,
+        )
+
+    assert archived[: len(old_branch)] == old_branch
+    assert [name for name, _value in calls].count("navigate") == 1
+    assert [name for name, _value in calls].count("send") == 2
+    assert [name for name, _value in calls].count("arun") == 2
+    assert len(active) == 2
+
+
+def test_restart_after_recovery_commit_resets_before_delivering(tmp_path, monkeypatch):
+    """A crash after reset persistence cannot deliver onto the polluted branch."""
+    config = runtime_config(tmp_path)
+    inbox = PersistentInbox(tmp_path / "inbox.sqlite3")
+    inbox.enqueue(config.conversation_id, "event:1", "canonical event")
+    old = inbox.next_turn(config.conversation_id, "old prompt")
+    assert old is not None
+    old_branch = [
+        SimpleNamespace(message=message.body, sender=message.sender)
+        for message in old.messages
+    ]
+    for message in old.messages:
+        inbox.record_delivered(message.delivery_id, message.body)
+    recovery = inbox.reset_turn(old.turn_id, "recovery prompt")
+
+    active = list(old_branch)
+    archived = list(old_branch)
+    calls = []
+
+    class FakeConversation:
+        def __init__(self, **kwargs):
+            self.id = kwargs["conversation_id"]
+            self.state = SimpleNamespace(
+                active_branch=lambda: list(active),
+                events=archived,
+                execution_status=ConversationExecutionStatus.ERROR,
+            )
+
+        def navigate_to(self, event_id):
+            calls.append(("navigate", event_id))
+            active.clear()
+
+        def send_message(self, message, sender=None):
+            calls.append(("send", message))
+            event = SimpleNamespace(message=message, sender=sender)
+            active.append(event)
+            archived.append(event)
+
+        async def arun(self):
+            calls.append(("arun", None))
+            self.state.execution_status = ConversationExecutionStatus.FINISHED
+
+        def close(self):
+            calls.append(("close", None))
+
+    monkeypatch.setattr(runner, "LocalConversation", FakeConversation)
+    monkeypatch.setattr(
+        runner.ConversationState,
+        "get_unmatched_actions",
+        lambda _events: [],
+    )
+    isolate_agent_discovery(monkeypatch, runner)
+
+    assert run_openhands(
+        "unused normal-restart prompt",
+        config,
+        inbox=PersistentInbox(inbox.path),
+        inbox_turn_id=recovery.turn_id,
+    ) == 0
+
+    assert [name for name, _value in calls[:3]] == ["navigate", "send", "send"]
+    assert [event.message for event in active] == [
+        "recovery prompt",
+        "canonical event",
+    ]
 
 
 def test_child_requests_ephemeral_storage_and_emits_its_terminal_report(

--- a/tests/test_openhands_sdk.py
+++ b/tests/test_openhands_sdk.py
@@ -2,6 +2,7 @@ import re
 import tomllib
 from types import SimpleNamespace
 from urllib.parse import parse_qs, urlsplit
+from uuid import UUID
 
 import pytest
 from openhands.sdk import Agent, LLM, LocalConversation
@@ -20,6 +21,7 @@ from senpai_agent.openhands_runner import (
     parse_runner_args,
     prompt_cache_configuration,
 )
+from senpai_agent.inbox import DeliveryState, PersistentInbox, deliver_turn_messages
 from openhands_support import REPO_ROOT, runtime_config
 
 
@@ -418,6 +420,45 @@ def test_local_conversation_exposes_the_configured_prompt_cache_key(tmp_path):
         )
     finally:
         conversation.close()
+
+
+def test_local_conversation_persists_delivery_sender_and_payload(tmp_path):
+    conversation_id = UUID("00000000-0000-0000-0000-000000000117")
+    inbox = PersistentInbox(tmp_path / "inbox.sqlite3")
+    inbox.enqueue(conversation_id, "event:1", "durable event")
+    turn = inbox.next_turn(conversation_id, "durable prompt")
+    assert turn is not None
+
+    def conversation():
+        return LocalConversation(
+            agent=Agent(
+                llm=LLM(
+                    model="openai/gpt-5.6",
+                    api_key=SecretStr("test-key"),
+                ),
+                tools=[],
+            ),
+            workspace=tmp_path,
+            persistence_dir=tmp_path / "openhands-state",
+            conversation_id=conversation_id,
+            visualizer=None,
+        )
+
+    first = conversation()
+    try:
+        for message in turn.messages:
+            first.send_message(message.body, sender=message.sender)
+    finally:
+        first.close()
+
+    reopened = conversation()
+    try:
+        event_count = len(reopened.state.events)
+        recovered = deliver_turn_messages(reopened, inbox, turn.turn_id)
+        assert len(reopened.state.events) == event_count
+        assert recovered.state is DeliveryState.DELIVERED
+    finally:
+        reopened.close()
 
 
 def test_event_summary_bounds_fields_and_keeps_the_latest_text():


### PR DESCRIPTION
## Summary

- replace retry-time message replay with a durable pending → delivered → processed inbox
- resume delivered provider failures without resending, and reconcile completed turns without inference
- bound and fairly schedule queued events while keeping new events behind unresolved turns
- migrate PR #3472 JSON delivery IDs, including initial/system/continuation prompts and verbose event-pump payloads
- preserve context-reset history while requeueing one canonical recovery copy

## Verification

- `python -m pytest -q` — 845 passed, 6 skipped
- `python -m compileall -q senpai_agent tests`
- `git diff --check`
- three independent P0/P1 release audits: clear
