### PR TITLE
Resume advanced student assignment branches safely

### DIFF
--- a/senpai_agent/workspace.py
+++ b/senpai_agent/workspace.py
@@ -156,7 +156,7 @@ class StudentWorkspaceReconciler:
             return
 
         assignment = _Assignment.from_event(assignment_event)
-        self._hydrate(assignment)
+        fetched_head = self._hydrate(assignment)
         current_branch = self._git("branch", "--show-current") or None
         worktree_state = self._worktree_state()
         if current_branch != assignment.head_ref and worktree_state:
@@ -179,21 +179,29 @@ class StudentWorkspaceReconciler:
             check=False,
         ).returncode == 0
         if not branch_exists:
+            if fetched_head != assignment.head_sha:
+                raise WorkspaceDivergence(
+                    head_ref=assignment.head_ref,
+                    expected_head=fetched_head,
+                    local_head=self._git("rev-parse", "HEAD"),
+                    base_ref=assignment.base_ref,
+                    base_sha=assignment.base_sha,
+                    current_branch=current_branch,
+                    worktree_state=worktree_state,
+                )
             self._run("checkout", "-b", assignment.head_ref, _HEAD_REF)
             return
 
         local_head = self._git("rev-parse", local_ref)
-        ancestor = self._run(
-            "merge-base",
-            "--is-ancestor",
+        # A stale event may outlive successful student pushes. Resume only when
+        # the assigned, remote, and preserved local heads form one forward chain.
+        if not self._is_ancestor(
             assignment.head_sha,
-            local_head,
-            check=False,
-        ).returncode
-        if ancestor != 0:
+            fetched_head,
+        ) or not self._is_ancestor(fetched_head, local_head):
             raise WorkspaceDivergence(
                 head_ref=assignment.head_ref,
-                expected_head=assignment.head_sha,
+                expected_head=fetched_head,
                 local_head=local_head,
                 base_ref=assignment.base_ref,
                 base_sha=assignment.base_sha,
@@ -202,7 +210,7 @@ class StudentWorkspaceReconciler:
             )
         self._run("checkout", assignment.head_ref)
 
-    def _hydrate(self, assignment: _Assignment) -> None:
+    def _hydrate(self, assignment: _Assignment) -> str:
         self._git("check-ref-format", "--branch", assignment.head_ref)
         self._git("check-ref-format", "--branch", assignment.base_ref)
         self._fetch_refs(
@@ -210,11 +218,6 @@ class StudentWorkspaceReconciler:
             (f"refs/heads/{assignment.base_ref}", _BASE_TIP_REF),
         )
         fetched_head = self._git("rev-parse", _HEAD_REF)
-        if fetched_head != assignment.head_sha:
-            raise RuntimeError(
-                "assignment head moved: "
-                f"expected {assignment.head_sha}, fetched {fetched_head}"
-            )
 
         if not self._commit_exists(assignment.base_sha):
             try:
@@ -230,6 +233,19 @@ class StudentWorkspaceReconciler:
                     "is unavailable from the configured GitHub repository"
                 )
         self._run("update-ref", _BASE_REF, assignment.base_sha)
+        return fetched_head
+
+    def _is_ancestor(self, ancestor: str, descendant: str) -> bool:
+        return (
+            self._run(
+                "merge-base",
+                "--is-ancestor",
+                ancestor,
+                descendant,
+                check=False,
+            ).returncode
+            == 0
+        )
 
     def _fetch_refs(self, *refs: tuple[str, str]) -> None:
         if self.token is None:

--- a/tests/test_controller_workspace.py
+++ b/tests/test_controller_workspace.py
@@ -51,9 +51,14 @@ def assigned_workspace(tmp_path: Path):
     return remote, seed, workspace, base_sha, assigned_head
 
 
