### PR TITLE
Make GitHub inbox event payloads immutable

### DIFF
--- a/senpai_agent/github/mailbox/advisor.py
+++ b/senpai_agent/github/mailbox/advisor.py
@@ -25,8 +25,9 @@ from .values import (
     github_datetime,
     label_names,
     object_value,
-    pull_payload,
+    pull_reference,
     result_matches_assignment,
+    versioned_event,
 )
 from .issues import human_issue_events
 
@@ -41,9 +42,7 @@ def advisor_events(
 ) -> tuple[ControllerEvent, ...]:
     events: list[ControllerEvent] = []
     active_assignments: list[tuple[dict[str, object], AssignmentRecord]] = []
-    active_by_student: dict[str, list[int]] = {
-        student: [] for student in mailbox.students
-    }
+    active_by_student: dict[str, list[int]] = {student: [] for student in mailbox.students}
     now = datetime.now(UTC)
     for pull in pulls:
         labels = label_names(pull)
@@ -57,41 +56,39 @@ def advisor_events(
         if "status:wip" in labels:
             for student in students:
                 active_by_student.setdefault(student, []).append(number)
-        payload = pull_payload(pull)
+        reference = pull_reference(pull)
         assignment = None
         if {"status:wip", "status:review"} & labels:
             try:
-                assignments = parse_assignment_markers(
-                    str(pull.get("body") or "")
-                )
+                assignments = parse_assignment_markers(str(pull.get("body") or ""))
             except ValueError:
                 assignments = []
             if len(assignments) == 1:
                 assignment = assignments[0]
                 active_assignments.append((pull, assignment))
         if "status:review" in labels:
-            dedupe_key = f"review_ready:{number}:{head_sha}"
-            review_payload = payload
+            review_payload = reference
+            review_identity: tuple[object, ...] = (number, head_sha)
             if assignment is not None:
-                dedupe_key = (
-                    f"review_ready:{number}:{assignment.assignment_id}:"
-                    f"{assignment.revision_id}:{head_sha}"
+                review_identity = (
+                    number,
+                    assignment.assignment_id,
+                    assignment.revision_id,
+                    head_sha,
                 )
                 review_payload = {
-                    **payload,
+                    **reference,
                     "assignment_id": assignment.assignment_id,
                     "revision_id": assignment.revision_id,
                 }
             events.append(
-                ControllerEvent(
-                    kind="review_ready",
-                    dedupe_key=dedupe_key,
-                    payload=review_payload,
-                )
+                versioned_event("review_ready", *review_identity, payload=review_payload)
             )
         reasons: list[str] = []
         if "status:blocked" in labels:
             reasons.append("blocked")
+        if "status:hold" in labels:
+            reasons.append("hold")
         if "status:needs-rebase" in labels:
             reasons.append("needs_rebase")
         if not students:
@@ -103,13 +100,14 @@ def advisor_events(
             if (now - updated).total_seconds() >= mailbox.stale_wip_seconds:
                 reasons.append("stale_wip")
         if reasons:
+            action_payload = {**reference, "reasons": reasons}
             events.append(
-                ControllerEvent(
-                    kind="advisor_action",
-                    dedupe_key=(
-                        f"advisor_action:{number}:{head_sha}:{','.join(reasons)}"
-                    ),
-                    payload={**payload, "reasons": reasons},
+                versioned_event(
+                    "advisor_action",
+                    number,
+                    head_sha,
+                    ",".join(reasons),
+                    payload=action_payload,
                 )
             )
 
@@ -183,27 +181,30 @@ def _research_base_events(
             )
         ):
             continue
+        payload = {
+            **pull_reference(pull),
+            "assignment_id": assignment.assignment_id,
+            "revision_id": assignment.revision_id,
+            "student": assignment.student,
+            "base_ref": assignment.base_ref,
+            "required_base_sha": assignment.base_sha,
+            "current_base_sha": current_base_sha,
+            "compare_url": (
+                f"{str(pull['html_url']).rsplit('/pull/', 1)[0]}"
+                f"/compare/{assignment.base_sha}...{current_base_sha}"
+            ),
+        }
         events.append(
-            ControllerEvent(
-                kind="research_base_changed",
-                dedupe_key=(
-                    f"research_base_changed:{number}:"
-                    f"{assignment.assignment_id}:{assignment.revision_id}:"
-                    f"{head_sha}:{assignment.base_sha}:{current_base_sha}"
-                ),
-                payload={
-                    **pull_payload(pull),
-                    "assignment_id": assignment.assignment_id,
-                    "revision_id": assignment.revision_id,
-                    "student": assignment.student,
-                    "base_ref": assignment.base_ref,
-                    "required_base_sha": assignment.base_sha,
-                    "current_base_sha": current_base_sha,
-                    "compare_url": (
-                        f"{str(pull['html_url']).rsplit('/pull/', 1)[0]}"
-                        f"/compare/{assignment.base_sha}...{current_base_sha}"
-                    ),
-                },
+            versioned_event(
+                "research_base_changed",
+                number,
+                assignment.assignment_id,
+                assignment.revision_id,
+                head_sha,
+                assignment.base_ref,
+                assignment.base_sha,
+                current_base_sha,
+                payload=payload,
             )
         )
     return events

--- a/senpai_agent/github/mailbox/feedback.py
+++ b/senpai_agent/github/mailbox/feedback.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from senpai_agent.mailbox import ControllerEvent
@@ -11,15 +12,24 @@ from senpai_agent.models import AssignmentRecord
 from .ledger import read_feedback_ledger, write_feedback_ledger
 from .values import (
     FEEDBACK_EXCERPT_BYTES,
+    FEEDBACK_KEY_PREFIX,
     FeedbackBinding,
     feedback_excerpt,
     github_datetime,
     object_value,
+    payload_digest,
     trusted_feedback,
 )
 
 if TYPE_CHECKING:
     from .core import GitHubMailbox
+
+
+@dataclass(frozen=True, slots=True)
+class _FeedbackCandidate:
+    source_key: str
+    content_digest: str
+    payload: dict[str, object]
 
 
 def student_pr_feedback_events(
@@ -49,7 +59,7 @@ def student_pr_feedback_events(
         for item in feedback_by_surface.get("review", ())
         if item.get("submitted_at") is not None
     }
-    events: list[ControllerEvent] = []
+    candidates: list[_FeedbackCandidate] = []
     for surface, _url in sources:
         for item in feedback_by_surface[surface]:
             if surface == "review" and item.get("submitted_at") is None:
@@ -112,51 +122,117 @@ def student_pr_feedback_events(
                 line = item.get("line") or item.get("original_line")
                 if line is not None:
                     payload["line"] = int(line)
-            events.append(
-                ControllerEvent(
-                    kind="student_pr_feedback",
-                    dedupe_key=(
+            content = {
+                "feedback_type": surface,
+                "feedback_id": feedback_id,
+                "author": payload["author"],
+                "author_association": payload["author_association"],
+                "message": str(item.get("body") or ""),
+                "created_at": created_at,
+                "updated_at": str(
+                    item.get("updated_at")
+                    or item.get("submitted_at")
+                    or item.get("created_at")
+                    or ""
+                ),
+            }
+            content.update(
+                {
+                    key: payload[key]
+                    for key in ("state", "path", "line")
+                    if key in payload
+                }
+            )
+            candidates.append(
+                _FeedbackCandidate(
+                    source_key=(
                         f"student_pr_feedback:{surface}:{number}:{feedback_id}"
                     ),
+                    content_digest=payload_digest(content),
                     payload=payload,
                 )
             )
-    events.sort(
-        key=lambda event: (
-            github_datetime(str(event.payload["created_at"])),
-            str(event.payload["feedback_type"]),
-            int(event.payload["feedback_id"]),
+    candidates.sort(
+        key=lambda candidate: (
+            github_datetime(str(candidate.payload["created_at"])),
+            str(candidate.payload["feedback_type"]),
+            int(candidate.payload["feedback_id"]),
         )
     )
-    return _pending_feedback(mailbox, events, assignment)
+    return _pending_feedback(mailbox, candidates, assignment)
 
 
 def _pending_feedback(
     mailbox: GitHubMailbox,
-    events: Iterable[ControllerEvent],
+    candidates: Iterable[_FeedbackCandidate],
     assignment: AssignmentRecord,
 ) -> list[ControllerEvent]:
     ledger = read_feedback_ledger(mailbox)
     ledger_changed = False
     bound_events: list[ControllerEvent] = []
-    for event in events:
-        binding = ledger.get(event.dedupe_key)
+    for candidate in candidates:
+        event_key = (
+            f"student_pr_feedback:v2:{candidate.source_key.removeprefix(FEEDBACK_KEY_PREFIX)}:"
+            f"{candidate.content_digest}"
+        )
+        binding = ledger.get(event_key)
         if binding is None:
-            binding = FeedbackBinding(
-                assignment_id=str(event.payload["assignment_id"]),
-                revision_id=str(event.payload["revision_id"]),
+            prior = [
+                value
+                for key, value in ledger.items()
+                if key == candidate.source_key
+                or value.source_key == candidate.source_key
+            ]
+            identities = {
+                (value.assignment_id, value.revision_id) for value in prior
+            }
+            if len(identities) > 1:
+                raise RuntimeError(
+                    f"feedback source {candidate.source_key!r} has conflicting bindings"
+                )
+            if identities:
+                assignment_id, revision_id = next(iter(identities))
+            else:
+                assignment_id = str(candidate.payload["assignment_id"])
+                revision_id = str(candidate.payload["revision_id"])
+            payload = {
+                **candidate.payload,
+                "assignment_id": assignment_id,
+                "revision_id": revision_id,
+            }
+            versioned_prior = any(
+                value.source_key == candidate.source_key for value in prior
             )
-            ledger[event.dedupe_key] = binding
+            acknowledged = (
+                bool(prior)
+                and not versioned_prior
+                and all(value.acknowledged for value in prior)
+            )
+            binding = FeedbackBinding(
+                assignment_id=assignment_id,
+                revision_id=revision_id,
+                acknowledged=acknowledged,
+                source_key=candidate.source_key,
+                content_digest=candidate.content_digest,
+                payload=payload,
+            )
+            ledger[event_key] = binding
             ledger_changed = True
+        if (
+            binding.source_key != candidate.source_key
+            or binding.content_digest != candidate.content_digest
+            or binding.payload is None
+            or binding.payload.get("assignment_id") != binding.assignment_id
+            or binding.payload.get("revision_id") != binding.revision_id
+        ):
+            raise RuntimeError(
+                f"feedback event {event_key!r} has incomplete durable content"
+            )
         bound_events.append(
             ControllerEvent(
-                kind=event.kind,
-                dedupe_key=event.dedupe_key,
-                payload={
-                    **event.payload,
-                    "assignment_id": binding.assignment_id,
-                    "revision_id": binding.revision_id,
-                },
+                kind="student_pr_feedback",
+                dedupe_key=event_key,
+                payload=binding.payload,
             )
         )
     if ledger_changed:

--- a/senpai_agent/github/mailbox/issues.py
+++ b/senpai_agent/github/mailbox/issues.py
@@ -13,6 +13,8 @@ from .values import (
     github_datetime,
     label_names,
     object_value,
+    payload_digest,
+    versioned_event,
 )
 
 if TYPE_CHECKING:
@@ -67,22 +69,26 @@ def human_issue_events(
             ),
         )
         number = int(issue["number"])
+        full_message = str(latest["body"])
+        payload = {
+            "number": number,
+            "title": str(issue["title"]),
+            "url": str(issue["html_url"]),
+            "human_message_id": int(latest["id"]),
+            "author": str(latest["author"]),
+            "message": bounded_text(
+                full_message,
+                limit=12_000,
+            ),
+            "created_at": str(latest["created_at"]),
+        }
         events.append(
-            ControllerEvent(
-                kind="human_issue",
-                dedupe_key=f"human_issue:{number}:{latest['id']}",
-                payload={
-                    "number": number,
-                    "title": str(issue["title"]),
-                    "url": str(issue["html_url"]),
-                    "human_message_id": int(latest["id"]),
-                    "author": str(latest["author"]),
-                    "message": bounded_text(
-                        str(latest["body"]),
-                        limit=12_000,
-                    ),
-                    "created_at": str(latest["created_at"]),
-                },
+            versioned_event(
+                "human_issue",
+                number,
+                latest["id"],
+                payload_digest({"message": full_message}),
+                payload=payload,
             )
         )
     return events

--- a/senpai_agent/github/mailbox/ledger.py
+++ b/senpai_agent/github/mailbox/ledger.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping, Sequence
+from dataclasses import replace
 from typing import TYPE_CHECKING
 
 from .values import FEEDBACK_KEY_PREFIX, FeedbackBinding
@@ -33,11 +34,7 @@ def acknowledge_feedback(
         binding = ledger[key]
         if binding.acknowledged:
             continue
-        ledger[key] = FeedbackBinding(
-            assignment_id=binding.assignment_id,
-            revision_id=binding.revision_id,
-            acknowledged=True,
-        )
+        ledger[key] = replace(binding, acknowledged=True)
         changed = True
     if changed:
         write_feedback_ledger(mailbox, ledger)
@@ -64,6 +61,18 @@ def read_feedback_ledger(
             or not isinstance(item.get("assignment_id"), str)
             or not isinstance(item.get("revision_id"), str)
             or not isinstance(item.get("acknowledged"), bool)
+            or (
+                item.get("source_key") is not None
+                and not isinstance(item.get("source_key"), str)
+            )
+            or (
+                item.get("content_digest") is not None
+                and not isinstance(item.get("content_digest"), str)
+            )
+            or (
+                item.get("payload") is not None
+                and not isinstance(item.get("payload"), dict)
+            )
         ):
             raise RuntimeError(
                 f"invalid student PR feedback ledger: {mailbox.feedback_path}"
@@ -72,6 +81,9 @@ def read_feedback_ledger(
             assignment_id=item["assignment_id"],
             revision_id=item["revision_id"],
             acknowledged=item["acknowledged"],
+            source_key=item.get("source_key"),
+            content_digest=item.get("content_digest"),
+            payload=item.get("payload"),
         )
     return ledger
 
@@ -94,6 +106,15 @@ def write_feedback_ledger(
                     "assignment_id": binding.assignment_id,
                     "revision_id": binding.revision_id,
                     "acknowledged": binding.acknowledged,
+                    **(
+                        {
+                            "source_key": binding.source_key,
+                            "content_digest": binding.content_digest,
+                            "payload": binding.payload,
+                        }
+                        if binding.source_key is not None
+                        else {}
+                    ),
                 }
                 for key, binding in sorted(ledger.items())
             },

--- a/senpai_agent/github/mailbox/student.py
+++ b/senpai_agent/github/mailbox/student.py
@@ -11,7 +11,7 @@ from senpai_agent.models import AssignmentRecord, parse_assignment_markers
 
 from .feedback import student_pr_feedback_events
 from .issues import human_issue_events
-from .values import label_names, object_value, pull_payload
+from .values import label_names, object_value, pull_reference, versioned_event
 
 if TYPE_CHECKING:
     from .core import GitHubMailbox
@@ -116,14 +116,13 @@ def student_events(
         except ValueError as error:
             number = int(pull["number"])
             head_sha = str(object_value(pull["head"])["sha"])
+            payload = {
+                **pull_reference(pull),
+                "error": f"Assigned PR #{number}: {error}",
+            }
             events.append(
-                ControllerEvent(
-                    kind="malformed_assignment",
-                    dedupe_key=f"malformed_assignment:{number}:{head_sha}",
-                    payload={
-                        **pull_payload(pull),
-                        "error": f"Assigned PR #{number}: {error}",
-                    },
+                versioned_event(
+                    "malformed_assignment", number, head_sha, payload=payload
                 )
             )
             continue
@@ -139,23 +138,37 @@ def student_events(
             and not duplicate_wip
             and not prior_revision_pending
         ):
+            number = int(pull["number"])
+            head_sha = str(object_value(pull["head"])["sha"])
+            blockers = sorted(
+                label.removeprefix("status:")
+                for label in label_names(pull)
+                if label
+                in {
+                    "status:blocked",
+                    "status:hold",
+                    "status:needs-rebase",
+                }
+            )
+            payload = {
+                **pull_reference(pull),
+                "assignment_id": assignment.assignment_id,
+                "revision_id": assignment.revision_id,
+                "base_ref": assignment.base_ref,
+                "base_sha": assignment.base_sha,
+                "blockers": blockers,
+            }
             events.append(
-                ControllerEvent(
-                    kind="student_assignment",
-                    dedupe_key=(
-                        f"student_assignment:{assignment.assignment_id}:"
-                        f"{assignment.revision_id}:"
-                        f"{assignment.base_ref}:{assignment.head_ref}:"
-                        f"{assignment.base_sha}:"
-                        f"{object_value(pull['head'])['sha']!s}"
-                    ),
-                    payload={
-                        **pull_payload(pull),
-                        "assignment_id": assignment.assignment_id,
-                        "revision_id": assignment.revision_id,
-                        "base_ref": assignment.base_ref,
-                        "base_sha": assignment.base_sha,
-                    },
+                versioned_event(
+                    "student_assignment",
+                    number,
+                    assignment.assignment_id,
+                    assignment.revision_id,
+                    assignment.base_ref,
+                    assignment.head_ref,
+                    assignment.base_sha,
+                    head_sha,
+                    payload=payload,
                 )
             )
         events.extend(feedback)

--- a/senpai_agent/github/mailbox/values.py
+++ b/senpai_agent/github/mailbox/values.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from hashlib import sha256
 
+from senpai_agent.mailbox import ControllerEvent
 from senpai_agent.models import (
     AssignmentRecord,
     ExperimentResult,
@@ -25,19 +28,42 @@ class FeedbackBinding:
     assignment_id: str
     revision_id: str
     acknowledged: bool = False
+    source_key: str | None = None
+    content_digest: str | None = None
+    payload: dict[str, object] | None = None
 
 
-def pull_payload(pull: Mapping[str, object]) -> dict[str, object]:
+def pull_reference(pull: Mapping[str, object]) -> dict[str, object]:
     head = object_value(pull["head"])
     return {
         "number": int(pull["number"]),
-        "title": str(pull["title"]),
         "url": str(pull["html_url"]),
         "head_ref": str(head["ref"]),
         "head_sha": str(head["sha"]),
-        "labels": sorted(label_names(pull)),
-        "updated_at": str(pull["updated_at"]),
     }
+
+
+def payload_digest(payload: Mapping[str, object]) -> str:
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode()
+    return sha256(encoded).hexdigest()
+
+
+def versioned_event(
+    kind: str,
+    *identity: object,
+    payload: dict[str, object],
+) -> ControllerEvent:
+    prefix = ":".join((kind, "v2", *(str(value) for value in identity)))
+    return ControllerEvent(
+        kind=kind,
+        dedupe_key=f"{prefix}:{payload_digest(payload)}",
+        payload=payload,
+    )
 
 
 def result_matches_assignment(
@@ -78,22 +104,38 @@ def github_datetime(value: str) -> datetime:
 
 
 def bounded_text(value: str, *, limit: int) -> str:
-    encoded = value.encode()
-    if len(encoded) <= limit:
-        return value
-    return encoded[-limit:].decode(errors="ignore")
+    return _middle_excerpt(
+        value,
+        limit=limit,
+        marker="\n\n[... middle omitted; open the event URL for full text ...]\n\n",
+    )[0]
 
 
 def feedback_excerpt(value: str, *, limit: int) -> tuple[str, bool]:
+    return _middle_excerpt(
+        value,
+        limit=limit,
+        marker=(
+            "\n\n[... middle omitted; open feedback_url for full text ...]\n\n"
+        ),
+    )
+
+
+def _middle_excerpt(
+    value: str,
+    *,
+    limit: int,
+    marker: str,
+) -> tuple[str, bool]:
     encoded = value.encode()
     if len(encoded) <= limit:
         return value, False
-    marker = "\n\n[... middle omitted; open feedback_url for full text ...]\n\n".encode()
-    content_bytes = limit - len(marker)
+    marker_bytes = marker.encode()
+    content_bytes = limit - len(marker_bytes)
     head_bytes = 3 * content_bytes // 4
     excerpt = (
         encoded[:head_bytes].decode(errors="ignore")
-        + marker.decode()
+        + marker
         + encoded[-(content_bytes - head_bytes) :].decode(errors="ignore")
     )
     return excerpt, True

--- a/senpai_agent/inbox.py
+++ b/senpai_agent/inbox.py
@@ -138,6 +138,9 @@ class PersistentInbox:
             CREATE INDEX IF NOT EXISTS inbox_pending_by_conversation
             ON inbox_messages(conversation_id, state, turn_id, sequence);
 
+            CREATE INDEX IF NOT EXISTS inbox_event_identity
+            ON inbox_messages(conversation_id, event_key);
+
             CREATE INDEX IF NOT EXISTS inbox_turns_by_conversation
             ON inbox_turns(conversation_id, acknowledged, superseded_by, created_at);
 
@@ -201,9 +204,25 @@ class PersistentInbox:
             raise ValueError("event body must not be empty")
         conversation = str(conversation_id)
         with self._transaction() as database:
+            payload_conflict = database.execute(
+                """
+                SELECT 1
+                FROM inbox_messages
+                WHERE conversation_id = ?
+                  AND event_key = ?
+                  AND legacy = 0
+                  AND body != ?
+                LIMIT 1
+                """,
+                (conversation, event_key, body),
+            ).fetchone()
+            if payload_conflict is not None:
+                raise RuntimeError(
+                    f"event {event_key!r} was reused with a different payload"
+                )
             existing = database.execute(
                 """
-                SELECT message.sequence, message.body, message.requires_ack
+                SELECT message.sequence, message.requires_ack
                 FROM inbox_messages AS message
                 LEFT JOIN inbox_turns AS turn ON turn.turn_id = message.turn_id
                 WHERE message.conversation_id = ?
@@ -221,10 +240,6 @@ class PersistentInbox:
                 (conversation, event_key),
             ).fetchone()
             if existing is not None:
-                if existing["body"] != body:
-                    raise RuntimeError(
-                        f"event {event_key!r} was reused with a different payload"
-                    )
                 if requires_ack and not existing["requires_ack"]:
                     database.execute(
                         "UPDATE inbox_messages SET requires_ack = 1 WHERE sequence = ?",
@@ -741,9 +756,10 @@ class PersistentInbox:
                         sender,
                         state,
                         requires_ack,
+                        legacy,
                         turn_id,
                         position
-                    ) VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?)
+                    ) VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?)
                     """,
                     (
                         original.conversation_id,
@@ -753,6 +769,7 @@ class PersistentInbox:
                         delivery_id,
                         _sender(delivery_id),
                         int(message.requires_ack),
+                        int(self._is_legacy_message(database, message.delivery_id)),
                         recovery_id,
                         position,
                     ),

--- a/tests/test_controller_github_advisor.py
+++ b/tests/test_controller_github_advisor.py
@@ -110,14 +110,50 @@ def test_new_review_revision_at_the_same_head_wakes_the_advisor(monkeypatch):
     )
     second = next(event for event in advisor.poll() if event.kind == "review_ready")
 
-    assert first.dedupe_key == (
-        f"review_ready:17:assignment-17:revision-1:{'7' * 40}"
+    assert first.dedupe_key.startswith(
+        f"review_ready:v2:17:assignment-17:revision-1:{'7' * 40}:"
     )
-    assert second.dedupe_key == (
-        f"review_ready:17:assignment-17:revision-2:{'7' * 40}"
+    assert second.dedupe_key.startswith(
+        f"review_ready:v2:17:assignment-17:revision-2:{'7' * 40}:"
     )
     assert first.payload["revision_id"] == "revision-1"
     assert second.payload["revision_id"] == "revision-2"
+
+
+def test_review_event_ignores_mutable_pull_presentation(monkeypatch):
+    reviewed_pull = pull(
+        labels=("research", "student:student-1", "status:review"),
+        body=render_assignment_marker(assignment()),
+        head_sha="7" * 40,
+    )
+    advisor = mailbox(monkeypatch, [reviewed_pull])
+    first = next(event for event in advisor.poll() if event.kind == "review_ready")
+
+    reviewed_pull["title"] = "Clarify the review"
+    reviewed_pull["updated_at"] = "2099-07-29T19:00:00Z"
+    reviewed_pull["labels"].append({"name": "operator-note"})
+    repeated = next(
+        event for event in advisor.poll() if event.kind == "review_ready"
+    )
+
+    assert repeated.dedupe_key == first.dedupe_key
+    assert repeated.to_prompt() == first.to_prompt()
+
+
+def test_review_event_versions_a_branch_rename_at_the_same_head(monkeypatch):
+    reviewed_pull = pull(
+        labels=("research", "student:student-1", "status:review"),
+        body=render_assignment_marker(assignment()),
+        head_sha="7" * 40,
+    )
+    advisor = mailbox(monkeypatch, [reviewed_pull])
+    first = next(event for event in advisor.poll() if event.kind == "review_ready")
+
+    reviewed_pull["head"]["ref"] = "student/renamed-candidate"
+    renamed = next(event for event in advisor.poll() if event.kind == "review_ready")
+
+    assert renamed.dedupe_key != first.dedupe_key
+    assert renamed.payload["head_ref"] == "student/renamed-candidate"
 
 
 @pytest.mark.parametrize(
@@ -157,6 +193,60 @@ def test_advisor_action_reports_each_unsafe_assignment_state(
 
     assert len(actions) == 1
     assert actions[0].payload["reasons"] == [reason]
+
+
+def test_advisor_action_ignores_metadata_that_does_not_change_its_reasons(
+    monkeypatch,
+):
+    assigned_pull = pull(
+        labels=("research", "student:student-1", "status:wip", "status:blocked"),
+    )
+    advisor = mailbox(monkeypatch, [assigned_pull])
+    first = next(event for event in advisor.poll() if event.kind == "advisor_action")
+
+    assigned_pull["title"] = "Clarify the blocked work"
+    assigned_pull["updated_at"] = "2099-07-29T19:00:00Z"
+    assigned_pull["labels"].append({"name": "operator-note"})
+    repeated = next(
+        event for event in advisor.poll() if event.kind == "advisor_action"
+    )
+
+    assert repeated.dedupe_key == first.dedupe_key
+    assert repeated.to_prompt() == first.to_prompt()
+
+
+def test_advisor_action_versions_a_branch_rename_at_the_same_head(monkeypatch):
+    assigned_pull = pull(
+        labels=("research", "student:student-1", "status:wip", "status:blocked"),
+    )
+    advisor = mailbox(monkeypatch, [assigned_pull])
+    first = next(event for event in advisor.poll() if event.kind == "advisor_action")
+
+    assigned_pull["head"]["ref"] = "student/renamed-candidate"
+    renamed = next(event for event in advisor.poll() if event.kind == "advisor_action")
+
+    assert renamed.dedupe_key != first.dedupe_key
+    assert renamed.payload["head_ref"] == "student/renamed-candidate"
+
+
+def test_advisor_action_reports_hold_as_a_blocker(monkeypatch):
+    advisor = mailbox(
+        monkeypatch,
+        [
+            pull(
+                labels=(
+                    "research",
+                    "student:student-1",
+                    "status:wip",
+                    "status:hold",
+                )
+            )
+        ],
+    )
+
+    action = next(event for event in advisor.poll() if event.kind == "advisor_action")
+
+    assert action.payload["reasons"] == ["hold"]
 
 
 def test_duplicate_assignments_report_every_pr_for_the_student(monkeypatch):
@@ -209,9 +299,9 @@ def test_research_base_change_uses_the_fresh_live_branch_head_on_each_poll(
         event for event in advisor.poll() if event.kind == "research_base_changed"
     )
 
-    assert first.dedupe_key == (
-        f"research_base_changed:17:assignment-17:revision-2:"
-        f"{'7' * 40}:{assigned_sha}:{'c' * 40}"
+    assert first.dedupe_key.startswith(
+        f"research_base_changed:v2:17:assignment-17:revision-2:"
+        f"{'7' * 40}:research:{assigned_sha}:{'c' * 40}:"
     )
     assert first.payload["required_base_sha"] == assigned_sha
     assert first.payload["current_base_sha"] == "c" * 40
@@ -223,6 +313,58 @@ def test_research_base_change_uses_the_fresh_live_branch_head_on_each_poll(
         "/repos/acme/widgets/git/ref/heads/research",
         "/repos/acme/widgets/git/ref/heads/research",
     ]
+
+
+def test_research_base_event_ignores_mutable_pull_presentation(monkeypatch):
+    assigned_pull = pull(
+        labels=("research", "student:student-1", "status:wip"),
+        body=render_assignment_marker(assignment(base_sha="b" * 40)),
+        head_sha="7" * 40,
+    )
+    advisor = mailbox(monkeypatch, [assigned_pull])
+    monkeypatch.setattr(
+        advisor._github,
+        "get",
+        lambda _path: {"object": {"sha": "c" * 40}},
+    )
+    first = next(
+        event for event in advisor.poll() if event.kind == "research_base_changed"
+    )
+
+    assigned_pull["title"] = "Clarify the base change"
+    assigned_pull["updated_at"] = "2099-07-29T19:00:00Z"
+    assigned_pull["labels"].append({"name": "operator-note"})
+    repeated = next(
+        event for event in advisor.poll() if event.kind == "research_base_changed"
+    )
+
+    assert repeated.dedupe_key == first.dedupe_key
+    assert repeated.to_prompt() == first.to_prompt()
+
+
+def test_research_base_event_versions_a_branch_rename_at_the_same_head(monkeypatch):
+    assigned_pull = pull(
+        labels=("research", "student:student-1", "status:wip"),
+        body=render_assignment_marker(assignment(base_sha="b" * 40)),
+        head_sha="7" * 40,
+    )
+    advisor = mailbox(monkeypatch, [assigned_pull])
+    monkeypatch.setattr(
+        advisor._github,
+        "get",
+        lambda _path: {"object": {"sha": "c" * 40}},
+    )
+    first = next(
+        event for event in advisor.poll() if event.kind == "research_base_changed"
+    )
+
+    assigned_pull["head"]["ref"] = "student/renamed-candidate"
+    renamed = next(
+        event for event in advisor.poll() if event.kind == "research_base_changed"
+    )
+
+    assert renamed.dedupe_key != first.dedupe_key
+    assert renamed.payload["head_ref"] == "student/renamed-candidate"
 
 
 def terminal_result(*, summary="The candidate remains valid."):

--- a/tests/test_controller_github_feedback.py
+++ b/tests/test_controller_github_feedback.py
@@ -6,6 +6,8 @@ from pydantic import SecretStr
 
 from senpai_agent.controller import Controller, TurnResult
 from senpai_agent.github.mailbox import GitHubMailbox
+from senpai_agent.inbox import PersistentInbox
+from senpai_agent.mailbox import ControllerEvent
 from senpai_agent.models import (
     AssignmentFeedbackRecord,
     AssignmentRecord,
@@ -26,6 +28,7 @@ def feedback(
     association="OWNER",
     user_type="User",
     created_at="2026-07-29T18:01:00Z",
+    updated_at=None,
     **extra,
 ):
     return {
@@ -33,6 +36,7 @@ def feedback(
         "html_url": f"https://github.test/comment/{feedback_id}",
         "body": body,
         "created_at": created_at,
+        "updated_at": updated_at or created_at,
         "author_association": association,
         "user": {"login": author, "type": user_type},
         **extra,
@@ -171,7 +175,80 @@ def test_student_assignment_carries_the_marker_revision_identity(monkeypatch):
     assert event.payload["base_sha"] == "b" * 40
     assert event.payload["head_ref"] == "student/candidate"
     assert event.payload["head_sha"] == "a" * 40
-    assert event.dedupe_key.endswith(f":{'b' * 40}:{'a' * 40}")
+    assert event.dedupe_key.startswith("student_assignment:v2:17:")
+    assert len(event.dedupe_key.rsplit(":", 1)[1]) == 64
+
+
+def test_repolling_one_assignment_after_mutable_pr_metadata_changes_is_idempotent(
+    monkeypatch,
+    tmp_path,
+):
+    mailbox = student_mailbox(monkeypatch, feedback_responses())
+    first = mailbox.poll()[0]
+    inbox = PersistentInbox(tmp_path / "inbox.sqlite3")
+
+    assert inbox.enqueue(UUID(int=17), first.dedupe_key, first.to_prompt()) is True
+
+    pull = mailbox._pulls()[0]
+    pull["title"] = "Clarify the bounded change"
+    pull["updated_at"] = "2026-07-29T18:05:00Z"
+    pull["labels"].append({"name": "operator-note"})
+    repeated = mailbox.poll()[0]
+
+    assert repeated.dedupe_key == first.dedupe_key
+    assert repeated.to_prompt() == first.to_prompt()
+    assert (
+        inbox.enqueue(UUID(int=17), repeated.dedupe_key, repeated.to_prompt())
+        is False
+    )
+
+
+@pytest.mark.parametrize("blocker", ("blocked", "hold", "needs-rebase"))
+def test_actionable_assignment_blockers_create_a_new_event_version(
+    monkeypatch,
+    blocker,
+):
+    mailbox = student_mailbox(monkeypatch, feedback_responses())
+    first = mailbox.poll()[0]
+
+    mailbox._pulls()[0]["labels"].append({"name": f"status:{blocker}"})
+    changed = mailbox.poll()[0]
+
+    assert changed.dedupe_key != first.dedupe_key
+    assert changed.payload["blockers"] == [blocker]
+
+
+def test_v2_assignment_queues_behind_an_unresolved_v1_delivery(
+    monkeypatch,
+    tmp_path,
+):
+    mailbox = student_mailbox(monkeypatch, feedback_responses())
+    current = mailbox.poll()[0]
+    key_parts = current.dedupe_key.split(":")
+    legacy_key = "student_assignment:" + ":".join(key_parts[3:-1])
+    legacy_payload = {
+        **{key: value for key, value in current.payload.items() if key != "blockers"},
+        "title": "Try bounded change",
+        "labels": ["research", "status:wip", "student:student-1"],
+        "updated_at": "2026-07-29T18:00:00Z",
+    }
+    legacy = ControllerEvent(
+        kind="student_assignment",
+        dedupe_key=legacy_key,
+        payload=legacy_payload,
+    )
+    inbox = PersistentInbox(tmp_path / "inbox.sqlite3")
+    inbox.enqueue(UUID(int=17), legacy.dedupe_key, legacy.to_prompt())
+    active = inbox.next_turn(UUID(int=17), "legacy prompt")
+    assert active is not None
+
+    assert inbox.enqueue(UUID(int=17), current.dedupe_key, current.to_prompt()) is True
+    resumed = inbox.next_turn(UUID(int=17), "new prompt")
+
+    assert resumed is not None
+    assert resumed.turn_id == active.turn_id
+    assert resumed.events[0].event_key == legacy.dedupe_key
+    assert inbox.pending_count(UUID(int=17)) == 1
 
 
 @pytest.mark.parametrize(
@@ -266,10 +343,10 @@ def test_trusted_feedback_from_each_github_surface_is_ordered_and_routable(
         if event.kind == "student_pr_feedback"
     ]
 
-    assert [event.dedupe_key for event in events] == [
-        "student_pr_feedback:issue_comment:17:101",
-        "student_pr_feedback:review:17:201",
-        "student_pr_feedback:inline_comment:17:301",
+    assert [":".join(event.dedupe_key.split(":")[:5]) for event in events] == [
+        "student_pr_feedback:v2:issue_comment:17:101",
+        "student_pr_feedback:v2:review:17:201",
+        "student_pr_feedback:v2:inline_comment:17:301",
     ]
     assert {
         (event.payload["assignment_id"], event.payload["revision_id"])
@@ -285,6 +362,66 @@ def test_trusted_feedback_from_each_github_surface_is_ordered_and_routable(
     assert events[1].payload["state"] == "CHANGES_REQUESTED"
     assert events[2].payload["path"] == "train.py"
     assert events[2].payload["line"] == 42
+
+
+def test_editing_unacknowledged_feedback_creates_a_new_event_version(monkeypatch):
+    comment = feedback(101, "Try the narrow change.")
+    mailbox = student_mailbox(
+        monkeypatch,
+        feedback_responses(issue_comments=[comment]),
+    )
+    first = next(
+        event for event in mailbox.poll() if event.kind == "student_pr_feedback"
+    )
+
+    comment["body"] = "Try the narrow change with a paired baseline."
+    comment["updated_at"] = "2026-07-29T18:02:00Z"
+    edited = next(
+        event for event in mailbox.poll() if event.kind == "student_pr_feedback"
+    )
+
+    assert edited.dedupe_key != first.dedupe_key
+    assert edited.payload["feedback_id"] == first.payload["feedback_id"]
+
+    comment["body"] = "Try the narrow change."
+    comment["updated_at"] = "2026-07-29T18:03:00Z"
+    reverted = next(
+        event for event in mailbox.poll() if event.kind == "student_pr_feedback"
+    )
+    assert reverted.dedupe_key != first.dedupe_key
+    assert reverted.dedupe_key != edited.dedupe_key
+    assert reverted.to_prompt() == first.to_prompt()
+
+
+def test_reverting_feedback_after_an_acknowledged_version_emits_a_correction(
+    monkeypatch,
+    tmp_path,
+):
+    comment = feedback(101, "Use direction A.")
+    mailbox = student_mailbox(
+        monkeypatch,
+        feedback_responses(issue_comments=[comment]),
+        feedback_path=tmp_path / "feedback.json",
+    )
+    first = next(
+        event for event in mailbox.poll() if event.kind == "student_pr_feedback"
+    )
+    run_student_controller(tmp_path, mailbox, Turns())
+
+    comment["body"] = "Use direction B."
+    comment["updated_at"] = "2026-07-29T18:02:00Z"
+    edited = next(
+        event for event in mailbox.poll() if event.kind == "student_pr_feedback"
+    )
+
+    comment["body"] = "Use direction A."
+    comment["updated_at"] = "2026-07-29T18:03:00Z"
+    reverted = next(
+        event for event in mailbox.poll() if event.kind == "student_pr_feedback"
+    )
+
+    assert reverted.dedupe_key not in {first.dedupe_key, edited.dedupe_key}
+    assert reverted.payload["message"] == "Use direction A."
 
 
 def test_review_ready_pull_routes_feedback_to_its_assignment_conversation(monkeypatch):
@@ -443,6 +580,9 @@ def test_feedback_stays_pending_and_bound_until_a_student_turn_succeeds(
         responses,
         feedback_path=ledger,
     )
+    original = next(
+        event for event in failed.poll() if event.kind == "student_pr_feedback"
+    )
     run_student_controller(tmp_path, failed, Turns((1,)))
 
     revised = student_mailbox(
@@ -451,9 +591,12 @@ def test_feedback_stays_pending_and_bound_until_a_student_turn_succeeds(
         revision_id="revision-3",
         feedback_path=ledger,
     )
+    revised._pulls()[0]["head"]["sha"] = "c" * 40
     pending = revised.poll()
     assert [event.kind for event in pending] == ["student_pr_feedback"]
     assert pending[0].payload["revision_id"] == "revision-2"
+    assert pending[0].dedupe_key == original.dedupe_key
+    assert pending[0].to_prompt() == original.to_prompt()
 
     turns = Turns()
     run_student_controller(tmp_path, revised, turns)
@@ -496,7 +639,7 @@ def test_controller_drains_feedback_batches_oldest_first_after_success(
 
     feedback_batches = [
         sorted(
-            int(key.rsplit(":", 1)[1])
+            int(key.split(":")[4])
             for key in event_keys
             if key.startswith("student_pr_feedback:")
         )

--- a/tests/test_controller_github_issues.py
+++ b/tests/test_controller_github_issues.py
@@ -62,8 +62,41 @@ def test_malformed_assignment_does_not_suppress_a_human_issue(monkeypatch):
         "malformed_assignment",
         "human_issue",
     ]
-    assert events[0].dedupe_key == f"malformed_assignment:17:{'a' * 40}"
+    assert events[0].dedupe_key.startswith(
+        f"malformed_assignment:v2:17:{'a' * 40}:"
+    )
     assert events[1].payload["human_message_id"] == 700
+
+
+def test_malformed_assignment_versions_only_actionable_error_changes(monkeypatch):
+    student = mailbox(role="student")
+    malformed = {
+        "number": 17,
+        "title": "Try bounded change",
+        "html_url": "https://github.test/acme/widgets/pull/17",
+        "updated_at": "2026-07-29T18:00:00Z",
+        "body": "<!-- senpai-assignment:v1 not-json -->",
+        "head": {"ref": "student/candidate", "sha": "a" * 40},
+        "labels": [
+            {"name": "research"},
+            {"name": "student:student-1"},
+            {"name": "status:wip"},
+        ],
+    }
+    monkeypatch.setattr(student, "_pulls", lambda: [malformed])
+    monkeypatch.setattr(student, "_issues", list)
+    first = student.poll()[0]
+
+    malformed["title"] = "Clarify the malformed assignment"
+    malformed["updated_at"] = "2026-07-29T19:00:00Z"
+    repeated = student.poll()[0]
+    assert repeated.dedupe_key == first.dedupe_key
+    assert repeated.to_prompt() == first.to_prompt()
+
+    malformed["labels"].append({"name": "student:student-2"})
+    changed = student.poll()[0]
+    assert changed.dedupe_key != first.dedupe_key
+    assert changed.payload["error"] != first.payload["error"]
 
 
 def test_human_issue_tracks_the_exact_latest_human_message(monkeypatch):
@@ -94,10 +127,66 @@ def test_human_issue_tracks_the_exact_latest_human_message(monkeypatch):
     event = advisor.poll()[0]
 
     assert event.kind == "human_issue"
-    assert event.dedupe_key == "human_issue:23:702"
+    assert event.dedupe_key.startswith("human_issue:v2:23:702:")
     assert event.payload["human_message_id"] == 702
     assert event.payload["author"] == "ada"
     assert event.payload["message"] == "Also compare memory."
+
+
+def test_editing_a_human_message_creates_a_new_event_version(monkeypatch):
+    advisor = mailbox()
+    human_issue = issue()
+    monkeypatch.setattr(advisor, "_pulls", list)
+    monkeypatch.setattr(advisor, "_issues", lambda: [human_issue])
+    monkeypatch.setattr(advisor, "_issue_comments", lambda _issue: [])
+    first = advisor.poll()[0]
+
+    human_issue["updated_at"] = "2026-07-29T18:20:00Z"
+    human_issue["labels"].append({"name": "operator-note"})
+    repeated = advisor.poll()[0]
+    assert repeated.dedupe_key == first.dedupe_key
+    assert repeated.to_prompt() == first.to_prompt()
+
+    human_issue["body"] = "Start with the stronger baseline."
+    edited = advisor.poll()[0]
+
+    assert edited.dedupe_key != first.dedupe_key
+    assert edited.payload["human_message_id"] == first.payload["human_message_id"]
+
+
+def test_editing_a_human_issue_title_creates_a_new_event_version(monkeypatch):
+    advisor = mailbox()
+    human_issue = issue()
+    monkeypatch.setattr(advisor, "_pulls", list)
+    monkeypatch.setattr(advisor, "_issues", lambda: [human_issue])
+    monkeypatch.setattr(advisor, "_issue_comments", lambda _issue: [])
+    first = advisor.poll()[0]
+
+    human_issue["title"] = "Clarify the direction"
+    edited = advisor.poll()[0]
+
+    assert edited.dedupe_key != first.dedupe_key
+    assert edited.payload["title"] == "Clarify the direction"
+
+
+def test_editing_the_omitted_prefix_of_a_long_human_message_versions_it(
+    monkeypatch,
+):
+    advisor = mailbox()
+    human_issue = issue()
+    human_issue["body"] = "prefix A\n" + "x" * 13_000
+    monkeypatch.setattr(advisor, "_pulls", list)
+    monkeypatch.setattr(advisor, "_issues", lambda: [human_issue])
+    monkeypatch.setattr(advisor, "_issue_comments", lambda _issue: [])
+    first = advisor.poll()[0]
+
+    human_issue["body"] = "prefix B\n" + "x" * 13_000
+    edited = advisor.poll()[0]
+
+    assert "prefix A" in first.payload["message"]
+    assert "prefix B" in edited.payload["message"]
+    assert "open the event URL for full text" in edited.payload["message"]
+    assert edited.dedupe_key != first.dedupe_key
 
 
 def test_third_party_bot_comment_cannot_replace_the_latest_human_message(
@@ -122,7 +211,7 @@ def test_third_party_bot_comment_cannot_replace_the_latest_human_message(
 
     event = advisor.poll()[0]
 
-    assert event.dedupe_key == "human_issue:23:700"
+    assert event.dedupe_key.startswith("human_issue:v2:23:700:")
     assert event.payload["human_message_id"] == 700
 
 
@@ -146,7 +235,7 @@ def test_untrusted_user_cannot_displace_the_latest_operator_message(monkeypatch)
 
     event = advisor.poll()[0]
 
-    assert event.dedupe_key == "human_issue:23:700"
+    assert event.dedupe_key.startswith("human_issue:v2:23:700:")
     assert event.payload["author"] == "ada"
 
 

--- a/tests/test_inbox_delivery.py
+++ b/tests/test_inbox_delivery.py
@@ -105,6 +105,27 @@ def test_stable_sender_verifies_payload_after_crash_between_append_and_receipt(
         deliver_turn_messages(tampered, PersistentInbox(inbox.path), turn.turn_id)
 
 
+def test_event_identity_cannot_hide_a_changed_payload(tmp_path: Path):
+    """
+    Requirement: one event identity always denotes one canonical payload.
+    Interface: repeated enqueue calls against the persistent inbox.
+    """
+    inbox = PersistentInbox(tmp_path / "inbox.sqlite3")
+    inbox.enqueue(CONVERSATION_ID, "event:1", "canonical event")
+
+    with pytest.raises(RuntimeError, match="reused with a different payload"):
+        inbox.enqueue(CONVERSATION_ID, "event:1", "changed event")
+
+    turn = inbox.next_turn(CONVERSATION_ID, "controller prompt")
+    assert turn is not None
+    deliver_turn_messages(Conversation(), inbox, turn.turn_id)
+    inbox.record_processed(turn.turn_id)
+    inbox.acknowledge(turn.turn_id)
+
+    with pytest.raises(RuntimeError, match="reused with a different payload"):
+        inbox.enqueue(CONVERSATION_ID, "event:1", "changed after acknowledgement")
+
+
 def test_crash_before_append_reuses_turn_and_appends_each_message_once(tmp_path: Path):
     """
     Requirement: a crash before append retries the same durable delivery normally.
@@ -339,6 +360,42 @@ def test_legacy_pr3472_delivery_is_adopted_without_replay(
     assert reminder is not None
     assert reminder.events[0].delivery_id != legacy_event_id
     assert json.loads(legacy_path.read_text(encoding="utf-8")) == legacy_value
+
+
+def test_reset_preserves_legacy_provenance_for_a_later_compact_reminder(
+    tmp_path: Path,
+):
+    event_key = "idle_student:Fern"
+    compact_body = "compact event"
+    legacy_id = str(UUID(int=119))
+    legacy_path = tmp_path / "pending-message-deliveries.json"
+    legacy_path.write_text(
+        json.dumps({str(CONVERSATION_ID): {event_key: legacy_id}}),
+        encoding="utf-8",
+    )
+    inbox = PersistentInbox(tmp_path / "inbox.sqlite3", legacy_path=legacy_path)
+    inbox.enqueue(CONVERSATION_ID, event_key, compact_body)
+    original = inbox.next_turn(CONVERSATION_ID, "new prompt")
+    assert original is not None
+    branch = [
+        SimpleNamespace(
+            message="old prompt",
+            sender=delivery_sender(original.legacy_prompt_delivery_id),
+        ),
+        SimpleNamespace(
+            message="verbose legacy event",
+            sender=delivery_sender(legacy_id),
+        ),
+    ]
+    deliver_turn_messages(Conversation(branch), inbox, original.turn_id)
+
+    recovery = inbox.reset_turn(original.turn_id, "recovery prompt")
+    inbox.record_context_reset(recovery.turn_id)
+    deliver_turn_messages(Conversation(), inbox, recovery.turn_id)
+    inbox.record_processed(recovery.turn_id)
+    inbox.acknowledge(recovery.turn_id)
+
+    assert inbox.enqueue(CONVERSATION_ID, event_key, compact_body) is True
 
 
 def test_adopted_legacy_prompt_is_stable_when_migration_reenters(tmp_path: Path):


### PR DESCRIPTION
Fix the remaining durable-inbox restart loop by making GitHub event identities cover their exact model-visible payloads and by persisting versioned feedback content.\n\nThis also enforces native event identity across acknowledgements, preserves legacy provenance through context reset, retains actionable blocker state, and bounds long human instructions with a visible head/tail excerpt.\n\nVerification: 867 passed, 6 skipped. Three independent reviews found no blockers.