### PR TITLE
Make legacy inbox adoption restart-idempotent

### DIFF
--- a/senpai_agent/inbox.py
+++ b/senpai_agent/inbox.py
@@ -499,11 +499,20 @@ class PersistentInbox:
                 for message in turn.events
                 if message.sender in positions
             ]
-            prompt_index = self._legacy_prompt_index(
-                turn,
-                branch_senders,
-                frozenset(legacy_by_sender),
-                selected_positions,
+            persisted_prompt_positions = positions.get(turn.prompt.sender, [])
+            if len(persisted_prompt_positions) > 1:
+                raise RuntimeError(
+                    f"duplicate sender {turn.prompt.sender!r} on active branch"
+                )
+            prompt_index = (
+                persisted_prompt_positions[0]
+                if persisted_prompt_positions
+                else self._legacy_prompt_index(
+                    turn,
+                    branch_senders,
+                    frozenset(legacy_by_sender),
+                    selected_positions,
+                )
             )
             if prompt_index is None:
                 return turn
@@ -571,6 +580,7 @@ class PersistentInbox:
                     "UPDATE inbox_messages SET position = ? WHERE delivery_id = ?",
                     (position, row["delivery_id"]),
                 )
+            self._refresh_turn_state(database, turn_id)
             return self._turn(database, turn_id)
 
     def turn(self, turn_id: str) -> InboxTurn:
@@ -888,12 +898,30 @@ class PersistentInbox:
             raise RuntimeError(
                 f"native delivery {current_delivery_id} cannot adopt legacy payload"
             )
-        if DeliveryState(row["state"]) is not DeliveryState.PENDING:
+        already_adopted = (
+            row["event_key"] is None
+            and bool(row["legacy"])
+        )
+        if (
+            DeliveryState(row["state"]) is not DeliveryState.PENDING
+            or already_adopted
+        ):
             _verify_body(row, body)
+            if delivery_id is not None and row["delivery_id"] != delivery_id:
+                raise RuntimeError(
+                    f"delivery {current_delivery_id} identity mismatch"
+                )
             if sender is not None and row["sender"] != sender:
                 raise RuntimeError(
                     f"delivery {current_delivery_id} sender mismatch"
                 )
+            if DeliveryState(row["state"]) is DeliveryState.PENDING:
+                database.execute(
+                    "UPDATE inbox_messages SET state = 'delivered' WHERE delivery_id = ?",
+                    (current_delivery_id,),
+                )
+                if row["turn_id"] is not None:
+                    self._refresh_turn_state(database, row["turn_id"])
             return
         adopted_id = delivery_id or str(row["delivery_id"])
         adopted_sender = sender or str(row["sender"])
@@ -904,7 +932,8 @@ class PersistentInbox:
                 body_sha256 = ?,
                 delivery_id = ?,
                 sender = ?,
-                legacy = 1
+                legacy = 1,
+                state = 'delivered'
             WHERE delivery_id = ?
             """,
             (
@@ -915,6 +944,8 @@ class PersistentInbox:
                 current_delivery_id,
             ),
         )
+        if row["turn_id"] is not None:
+            self._refresh_turn_state(database, row["turn_id"])
 
     def _is_legacy_message(
         self,

--- a/tests/test_inbox_delivery.py
+++ b/tests/test_inbox_delivery.py
@@ -341,6 +341,91 @@ def test_legacy_pr3472_delivery_is_adopted_without_replay(
     assert json.loads(legacy_path.read_text(encoding="utf-8")) == legacy_value
 
 
+def test_adopted_legacy_prompt_is_stable_when_migration_reenters(tmp_path: Path):
+    """Retrying a migrated turn must verify the same nearest historical prompt."""
+    event_key = "job:finished"
+    event_id = str(UUID(int=118))
+    legacy_path = tmp_path / "pending-message-deliveries.json"
+    legacy_path.write_text(
+        json.dumps({str(CONVERSATION_ID): {event_key: event_id}}),
+        encoding="utf-8",
+    )
+    inbox_path = tmp_path / "inbox.sqlite3"
+    inbox = PersistentInbox(
+        inbox_path,
+        legacy_path=legacy_path,
+    )
+    inbox.enqueue(CONVERSATION_ID, event_key, "new compact event")
+    turn = inbox.next_turn(
+        CONVERSATION_ID,
+        "new controller prompt",
+        legacy_prompt_identity="initial:new-controller-prompt",
+    )
+    assert turn is not None
+
+    current_prompt_id = "historical-current-prompt"
+    branch = [
+        SimpleNamespace(
+            message="older controller prompt",
+            sender=delivery_sender("older-controller-prompt"),
+        ),
+        SimpleNamespace(
+            message="current controller prompt",
+            sender=delivery_sender(current_prompt_id),
+        ),
+        SimpleNamespace(
+            message="historical event body",
+            sender=delivery_sender(event_id),
+        ),
+        SimpleNamespace(message="completed answer", sender="agent"),
+    ]
+    conversation = Conversation(branch)
+
+    first = inbox.prepare_legacy_turn(turn.turn_id, branch)
+    assert first.state is DeliveryState.DELIVERED
+    assert all(
+        message.state is DeliveryState.DELIVERED for message in first.messages
+    )
+    inbox.close()
+    reopened = PersistentInbox(inbox_path, legacy_path=legacy_path)
+    second = deliver_turn_messages(conversation, reopened, turn.turn_id)
+
+    assert conversation.sent == []
+    assert first.prompt.delivery_id == second.prompt.delivery_id == (
+        "legacy-prompt:"
+        + delivery_sender(current_prompt_id).removeprefix("senpai-delivery:")
+    )
+    assert second.prompt.body == "current controller prompt"
+    assert second.state is DeliveryState.DELIVERED
+    assert turn_has_finished_response(conversation, second)
+
+    tampered = Conversation(
+        [
+            branch[0],
+            SimpleNamespace(
+                message="tampered current controller prompt",
+                sender=delivery_sender(current_prompt_id),
+            ),
+            *branch[2:],
+        ]
+    )
+    with pytest.raises(RuntimeError, match="payload mismatch"):
+        deliver_turn_messages(tampered, reopened, turn.turn_id)
+
+    tampered_event = Conversation(
+        [
+            *branch[:2],
+            SimpleNamespace(
+                message="tampered historical event body",
+                sender=delivery_sender(event_id),
+            ),
+            branch[3],
+        ]
+    )
+    with pytest.raises(RuntimeError, match="payload mismatch"):
+        deliver_turn_messages(tampered_event, reopened, turn.turn_id)
+
+
 def test_unappended_legacy_backlog_obeys_normal_count_and_byte_limits(
     tmp_path: Path,
 ):


### PR DESCRIPTION
## Summary
- prefer the persisted legacy prompt sender on migration re-entry instead of rediscovering an older prompt
- atomically record visible legacy prompt/event adoption as delivered
- verify canonical payload, sender, and delivery identity on every retry
- add restart/crash-boundary coverage with older prompt history and tampered prompt/event payloads

## Validation
- 847 passed, 6 skipped
- focused inbox/OpenHands/controller suite: 80 passed
- independent P0/P1 re-review: no findings
- live fleet DB audit: 37 active-turn messages all delivered; zero pending legacy prompt/event rows

This fixes the live Cedar/Maple legacy-prompt payload-mismatch controller loops discovered by the fail-closed deployment preflight.