-def assignment_event(head_sha: str, base_sha: str):
+def assignment_event(
+    head_sha: str,
+    base_sha: str,
+    *,
+    kind: str = "student_assignment",
+):
     return ControllerEvent(
-        kind="student_assignment",
+        kind=kind,
         dedupe_key="assignment:restart",
         payload={
             "head_ref": "student/candidate",
@@ -81,20 +86,103 @@ def test_reconciliation_preserves_unpushed_commits_and_dirty_files(
     assert (workspace / "notes.txt").read_text() == "dirty but recoverable\n"
 
 
-def test_reconciliation_rejects_a_remote_head_newer_than_the_assignment(
+def test_reconciliation_surfaces_a_remote_head_not_present_locally(
     tmp_path: Path,
 ):
     _remote, seed, workspace, base_sha, assigned_head = assigned_workspace(tmp_path)
     (seed / "program.py").write_text("moved after assignment\n")
     git("commit", "-am", "move assignment branch", cwd=seed)
     git("push", "origin", "student/candidate", cwd=seed)
+    remote_head = git("rev-parse", "HEAD", cwd=seed)
 
-    with pytest.raises(RuntimeError, match="assignment head moved"):
+    with pytest.raises(WorkspaceDivergence) as raised:
         StudentWorkspaceReconciler(workspace)(
             (assignment_event(assigned_head, base_sha),)
         )
 
+    assert raised.value.event.payload["expected_remote_head"] == remote_head
     assert git("rev-parse", "HEAD", cwd=workspace) == assigned_head
+
+
+@pytest.mark.parametrize(
+    "event_kind",
+    ("student_assignment", "student_pr_feedback"),
+)
+def test_reconciliation_resumes_when_local_contains_the_advanced_remote(
+    tmp_path: Path,
+    event_kind: str,
+):
+    _remote, _seed, workspace, base_sha, assigned_head = assigned_workspace(tmp_path)
+    (workspace / "program.py").write_text("pushed student work\n")
+    git("commit", "-am", "pushed student work", cwd=workspace)
+    git("push", "origin", "student/candidate", cwd=workspace)
+    remote_head = git("rev-parse", "HEAD", cwd=workspace)
+    (workspace / "program.py").write_text("unpushed student work\n")
+    git("commit", "-am", "unpushed student work", cwd=workspace)
+    local_head = git("rev-parse", "HEAD", cwd=workspace)
+    (workspace / "program.py").write_text("unstaged measurements\n")
+    (workspace / "staged.txt").write_text("staged measurements\n")
+    git("add", "staged.txt", cwd=workspace)
+    (workspace / "notes.txt").write_text("dirty measurements\n")
+    status = git("status", "--porcelain=v1", cwd=workspace)
+    reconciler = StudentWorkspaceReconciler(workspace)
+
+    for _ in range(2):
+        reconciler(
+            (assignment_event(assigned_head, base_sha, kind=event_kind),)
+        )
+
+    assert git("merge-base", remote_head, local_head, cwd=workspace) == remote_head
+    assert git("rev-parse", "HEAD", cwd=workspace) == local_head
+    assert git("branch", "--show-current", cwd=workspace) == "student/candidate"
+    assert git("status", "--porcelain=v1", cwd=workspace) == status
+    assert (workspace / "notes.txt").read_text() == "dirty measurements\n"
+
+
+def test_reconciliation_rejects_a_non_fast_forward_remote_rewrite(
+    tmp_path: Path,
+):
+    _remote, seed, workspace, base_sha, assigned_head = assigned_workspace(tmp_path)
+    git("checkout", "--orphan", "replacement", cwd=seed)
+    git("rm", "-f", "program.py", cwd=seed)
+    (seed / "program.py").write_text("rewritten branch\n")
+    git("add", "program.py", cwd=seed)
+    git("commit", "-m", "rewrite assignment branch", cwd=seed)
+    git("push", "--force", "origin", "HEAD:student/candidate", cwd=seed)
+    rewritten_head = git("rev-parse", "HEAD", cwd=seed)
+    git("fetch", "origin", "student/candidate", cwd=workspace)
+    git("reset", "--hard", "FETCH_HEAD", cwd=workspace)
+    (workspace / "notes.txt").write_text("preserve after rewrite\n")
+    status = git("status", "--porcelain=v1", cwd=workspace)
+
+    with pytest.raises(WorkspaceDivergence) as raised:
+        StudentWorkspaceReconciler(workspace)(
+            (assignment_event(assigned_head, base_sha),)
+        )
+
+    assert raised.value.event.payload["expected_remote_head"] == rewritten_head
+    assert git("rev-parse", "HEAD", cwd=workspace) == rewritten_head
+    assert git("status", "--porcelain=v1", cwd=workspace) == status
+
+
+def test_reconciliation_does_not_adopt_an_advanced_remote_without_local_history(
+    tmp_path: Path,
+):
+    _remote, seed, workspace, base_sha, assigned_head = assigned_workspace(tmp_path)
+    git("switch", "-c", "other-work", cwd=workspace)
+    git("branch", "-D", "student/candidate", cwd=workspace)
+    local_head = git("rev-parse", "HEAD", cwd=workspace)
+    (seed / "program.py").write_text("remote-only continuation\n")
+    git("commit", "-am", "remote-only continuation", cwd=seed)
+    git("push", "origin", "student/candidate", cwd=seed)
+
+    with pytest.raises(WorkspaceDivergence):
+        StudentWorkspaceReconciler(workspace)(
+            (assignment_event(assigned_head, base_sha),)
+        )
+
+    assert git("branch", "--show-current", cwd=workspace) == "other-work"
+    assert git("rev-parse", "HEAD", cwd=workspace) == local_head
 
 
 def test_reconciliation_surfaces_and_preserves_a_diverged_active_branch(


### PR DESCRIPTION
Prevent a stale assignment event from crash-looping after the assigned student has already pushed and continued locally. Recovery now accepts only the proven forward chain assigned SHA -> fetched remote -> preserved local head; it preserves dirty and unpushed work. Remote-only advances, missing local evidence, force-pushes, and sibling histories become one actionable WorkspaceDivergence instead of an uncaught restart loop. Covers assignment and feedback events, retry idempotence, staged/unstaged/untracked preservation, rewritten history, and conservative missing-branch refusal. Verification: 876 passed, 6 skipped.