### PR TITLE
Keep runtime credentials through lazy tool initialization

### DIFF
--- a/senpai_agent/openhands_runner.py
+++ b/senpai_agent/openhands_runner.py
@@ -1425,30 +1425,25 @@ def run_openhands(
                 flush=True,
             )
         inference_required = True
-        try:
-            # send_message performs OpenHands' lazy tool initialization.
-            if inbox is None or active_inbox_turn_id is None:
-                conversation.send_message(prompt)
+        if inbox is None or active_inbox_turn_id is None:
+            conversation.send_message(prompt)
+        else:
+            turn = inbox.turn(active_inbox_turn_id)
+            if turn.state is DeliveryState.PROCESSED:
+                inference_required = False
             else:
-                turn = inbox.turn(active_inbox_turn_id)
-                if turn.state is DeliveryState.PROCESSED:
+                turn = deliver_turn_messages(
+                    conversation,
+                    inbox,
+                    active_inbox_turn_id,
+                )
+                if (
+                    conversation.state.execution_status
+                    == ConversationExecutionStatus.FINISHED
+                    and turn_has_finished_response(conversation, turn)
+                ):
+                    inbox.record_processed(active_inbox_turn_id)
                     inference_required = False
-                else:
-                    turn = deliver_turn_messages(
-                        conversation,
-                        inbox,
-                        active_inbox_turn_id,
-                    )
-                    if (
-                        conversation.state.execution_status
-                        == ConversationExecutionStatus.FINISHED
-                        and turn_has_finished_response(conversation, turn)
-                    ):
-                        inbox.record_processed(active_inbox_turn_id)
-                        inference_required = False
-        finally:
-            clear_github_credentials()
-            configure_delegation(None)
         if inference_required:
             with graceful_interrupts(conversation):
                 if not config.child:

--- a/tests/test_openhands_conversation.py
+++ b/tests/test_openhands_conversation.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import pytest
 from openhands.sdk.conversation import ConversationExecutionStatus
 from openhands.sdk.llm import Message, TextContent
+from openhands.sdk.tool import resolve_tool
 
 import senpai_agent.openhands_runner as runner
 from senpai_agent.inbox import DeliveryState, PersistentInbox
@@ -657,6 +658,69 @@ def test_conversation_and_credentials_are_cleaned_up_after_failures(
     assert closed == [True]
     assert cleared
     assert delegation[-1] is None
+
+
+def test_runtime_credentials_remain_configured_through_lazy_tool_initialization(
+    tmp_path,
+    monkeypatch,
+):
+    captured = {}
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    class FakeConversation:
+        def __init__(self, agent, **kwargs):
+            self.agent = agent
+            self.id = kwargs["conversation_id"]
+            self.state = SimpleNamespace(
+                execution_status=ConversationExecutionStatus.FINISHED,
+                workspace=SimpleNamespace(working_dir=workspace),
+            )
+
+        def send_message(self, _prompt):
+            pass
+
+        async def arun(self):
+            specs = {
+                tool.name: tool
+                for tool in self.agent.tools
+                if tool.name in {"senpai_github", "spawn_agents"}
+            }
+            captured["specs"] = specs
+            captured["state"] = self.state
+            captured["resolved"] = {
+                name: {tool.name for tool in resolve_tool(spec, self.state)}
+                for name, spec in specs.items()
+            }
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(runner, "LocalConversation", FakeConversation)
+    isolate_agent_discovery(monkeypatch, runner)
+
+    config = runtime_config(
+        tmp_path,
+        workspace=workspace,
+        role="student",
+        student_name="Fern",
+    )
+    assert run_openhands("task", config) == 0
+    assert captured["resolved"] == {
+        "senpai_github": {
+            "get_prs",
+            "respond_to_human_issue",
+            "submit_experiment_result",
+        },
+        "spawn_agents": {"spawn_agents"},
+    }
+    with pytest.raises(
+        RuntimeError,
+        match="configure GitHub credentials before initializing workflows",
+    ):
+        resolve_tool(captured["specs"]["senpai_github"], captured["state"])
+    with pytest.raises(RuntimeError, match="subagent runtime is not configured"):
+        resolve_tool(captured["specs"]["spawn_agents"], captured["state"])
 
 
 def test_turn_deadline_requests_conversation_interrupt(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- keep GitHub and delegation runtime configuration available through OpenHands lazy tool initialization in arun()
- rely on the existing outer finally for cleanup on success, failure, interrupt, and timeout
- add a high-fidelity regression test that resolves the real GitHub and spawn tools during inference and verifies cleanup afterward

## Validation
- 846 passed, 6 skipped
- independent P0/P1 review: no findings

This fixes the live Maple/Fern restart loop: send_message() did not always initialize tools, but Senpai cleared credentials before arun().