### PR TITLE
Recover markerless assignment PRs safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,27 @@ Useful launch controls:
 - `--extra_instructions` accepts a Markdown file or literal operator guidance.
 - `human_issues: false` disables GitHub Issue polling for isolated launches.
 
+Operators can use the same guarded assignment transitions as the advisor
+without constructing branches or pull requests through raw `git` or `gh`:
+
+```bash
+export GH_REPO=owner/repo
+# GITHUB_TOKEN or GH_TOKEN must already be set in the environment.
+uv run python -m senpai_agent.github.operator \
+  --workspace target --advisor-branch research --student-names fern,frieren \
+  adopt-assignment action.json
+```
+
+Use `create-assignment` for a new typed branch and draft PR. Each command reads
+its corresponding `CreateAssignmentAction` or `AdoptAssignmentAction` JSON from
+the named file, or from standard input when the path is `-`. Repository and
+GitHub credentials are accepted only through `GH_REPO` and
+`GITHUB_TOKEN`/`GH_TOKEN`; the command uses the same validated executors as the
+advisor tool.
+
+Do not edit an adopted PR body concurrently with this command; GitHub does not
+offer this client a body-write lease.
+
 Advisor and student images are built from the same source revision. The advisor image excludes CUDA and PyTorch; the student image contains the CUDA/PyTorch runtime; the cutoff image contains only the minimal job runtime and pinned `kubectl`. Advisor and student builds install Chromium and execute an OpenHands browser smoke test.
 
 For multi-day fleets, [`arm_senpai_cluster_cutoff.sh`](scripts/arm_senpai_cluster_cutoff.sh) creates a cluster-side hard cutoff that does not depend on an operator laptop remaining online. It can also hold a shared start gate until the expected fleet is ready or its readiness deadline expires.

--- a/SPEC.md
+++ b/SPEC.md
@@ -310,6 +310,7 @@ Advisor operations that act on an assignment share this object:
 | Tool | Role | Input beyond the shared `assignment` object |
 |---|---|---|
 | `create_assignment` | advisor | `assignment_id`, `revision_id`, `student`, `expected_base_sha`, `head_branch`, `title`, `body`; the base is the configured advisor branch |
+| `adopt_assignment` | advisor | `pr_number`, `assignment_id`, `revision_id`, `student`, `expected_base_sha`, `head_branch`, `expected_pr_head_sha`; the base is the configured advisor branch |
 | `publish_advisor_branch` | advisor | `remote_branch_sha_before_push`, `local_commit_sha` |
 | `repair_assignment_routing` | advisor | `working_state` (`wip` or `review`) and a `blockers` list containing only `blocked`, `hold`, or `needs-rebase` |
 | `send_assignment_feedback` | advisor | `feedback_id`, `comment` |
@@ -330,6 +331,17 @@ Assignment creation checks the remote base SHA, creates an isolated empty
 assignment commit with `git commit-tree`, publishes with force-with-lease,
 refuses a second active assignment for the student, creates or reconciles one
 draft PR, embeds a typed assignment marker, and verifies routing state.
+
+Assignment adoption is a separate, explicit recovery transition for an
+existing markerless draft PR. It verifies the configured student and base,
+exact remote head and Git ancestry, authenticated PR author, WIP routing, and
+absence of conflicting protocol state before adding one marker; it never
+infers assignment identity from PR prose. `repair_assignment_routing` remains
+limited to labels and draft state after a valid marker already exists.
+
+The transition re-reads the body immediately before its PATCH and verifies the
+marker afterward, but this client has no PR-body write lease; operators must
+not edit that body concurrently with adoption.
 
 Advisor feedback carries exact assignment, revision, and PR-head preconditions.
 It creates one immutable feedback ID without changing the assignment marker,

--- a/senpai_agent/git_assignment.py
+++ b/senpai_agent/git_assignment.py
@@ -1,0 +1,98 @@
+"""Read-only verification for adopting an existing remote assignment branch."""
+
+from pathlib import Path
+
+from pydantic import SecretStr
+
+from senpai_agent.git_workflow import (
+    GitWorkflowPreconditionError,
+    _git,
+    _remote_head,
+    _validate_token,
+)
+
+
+def require_remote_assignment_history(
+    workspace: Path,
+    *,
+    branch: str,
+    expected_head_sha: str,
+    base_branch: str,
+    expected_base_sha: str,
+    remote: str = "origin",
+    token: SecretStr | None = None,
+) -> None:
+    """Verify that an existing remote branch contains its declared research base."""
+
+    workspace = Path(workspace).resolve()
+    _validate_token(token)
+    _git(workspace, "rev-parse", "--is-inside-work-tree")
+    _git(workspace, "check-ref-format", "--branch", branch)
+    _git(workspace, "check-ref-format", "--branch", base_branch)
+    if branch == base_branch:
+        raise GitWorkflowPreconditionError(
+            "assignment branch must differ from the base branch"
+        )
+    if not expected_head_sha.strip() or not expected_base_sha.strip():
+        raise ValueError("expected head and base SHAs must not be empty")
+
+    remote_head = _remote_head(workspace, remote, branch, token=token)
+    if not remote_head:
+        raise GitWorkflowPreconditionError(
+            f"remote assignment branch {branch!r} does not exist"
+        )
+    remote_base = _remote_head(workspace, remote, base_branch, token=token)
+    if not remote_base:
+        raise GitWorkflowPreconditionError(
+            f"remote base branch {base_branch!r} does not exist"
+        )
+
+    for ref, expected in ((base_branch, remote_base), (branch, remote_head)):
+        _git(
+            workspace,
+            "fetch",
+            "--no-tags",
+            remote,
+            f"refs/heads/{ref}",
+            token=token,
+        )
+        if _git(workspace, "rev-parse", "FETCH_HEAD") != expected:
+            raise GitWorkflowPreconditionError(
+                f"remote branch {ref!r} moved while verifying assignment history"
+            )
+
+    try:
+        base = _git(workspace, "rev-parse", f"{expected_base_sha}^{{commit}}")
+        head = _git(workspace, "rev-parse", f"{expected_head_sha}^{{commit}}")
+    except GitWorkflowPreconditionError as error:
+        raise GitWorkflowPreconditionError(
+            "expected assignment head and base must be fetched Git commits"
+        ) from error
+    if base != expected_base_sha or head != expected_head_sha:
+        raise GitWorkflowPreconditionError(
+            "assignment SHAs must be full Git commit object IDs"
+        )
+    try:
+        _git(workspace, "merge-base", "--is-ancestor", head, remote_head)
+    except GitWorkflowPreconditionError as error:
+        raise GitWorkflowPreconditionError(
+            f"remote head {remote_head} does not contain expected head {head}"
+        ) from error
+    try:
+        branch_point = _git(workspace, "merge-base", remote_base, remote_head)
+    except GitWorkflowPreconditionError as error:
+        raise GitWorkflowPreconditionError(
+            f"assignment head {remote_head} does not share research-base history"
+        ) from error
+    if branch_point != base:
+        raise GitWorkflowPreconditionError(
+            f"assignment branch diverges at {branch_point}, expected base {base}"
+        )
+
+    if (
+        _remote_head(workspace, remote, branch, token=token) != remote_head
+        or _remote_head(workspace, remote, base_branch, token=token) != remote_base
+    ):
+        raise GitWorkflowPreconditionError(
+            "remote assignment history moved while it was being verified"
+        )

--- a/senpai_agent/github/mailbox/advisor.py
+++ b/senpai_agent/github/mailbox/advisor.py
@@ -16,14 +16,15 @@ from senpai_agent.models import (
     ResultMarkerError,
     authoritative_marker_line,
     experiment_result_digest,
-    parse_assignment_markers,
     parse_research_base_acceptance_markers,
     parse_result_markers,
 )
 
 from .values import (
+    assignment_from_pull,
     github_datetime,
     label_names,
+    malformed_assignment_event,
     object_value,
     pull_reference,
     result_matches_assignment,
@@ -42,7 +43,9 @@ def advisor_events(
 ) -> tuple[ControllerEvent, ...]:
     events: list[ControllerEvent] = []
     active_assignments: list[tuple[dict[str, object], AssignmentRecord]] = []
-    active_by_student: dict[str, list[int]] = {student: [] for student in mailbox.students}
+    active_by_student: dict[str, list[int]] = {
+        student: [] for student in mailbox.students
+    }
     now = datetime.now(UTC)
     for pull in pulls:
         labels = label_names(pull)
@@ -53,36 +56,33 @@ def advisor_events(
             for label in labels
             if label.startswith("student:")
         )
-        if "status:wip" in labels:
-            for student in students:
-                active_by_student.setdefault(student, []).append(number)
         reference = pull_reference(pull)
         assignment = None
-        if {"status:wip", "status:review"} & labels:
+        if {"status:wip", "status:review"} & labels and len(students) == 1:
             try:
-                assignments = parse_assignment_markers(str(pull.get("body") or ""))
-            except ValueError:
-                assignments = []
-            if len(assignments) == 1:
-                assignment = assignments[0]
+                assignment = assignment_from_pull(pull, repo=mailbox.repo)
+            except ValueError as error:
+                events.append(malformed_assignment_event(pull, error))
+            else:
                 active_assignments.append((pull, assignment))
-        if "status:review" in labels:
-            review_payload = reference
-            review_identity: tuple[object, ...] = (number, head_sha)
-            if assignment is not None:
-                review_identity = (
-                    number,
-                    assignment.assignment_id,
-                    assignment.revision_id,
-                    head_sha,
-                )
-                review_payload = {
-                    **reference,
-                    "assignment_id": assignment.assignment_id,
-                    "revision_id": assignment.revision_id,
-                }
+        if assignment is not None and "status:wip" in labels:
+            active_by_student.setdefault(assignment.student, []).append(number)
+        if assignment is not None and "status:review" in labels:
+            review_identity: tuple[object, ...] = (
+                number,
+                assignment.assignment_id,
+                assignment.revision_id,
+                head_sha,
+            )
+            review_payload = {
+                **reference,
+                "assignment_id": assignment.assignment_id,
+                "revision_id": assignment.revision_id,
+            }
             events.append(
-                versioned_event("review_ready", *review_identity, payload=review_payload)
+                versioned_event(
+                    "review_ready", *review_identity, payload=review_payload
+                )
             )
         reasons: list[str] = []
         if "status:blocked" in labels:

--- a/senpai_agent/github/mailbox/student.py
+++ b/senpai_agent/github/mailbox/student.py
@@ -2,55 +2,25 @@
 
 from __future__ import annotations
 
-import re
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from senpai_agent.mailbox import ControllerEvent
-from senpai_agent.models import AssignmentRecord, parse_assignment_markers
+from senpai_agent.models import AssignmentRecord
 
 from .feedback import student_pr_feedback_events
 from .issues import human_issue_events
-from .values import label_names, object_value, pull_reference, versioned_event
+from .values import (
+    assignment_from_pull,
+    label_names,
+    malformed_assignment_event,
+    object_value,
+    pull_reference,
+    versioned_event,
+)
 
 if TYPE_CHECKING:
     from .core import GitHubMailbox
-
-
-_GIT_OBJECT_ID = re.compile(r"(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})\Z")
-
-
-def _validate_assignment_route(
-    pull: Mapping[str, object],
-    assignment: AssignmentRecord,
-    *,
-    repo: str,
-    student: str,
-) -> None:
-    head = pull.get("head")
-    base = pull.get("base")
-    if not isinstance(head, dict) or not isinstance(base, dict):
-        raise ValueError("assigned PR has invalid head or base metadata")
-    expected = {
-        "repo": (assignment.repo, repo),
-        "student": (assignment.student, student),
-        "head_ref": (assignment.head_ref, str(head.get("ref") or "")),
-        "base_ref": (assignment.base_ref, str(base.get("ref") or "")),
-    }
-    mismatches = [
-        name for name, (recorded, live) in expected.items() if recorded != live
-    ]
-    if mismatches:
-        raise ValueError(
-            "assignment marker does not match PR routing: " + ", ".join(mismatches)
-        )
-    for name, value in (
-        ("assignment head SHA", assignment.head_sha),
-        ("assignment base SHA", assignment.base_sha),
-        ("live head SHA", str(head.get("sha") or "")),
-    ):
-        if _GIT_OBJECT_ID.fullmatch(value) is None:
-            raise ValueError(f"{name} is not a full Git object ID")
 
 
 def student_events(
@@ -66,12 +36,28 @@ def student_events(
         if assignment_label in label_names(pull)
         and {"status:wip", "status:review"} & label_names(pull)
     ]
-    wip = [pull for pull in relevant if "status:wip" in label_names(pull)]
-
     events: list[ControllerEvent] = []
+    assignments: list[tuple[dict[str, object], AssignmentRecord]] = []
+    for pull in relevant:
+        try:
+            assignment = assignment_from_pull(
+                pull,
+                repo=mailbox.repo,
+                expected_student=mailbox.student_name,
+            )
+        except ValueError as error:
+            events.append(malformed_assignment_event(pull, error))
+            continue
+        assignments.append((pull, assignment))
+
+    wip = [
+        (pull, assignment)
+        for pull, assignment in assignments
+        if "status:wip" in label_names(pull)
+    ]
     duplicate_wip = len(wip) > 1
     if duplicate_wip:
-        numbers = sorted(int(pull["number"]) for pull in wip)
+        numbers = sorted(int(pull["number"]) for pull, _assignment in wip)
         events.append(
             ControllerEvent(
                 kind="duplicate_assignment",
@@ -86,47 +72,7 @@ def student_events(
             )
         )
 
-    for pull in relevant:
-        try:
-            student_labels = {
-                label
-                for label in label_names(pull)
-                if label.startswith("student:")
-            }
-            if student_labels != {assignment_label}:
-                raise ValueError(
-                    "assigned PR must contain exactly one student label"
-                )
-            markers = parse_assignment_markers(str(pull.get("body") or ""))
-            if len(markers) != 1:
-                raise ValueError(
-                    "assigned PR must contain exactly one Senpai assignment marker"
-                )
-            assignment = markers[0]
-            if assignment.student != mailbox.student_name:
-                raise ValueError(
-                    "assignment marker student does not match the student label"
-                )
-            _validate_assignment_route(
-                pull,
-                assignment,
-                repo=mailbox.repo,
-                student=mailbox.student_name,
-            )
-        except ValueError as error:
-            number = int(pull["number"])
-            head_sha = str(object_value(pull["head"])["sha"])
-            payload = {
-                **pull_reference(pull),
-                "error": f"Assigned PR #{number}: {error}",
-            }
-            events.append(
-                versioned_event(
-                    "malformed_assignment", number, head_sha, payload=payload
-                )
-            )
-            continue
-
+    for pull, assignment in assignments:
         feedback = student_pr_feedback_events(mailbox, pull, assignment)
         prior_revision_pending = any(
             event.payload["assignment_id"] != assignment.assignment_id

--- a/senpai_agent/github/mailbox/values.py
+++ b/senpai_agent/github/mailbox/values.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -13,6 +14,7 @@ from senpai_agent.models import (
     AssignmentRecord,
     ExperimentResult,
     parse_assignment_feedback_markers,
+    parse_assignment_markers,
 )
 
 
@@ -21,6 +23,7 @@ FEEDBACK_KEY_PREFIX = "student_pr_feedback:"
 FEEDBACK_EXCERPT_BYTES = 4_000
 DEFAULT_FEEDBACK_BATCH_EVENTS = 8
 DEFAULT_FEEDBACK_BATCH_BYTES = 32_000
+_GIT_OBJECT_ID = re.compile(r"(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})\Z")
 
 
 @dataclass(frozen=True, slots=True)
@@ -41,6 +44,80 @@ def pull_reference(pull: Mapping[str, object]) -> dict[str, object]:
         "head_ref": str(head["ref"]),
         "head_sha": str(head["sha"]),
     }
+
+
+def assignment_from_pull(
+    pull: Mapping[str, object],
+    *,
+    repo: str,
+    expected_student: str | None = None,
+) -> AssignmentRecord:
+    """Return the one assignment whose marker and live PR route agree."""
+
+    student_labels = sorted(
+        label.removeprefix("student:")
+        for label in label_names(pull)
+        if label.startswith("student:")
+    )
+    if len(student_labels) != 1:
+        raise ValueError("assigned PR must contain exactly one student label")
+    student = student_labels[0]
+    if expected_student is not None and student != expected_student:
+        raise ValueError("assigned PR student label does not match this student")
+
+    markers = parse_assignment_markers(str(pull.get("body") or ""))
+    if len(markers) != 1:
+        raise ValueError(
+            "assigned PR must contain exactly one Senpai assignment marker"
+        )
+    assignment = markers[0]
+    if assignment.student != student:
+        raise ValueError("assignment marker student does not match the student label")
+
+    head = pull.get("head")
+    base = pull.get("base")
+    if not isinstance(head, dict) or not isinstance(base, dict):
+        raise ValueError("assigned PR has invalid head or base metadata")
+    expected = {
+        "repo": (assignment.repo, repo),
+        "head_ref": (assignment.head_ref, str(head.get("ref") or "")),
+        "base_ref": (assignment.base_ref, str(base.get("ref") or "")),
+    }
+    mismatches = [
+        name for name, (recorded, live) in expected.items() if recorded != live
+    ]
+    if mismatches:
+        raise ValueError(
+            "assignment marker does not match PR routing: " + ", ".join(mismatches)
+        )
+    for name, value in (
+        ("assignment head SHA", assignment.head_sha),
+        ("assignment base SHA", assignment.base_sha),
+        ("live head SHA", str(head.get("sha") or "")),
+    ):
+        if _GIT_OBJECT_ID.fullmatch(value) is None:
+            raise ValueError(f"{name} is not a full Git object ID")
+    return assignment
+
+
+def malformed_assignment_event(
+    pull: Mapping[str, object], error: ValueError
+) -> ControllerEvent:
+    number = int(pull["number"])
+    head_sha = str(object_value(pull["head"])["sha"])
+    students = sorted(
+        label.removeprefix("student:")
+        for label in label_names(pull)
+        if label.startswith("student:")
+    )
+    payload = {
+        **pull_reference(pull),
+        "error": f"Assigned PR #{number}: {error}",
+        "students": students,
+    }
+    return versioned_event(
+        "malformed_assignment", number, head_sha, payload=payload
+    )
 
 
 def payload_digest(payload: Mapping[str, object]) -> str:

--- a/senpai_agent/github/operator.py
+++ b/senpai_agent/github/operator.py
@@ -1,0 +1,161 @@
+"""Operator access to Senpai's typed assignment transitions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import TextIO
+
+os.environ.setdefault("OPENHANDS_SUPPRESS_BANNER", "1")
+
+from pydantic import SecretStr
+
+from senpai_agent.github.tools.advisor import (
+    AdoptAssignmentExecutor,
+    CreateAssignmentExecutor,
+)
+from senpai_agent.github.tools.contracts import (
+    AdoptAssignmentAction,
+    CreateAssignmentAction,
+)
+from senpai_agent.github.tools.runtime import (
+    GitHubToolRuntime,
+    configured_student_names,
+)
+from senpai_agent.github.workflow import GitHubWorkflow
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run Senpai's guarded assignment operations as an operator."
+    )
+    parser.add_argument(
+        "--workspace",
+        required=True,
+        type=Path,
+        help="Target-repository checkout used for guarded Git operations.",
+    )
+    parser.add_argument(
+        "--advisor-branch",
+        required=True,
+        help="Configured advisor branch that assignments target.",
+    )
+    parser.add_argument(
+        "--student-names",
+        required=True,
+        help="Comma-separated allowlist of students in this launch.",
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+    for name, help_text in (
+        (
+            "create-assignment",
+            "Create or exactly replay one typed assignment branch and draft PR.",
+        ),
+        (
+            "adopt-assignment",
+            "Attach typed identity to one exact pre-existing assignment PR.",
+        ),
+    ):
+        command = commands.add_parser(name, help=help_text)
+        command.add_argument(
+            "action",
+            help="JSON action file, or - to read the action from standard input.",
+        )
+    return parser
+
+
+def _github_repo(environment: Mapping[str, str]) -> str:
+    repo = environment.get("GH_REPO", "").strip()
+    if len(repo.split("/")) != 2 or not all(repo.split("/")):
+        raise ValueError("GH_REPO must use owner/name form")
+    return repo
+
+
+def _github_token(environment: Mapping[str, str]) -> SecretStr:
+    token = next(
+        (
+            value.strip()
+            for name in ("GITHUB_TOKEN", "GH_TOKEN")
+            if (value := environment.get(name, "")).strip()
+        ),
+        None,
+    )
+    if token is None:
+        raise ValueError("GITHUB_TOKEN or GH_TOKEN is required")
+    return SecretStr(token)
+
+
+def _read_action(source: str, stdin: TextIO) -> str:
+    if source == "-":
+        return stdin.read()
+    return Path(source).expanduser().read_text(encoding="utf-8")
+
+
+def _runtime(args: argparse.Namespace, environment: Mapping[str, str]) -> GitHubToolRuntime:
+    advisor_branch = args.advisor_branch.strip()
+    if not advisor_branch:
+        raise ValueError("--advisor-branch must not be empty")
+    students = configured_student_names(args.student_names)
+    if not students:
+        raise ValueError("--student-names must name at least one student")
+    token = _github_token(environment)
+    trusted_actor = environment.get("SENPAI_GITHUB_ACTOR", "").strip() or None
+    workflow = GitHubWorkflow(
+        _github_repo(environment),
+        token,
+        role="advisor",
+        trusted_actor=trusted_actor,
+    )
+    return GitHubToolRuntime(
+        workflow=workflow,
+        workspace=args.workspace.expanduser().resolve(),
+        git_token=token,
+        role="advisor",
+        advisor_branch=advisor_branch,
+        student_names=students,
+        student_name=None,
+    )
+
+
+def operator_main(
+    argv: Sequence[str] | None = None,
+    *,
+    environment: Mapping[str, str] = os.environ,
+    stdin: TextIO | None = None,
+    stdout: TextIO | None = None,
+) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    stdin = stdin or sys.stdin
+    stdout = stdout or sys.stdout
+    try:
+        runtime = _runtime(args, environment)
+        payload = _read_action(args.action, stdin)
+        if args.command == "create-assignment":
+            action = CreateAssignmentAction.model_validate_json(payload)
+            observation = CreateAssignmentExecutor(runtime)(action)
+        else:
+            action = AdoptAssignmentAction.model_validate_json(payload)
+            observation = AdoptAssignmentExecutor(runtime)(action)
+    except (OSError, RuntimeError, ValueError) as error:
+        parser.error(str(error))
+    print(
+        json.dumps(
+            observation.model_dump(
+                mode="json",
+                include={"changed", "resource_url", "state", "version"},
+            ),
+            sort_keys=True,
+            separators=(",", ":"),
+        ),
+        file=stdout,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(operator_main())

--- a/senpai_agent/github/tools/__init__.py
+++ b/senpai_agent/github/tools/__init__.py
@@ -2,6 +2,7 @@
 
 from .contracts import (
     AcceptResultOnCurrentBaseAction,
+    AdoptAssignmentAction,
     AssignmentVersion,
     CloseExperimentAction,
     CreateAssignmentAction,
@@ -16,6 +17,7 @@ from .contracts import (
 )
 from .definitions import (
     AcceptResultOnCurrentBaseTool,
+    AdoptAssignmentTool,
     CloseExperimentTool,
     CreateAssignmentTool,
     MergeExperimentTool,
@@ -43,6 +45,8 @@ from .toolset import GitHubWorkflowToolSet
 __all__ = (
     "AcceptResultOnCurrentBaseAction",
     "AcceptResultOnCurrentBaseTool",
+    "AdoptAssignmentAction",
+    "AdoptAssignmentTool",
     "AssignmentVersion",
     "CloseExperimentAction",
     "CloseExperimentTool",

--- a/senpai_agent/github/tools/advisor.py
+++ b/senpai_agent/github/tools/advisor.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from openhands.sdk.tool import ToolExecutor
 
-from senpai_agent import git_workflow
+from senpai_agent import git_assignment, git_workflow
 from senpai_agent.models import (
     AssignmentRecord,
     DispositionRecord,
@@ -15,6 +15,7 @@ from senpai_agent.models import (
 
 from .contracts import (
     AcceptResultOnCurrentBaseAction,
+    AdoptAssignmentAction,
     CloseExperimentAction,
     CreateAssignmentAction,
     GitHubMutationObservation,
@@ -66,6 +67,52 @@ class CreateAssignmentExecutor(
                 ),
                 title=action.title,
                 body=action.body,
+            )
+        return GitHubMutationObservation.from_result(result)
+
+
+class AdoptAssignmentExecutor(
+    ToolExecutor[AdoptAssignmentAction, GitHubMutationObservation]
+):
+    def __init__(self, runtime: GitHubToolRuntime):
+        self.runtime = runtime
+
+    def __call__(
+        self,
+        action: AdoptAssignmentAction,
+        conversation: LocalConversation | None = None,
+    ) -> GitHubMutationObservation:
+        base_branch = self.runtime.assignment_base_branch()
+        self.runtime.require_configured_student(action.student)
+        with self.runtime.workflow.serialized_assignment_mutation():
+            git_assignment.require_remote_assignment_history(
+                self.runtime.workspace,
+                branch=action.head_branch,
+                expected_head_sha=action.expected_pr_head_sha,
+                base_branch=base_branch,
+                expected_base_sha=action.expected_base_sha,
+                token=self.runtime.git_token,
+            )
+            result = self.runtime.workflow.adopt_assignment(
+                action.pr_number,
+                assignment=AssignmentRecord(
+                    repo=self.runtime.workflow.repo,
+                    assignment_id=action.assignment_id,
+                    revision_id=action.revision_id,
+                    student=action.student,
+                    base_ref=base_branch,
+                    base_sha=action.expected_base_sha,
+                    head_ref=action.head_branch,
+                    head_sha=action.expected_pr_head_sha,
+                ),
+            )
+            git_assignment.require_remote_assignment_history(
+                self.runtime.workspace,
+                branch=action.head_branch,
+                expected_head_sha=action.expected_pr_head_sha,
+                base_branch=base_branch,
+                expected_base_sha=action.expected_base_sha,
+                token=self.runtime.git_token,
             )
         return GitHubMutationObservation.from_result(result)
 

--- a/senpai_agent/github/tools/contracts.py
+++ b/senpai_agent/github/tools/contracts.py
@@ -75,6 +75,24 @@ class CreateAssignmentAction(Action):
     )
 
 
+class AdoptAssignmentAction(Action):
+    """Attach typed assignment identity to one exact pre-existing draft PR."""
+
+    pr_number: int = Field(gt=0, description="Existing assignment PR number.")
+    assignment_id: str = Field(min_length=1, description="New stable assignment ID.")
+    revision_id: str = Field(min_length=1, description="Initial revision ID.")
+    student: str = Field(min_length=1, description="Configured student owning the PR.")
+    expected_base_sha: str = Field(
+        min_length=1, description="Exact research-base commit contained by the PR head."
+    )
+    head_branch: str = Field(
+        min_length=1, description="Exact existing remote assignment branch."
+    )
+    expected_pr_head_sha: str = Field(
+        min_length=1, description="Exact current remote branch and PR-head commit."
+    )
+
+
 class PublishAdvisorBranchAction(Action):
     """Lease-publish the configured advisor branch at one exact local commit."""
 

--- a/senpai_agent/github/tools/definitions.py
+++ b/senpai_agent/github/tools/definitions.py
@@ -9,6 +9,7 @@ from openhands.sdk.tool import ToolDefinition, ToolExecutor
 
 from .advisor import (
     AcceptResultOnCurrentBaseExecutor,
+    AdoptAssignmentExecutor,
     CloseExperimentExecutor,
     CreateAssignmentExecutor,
     MergeExperimentExecutor,
@@ -19,6 +20,7 @@ from .advisor import (
 )
 from .contracts import (
     AcceptResultOnCurrentBaseAction,
+    AdoptAssignmentAction,
     CloseExperimentAction,
     CreateAssignmentAction,
     GitHubMutationObservation,
@@ -91,6 +93,22 @@ class CreateAssignmentTool(
         )
 
 
+class AdoptAssignmentTool(
+    ToolDefinition[AdoptAssignmentAction, GitHubMutationObservation]
+):
+    """Adopt one exact existing assignment PR for a configured student."""
+
+    @classmethod
+    def create(cls, runtime: GitHubToolRuntime) -> Sequence[Self]:
+        return _tool(
+            cls, AdoptAssignmentAction, "Adopt assignment PR",
+            "Attach typed assignment identity to one exact markerless draft PR "
+            "after verifying its configured student, routing, and Git history. "
+            "This never creates a branch or infers identity from PR prose.",
+            AdoptAssignmentExecutor(runtime),
+        )
+
+
 class PublishAdvisorBranchTool(
     ToolDefinition[PublishAdvisorBranchAction, GitHubMutationObservation]
 ):
@@ -114,10 +132,9 @@ class RepairAssignmentRoutingTool(
     @classmethod
     def create(cls, runtime: GitHubToolRuntime) -> Sequence[Self]:
         return _tool(
-            cls, RepairAssignmentRoutingAction, "Repair assignment routing",
-            "Repair one current assignment's protocol routing after labels or draft "
-            "state drift. Choose wip or review and only named blockers; do not use "
-            "this for ordinary assignment decisions.",
+            cls, RepairAssignmentRoutingAction, "Repair assignment labels and draft",
+            "Repair labels and draft state for an assignment that already has a "
+            "valid marker. This cannot create or adopt assignment identity.",
             RepairAssignmentRoutingExecutor(runtime.workflow),
         )
 

--- a/senpai_agent/github/tools/toolset.py
+++ b/senpai_agent/github/tools/toolset.py
@@ -13,6 +13,7 @@ from senpai_agent.github.workflow import GitHubWorkflow
 
 from .definitions import (
     AcceptResultOnCurrentBaseTool,
+    AdoptAssignmentTool,
     CloseExperimentTool,
     CreateAssignmentTool,
     MergeExperimentTool,
@@ -105,6 +106,7 @@ class GitHubWorkflowToolSet(
         return (
             *common,
             *CreateAssignmentTool.create(runtime),
+            *AdoptAssignmentTool.create(runtime),
             *PublishAdvisorBranchTool.create(runtime),
             *RepairAssignmentRoutingTool.create(runtime),
             *SendAssignmentFeedbackTool.create(runtime),

--- a/senpai_agent/github/workflow/adoption.py
+++ b/senpai_agent/github/workflow/adoption.py
@@ -1,0 +1,187 @@
+"""Adopt one pre-existing pull request into the typed assignment lifecycle."""
+
+from senpai_agent.github.workflow.errors import (
+    ReconciliationError,
+    WorkflowPreconditionError,
+)
+from senpai_agent.github.workflow.responses import MutationResult, PullRequestSnapshot
+from senpai_agent.github.workflow.text import marker_body
+from senpai_agent.github.workflow.validation import require_open
+from senpai_agent.models import (
+    AssignmentRecord,
+    authoritative_marker_line,
+    parse_assignment_markers,
+    render_assignment_marker,
+)
+
+
+class AdoptionMixin:
+    __slots__ = ()
+
+    def adopt_assignment(
+        self,
+        number: int,
+        assignment: AssignmentRecord,
+    ) -> MutationResult:
+        """Attach typed identity to one exact pre-existing assignment PR."""
+
+        with self._assignment_lifecycle_lock:
+            return self._adopt_assignment(number, assignment)
+
+    def _adopt_assignment(
+        self,
+        number: int,
+        assignment: AssignmentRecord,
+    ) -> MutationResult:
+        if self._role != "advisor":
+            raise WorkflowPreconditionError("only an advisor may adopt assignments")
+        if assignment.repo != self._repo:
+            raise WorkflowPreconditionError(
+                "assignment repository does not match the GitHub workflow"
+            )
+
+        current = self.pull_request(number)
+        if self._is_existing_adoption(current, assignment):
+            return MutationResult(
+                changed=False,
+                resource_url=current.url,
+                state="assignment_adopted",
+                version=current.head_sha,
+            )
+
+        matches = self._assignment_pull_requests(assignment)
+        if len(matches) != 1 or matches[0].number != number:
+            raise WorkflowPreconditionError(
+                "assignment branch must have exactly one matching pull request"
+            )
+        conflicts = tuple(
+            active
+            for active in self._active_student_assignment_numbers(assignment.student)
+            if active != number
+        )
+        if conflicts:
+            raise WorkflowPreconditionError(
+                f"student:{assignment.student} already has active assignment "
+                f"PR(s): {', '.join(f'#{active}' for active in conflicts)}"
+            )
+
+        before = self._pull_at_head(number, assignment.head_sha)
+        self._require_adoptable_assignment(before, assignment)
+        latest = self._pull_at_head(number, assignment.head_sha)
+        self._require_adoptable_assignment(latest, assignment)
+        if latest.body != before.body:
+            raise ReconciliationError(
+                "assignment pull request body changed during adoption"
+            )
+
+        rendered_body = marker_body(
+            render_assignment_marker(assignment),
+            latest.body,
+        )
+        self._mutate(
+            "PATCH",
+            f"/repos/{self._repo}/pulls/{number}",
+            json_body={"body": rendered_body},
+            expected_statuses={200},
+        )
+        after = self.pull_request(number)
+        if not self._is_existing_adoption(after, assignment):
+            raise ReconciliationError(
+                "GitHub did not persist the adopted assignment marker"
+            )
+        return MutationResult(
+            changed=True,
+            resource_url=after.url,
+            state="assignment_adopted",
+            version=after.head_sha,
+        )
+
+    def _is_existing_adoption(
+        self,
+        snapshot: PullRequestSnapshot,
+        assignment: AssignmentRecord,
+    ) -> bool:
+        if snapshot.author.casefold() != self._actor().casefold():
+            raise WorkflowPreconditionError(
+                "assignment pull request must be authored by the authenticated actor"
+            )
+        if snapshot.base_ref != assignment.base_ref:
+            raise WorkflowPreconditionError(
+                f"pull request base is {snapshot.base_ref!r}, "
+                f"expected {assignment.base_ref!r}"
+            )
+        if snapshot.head_ref != assignment.head_ref:
+            raise WorkflowPreconditionError(
+                f"pull request head is {snapshot.head_ref!r}, "
+                f"expected {assignment.head_ref!r}"
+            )
+
+        try:
+            markers = parse_assignment_markers(snapshot.body)
+        except ValueError as error:
+            raise WorkflowPreconditionError(
+                f"pull request contains an invalid assignment marker: {error}"
+            ) from error
+        protocol_lines = [
+            line
+            for line in snapshot.body.splitlines()
+            if line.startswith("<!-- senpai-")
+        ]
+        if markers:
+            if markers != (assignment,) or protocol_lines != [
+                render_assignment_marker(assignment)
+            ]:
+                raise WorkflowPreconditionError(
+                    "pull request must contain exactly the requested assignment marker"
+                )
+            return True
+        if protocol_lines:
+            raise WorkflowPreconditionError(
+                "markerless assignment body must not contain other Senpai markers"
+            )
+        return False
+
+    def _require_adoptable_assignment(
+        self,
+        snapshot: PullRequestSnapshot,
+        assignment: AssignmentRecord,
+    ) -> None:
+        require_open(snapshot)
+        if self._is_existing_adoption(snapshot, assignment):
+            raise ReconciliationError(
+                "assignment marker appeared during adoption; retry the operation"
+            )
+        if not snapshot.draft:
+            raise WorkflowPreconditionError(
+                "assignment pull request must be draft before adoption"
+            )
+        if not snapshot.body.strip():
+            raise WorkflowPreconditionError(
+                "assignment pull request body must not be empty"
+            )
+
+        labels = set(snapshot.labels)
+        student_labels = {label for label in labels if label.startswith("student:")}
+        if student_labels != {f"student:{assignment.student}"}:
+            raise WorkflowPreconditionError(
+                "assignment pull request must have exactly its requested student label"
+            )
+        status_labels = {label for label in labels if label.startswith("status:")}
+        if status_labels != {"status:wip"}:
+            raise WorkflowPreconditionError(
+                "assignment pull request must have status:wip as its only status"
+            )
+        if assignment.base_ref not in labels:
+            raise WorkflowPreconditionError(
+                "assignment pull request must retain its configured base label"
+            )
+        if any(
+            comment.author.casefold() == self._actor().casefold()
+            and authoritative_marker_line(comment.body).startswith(
+                ("<!-- senpai-result:", "<!-- senpai-disposition:")
+            )
+            for comment in self._comments(snapshot.number)
+        ):
+            raise WorkflowPreconditionError(
+                "cannot adopt a pull request with terminal Senpai evidence"
+            )

--- a/senpai_agent/github/workflow/responses.py
+++ b/senpai_agent/github/workflow/responses.py
@@ -46,6 +46,7 @@ class PullRequestSnapshot:
     base_ref: str
     head_ref: str
     head_sha: str
+    author: str
     labels: tuple[str, ...]
     draft: bool
     state: Literal["open", "closed"]
@@ -134,6 +135,7 @@ class PullRequestResponse(GitHubResponse):
     body: StrictStr | None
     base: GitHubRef
     head: GitHubHead
+    user: GitHubAuthor
     labels: tuple[GitHubLabel, ...]
     draft: StrictBool
     state: Literal["open", "closed"]
@@ -151,6 +153,7 @@ class PullRequestResponse(GitHubResponse):
             base_ref=self.base.ref,
             head_ref=self.head.ref,
             head_sha=self.head.sha,
+            author=self.user.login,
             labels=tuple(sorted({label.name for label in self.labels})),
             draft=self.draft,
             state=self.state,

--- a/senpai_agent/github/workflow/workflow.py
+++ b/senpai_agent/github/workflow/workflow.py
@@ -1,6 +1,7 @@
 """Public GitHub workflow client assembled from cohesive domain operations."""
 
 from senpai_agent.github.workflow.assignments import AssignmentMixin
+from senpai_agent.github.workflow.adoption import AdoptionMixin
 from senpai_agent.github.workflow.comments import CommentsMixin
 from senpai_agent.github.workflow.core import WorkflowCore
 from senpai_agent.github.workflow.issues import HumanIssueMixin
@@ -17,6 +18,7 @@ class GitHubWorkflow(
     ReviewMixin,
     ResultMixin,
     RevisionMixin,
+    AdoptionMixin,
     AssignmentMixin,
     LookupMixin,
     CommentsMixin,

--- a/system_instructions/SENPAI-HARNESS.md
+++ b/system_instructions/SENPAI-HARNESS.md
@@ -80,8 +80,8 @@ only when its named tool is present in your schema:
   next step. Call it only when browser navigation or page inspection is useful;
   loading is idempotent and persists for the conversation.
 - When present, operation-specific GitHub tools own the complete mutation they
-  name. Advisors may receive `create_assignment`, `publish_advisor_branch`,
-  `repair_assignment_routing`, `send_assignment_feedback`,
+  name. Advisors may receive `create_assignment`, `adopt_assignment`,
+  `publish_advisor_branch`, `repair_assignment_routing`, `send_assignment_feedback`,
   `request_assignment_revision`, `accept_result_on_current_base`,
   `merge_experiment`, and `close_experiment`. Students may receive
   `submit_experiment_result`. Both roles may receive

--- a/tests/github_workflow_support.py
+++ b/tests/github_workflow_support.py
@@ -61,6 +61,9 @@ def pull_request(
     base_ref: str = "schmidhuber",
     head_ref: str = "student-one/lower-lr",
     head_sha: str = HEAD_SHA,
+    author: str = "senpai-bot",
+    author_type: str = "Bot",
+    author_association: str = "NONE",
 ) -> dict[str, object]:
     if body is None:
         body = render_assignment_marker(
@@ -83,6 +86,9 @@ def pull_request(
         "body": body,
         "base_ref": base_ref,
         "head_ref": head_ref,
+        "author": author,
+        "author_type": author_type,
+        "author_association": author_association,
     }
 
 
@@ -375,6 +381,11 @@ class FakeGitHub:
             "html_url": self.pr["html_url"],
             "base": {"ref": self.pr["base_ref"]},
             "head": {"sha": self.pr["head_sha"], "ref": self.pr["head_ref"]},
+            "user": {
+                "login": self.pr["author"],
+                "type": self.pr["author_type"],
+            },
+            "author_association": self.pr["author_association"],
             "title": self.pr["title"],
             "body": self.pr["body"],
             "labels": [

--- a/tests/test_controller_github_advisor.py
+++ b/tests/test_controller_github_advisor.py
@@ -21,6 +21,7 @@ def pull(
     number=17,
     body="",
     head_sha=None,
+    base_ref="research",
     comments_url=None,
     updated_at="2099-07-29T18:00:00Z",
 ):
@@ -34,6 +35,7 @@ def pull(
             "ref": f"student/candidate-{number}",
             "sha": head_sha or str(number % 10) * 40,
         },
+        "base": {"ref": base_ref, "sha": "b" * 40},
         "labels": [{"name": label} for label in labels],
     }
     if comments_url is not None:
@@ -60,12 +62,13 @@ def assignment(
     base_ref="research",
     number=17,
     revision_id="revision-2",
+    student="student-1",
 ):
     return AssignmentRecord(
         repo="acme/widgets",
         assignment_id=f"assignment-{number}",
         revision_id=revision_id,
-        student="student-1",
+        student=student,
         base_ref=base_ref,
         base_sha=base_sha,
         head_ref=f"student/candidate-{number}",
@@ -79,6 +82,7 @@ def test_review_label_wakes_the_advisor_and_releases_the_student_slot(monkeypatc
         [
             pull(
                 labels=("research", "student:student-1", "status:review"),
+                body=render_assignment_marker(assignment()),
             )
         ],
         students=("student-1", "student-2"),
@@ -94,6 +98,40 @@ def test_review_label_wakes_the_advisor_and_releases_the_student_slot(monkeypatc
     assert events[0].payload["number"] == 17
     assert events[1].payload == {"student": "student-1"}
     assert events[2].payload == {"student": "student-2"}
+
+
+def test_markerless_wip_wakes_the_advisor_without_claiming_the_student_slot(
+    monkeypatch,
+):
+    advisor = mailbox(
+        monkeypatch,
+        [pull(labels=("research", "student:student-1", "status:wip"))],
+        students=("student-1",),
+    )
+
+    events = advisor.poll()
+
+    assert [event.kind for event in events] == [
+        "malformed_assignment",
+        "idle_student",
+    ]
+    assert events[0].payload["students"] == ["student-1"]
+    assert "exactly one Senpai assignment marker" in events[0].payload["error"]
+
+
+def test_markerless_review_does_not_emit_review_ready(monkeypatch):
+    advisor = mailbox(
+        monkeypatch,
+        [pull(labels=("research", "student:student-1", "status:review"))],
+        students=("student-1",),
+    )
+
+    events = advisor.poll()
+
+    assert [event.kind for event in events] == [
+        "malformed_assignment",
+        "idle_student",
+    ]
 
 
 def test_new_review_revision_at_the_same_head_wakes_the_advisor(monkeypatch):
@@ -140,7 +178,7 @@ def test_review_event_ignores_mutable_pull_presentation(monkeypatch):
     assert repeated.to_prompt() == first.to_prompt()
 
 
-def test_review_event_versions_a_branch_rename_at_the_same_head(monkeypatch):
+def test_review_branch_rename_is_reported_as_a_malformed_assignment(monkeypatch):
     reviewed_pull = pull(
         labels=("research", "student:student-1", "status:review"),
         body=render_assignment_marker(assignment()),
@@ -150,10 +188,15 @@ def test_review_event_versions_a_branch_rename_at_the_same_head(monkeypatch):
     first = next(event for event in advisor.poll() if event.kind == "review_ready")
 
     reviewed_pull["head"]["ref"] = "student/renamed-candidate"
-    renamed = next(event for event in advisor.poll() if event.kind == "review_ready")
+    events = advisor.poll()
+    malformed = next(
+        event for event in events if event.kind == "malformed_assignment"
+    )
 
-    assert renamed.dedupe_key != first.dedupe_key
-    assert renamed.payload["head_ref"] == "student/renamed-candidate"
+    assert "review_ready" not in {event.kind for event in events}
+    assert malformed.dedupe_key != first.dedupe_key
+    assert malformed.payload["head_ref"] == "student/renamed-candidate"
+    assert "head_ref" in malformed.payload["error"]
 
 
 @pytest.mark.parametrize(
@@ -253,8 +296,16 @@ def test_duplicate_assignments_report_every_pr_for_the_student(monkeypatch):
     advisor = mailbox(
         monkeypatch,
         [
-            pull(labels=("student:student-1", "status:wip"), number=17),
-            pull(labels=("student:student-1", "status:wip"), number=18),
+            pull(
+                labels=("student:student-1", "status:wip"),
+                number=17,
+                body=render_assignment_marker(assignment(number=17)),
+            ),
+            pull(
+                labels=("student:student-1", "status:wip"),
+                number=18,
+                body=render_assignment_marker(assignment(number=18)),
+            ),
         ],
         students=("student-1",),
     )
@@ -265,6 +316,39 @@ def test_duplicate_assignments_report_every_pr_for_the_student(monkeypatch):
 
     assert duplicate.dedupe_key == "duplicate_assignment:student-1:17,18"
     assert duplicate.payload["pull_requests"] == [17, 18]
+
+
+def test_malformed_wip_does_not_turn_one_valid_assignment_into_a_duplicate(
+    monkeypatch,
+):
+    advisor = mailbox(
+        monkeypatch,
+        [
+            pull(
+                labels=("student:student-1", "status:wip"),
+                number=17,
+                body=render_assignment_marker(assignment(number=17)),
+            ),
+            pull(labels=("student:student-1", "status:wip"), number=18),
+        ],
+        students=("student-1",),
+    )
+    monkeypatch.setattr(
+        advisor._github,
+        "get",
+        lambda _path: {"object": {"sha": "b" * 40}},
+    )
+
+    events = advisor.poll()
+
+    malformed_numbers = [
+        event.payload["number"]
+        for event in events
+        if event.kind == "malformed_assignment"
+    ]
+    assert malformed_numbers == [18]
+    assert "duplicate_assignment" not in {event.kind for event in events}
+    assert "idle_student" not in {event.kind for event in events}
 
 
 def test_research_base_change_uses_the_fresh_live_branch_head_on_each_poll(
@@ -342,7 +426,9 @@ def test_research_base_event_ignores_mutable_pull_presentation(monkeypatch):
     assert repeated.to_prompt() == first.to_prompt()
 
 
-def test_research_base_event_versions_a_branch_rename_at_the_same_head(monkeypatch):
+def test_research_base_branch_rename_is_reported_as_a_malformed_assignment(
+    monkeypatch,
+):
     assigned_pull = pull(
         labels=("research", "student:student-1", "status:wip"),
         body=render_assignment_marker(assignment(base_sha="b" * 40)),
@@ -359,12 +445,15 @@ def test_research_base_event_versions_a_branch_rename_at_the_same_head(monkeypat
     )
 
     assigned_pull["head"]["ref"] = "student/renamed-candidate"
-    renamed = next(
-        event for event in advisor.poll() if event.kind == "research_base_changed"
+    events = advisor.poll()
+    malformed = next(
+        event for event in events if event.kind == "malformed_assignment"
     )
 
-    assert renamed.dedupe_key != first.dedupe_key
-    assert renamed.payload["head_ref"] == "student/renamed-candidate"
+    assert "research_base_changed" not in {event.kind for event in events}
+    assert malformed.dedupe_key != first.dedupe_key
+    assert malformed.payload["head_ref"] == "student/renamed-candidate"
+    assert "head_ref" in malformed.payload["error"]
 
 
 def terminal_result(*, summary="The candidate remains valid."):
@@ -716,13 +805,19 @@ def test_each_assignment_watches_its_own_research_base_ref(monkeypatch):
                 body=render_assignment_marker(
                     assignment(base_ref="research-a", number=17)
                 ),
+                base_ref="research-a",
             ),
             pull(
                 number=18,
                 labels=("research-b", "student:student-2", "status:wip"),
                 body=render_assignment_marker(
-                    assignment(base_ref="research-b", number=18)
+                    assignment(
+                        base_ref="research-b",
+                        number=18,
+                        student="student-2",
+                    )
                 ),
+                base_ref="research-b",
             ),
         ],
     )

--- a/tests/test_controller_github_feedback.py
+++ b/tests/test_controller_github_feedback.py
@@ -451,6 +451,28 @@ def test_student_does_not_launch_a_doubly_labeled_assignment(monkeypatch):
     assert "exactly one student label" in events[0].payload["error"]
 
 
+def test_malformed_wip_does_not_suppress_a_valid_student_assignment(monkeypatch):
+    mailbox = student_mailbox(monkeypatch, feedback_responses())
+    valid = mailbox._pulls()[0]
+    malformed = {
+        **valid,
+        "number": 18,
+        "html_url": "https://github.test/acme/widgets/pull/18",
+        "body": "",
+        "head": {"ref": "student/candidate-18", "sha": "8" * 40},
+    }
+    monkeypatch.setattr(mailbox, "_pulls", lambda: [valid, malformed])
+
+    events = mailbox.poll()
+
+    assert [event.kind for event in events] == [
+        "malformed_assignment",
+        "student_assignment",
+    ]
+    assert events[0].payload["number"] == 18
+    assert events[1].payload["number"] == 17
+
+
 def test_student_does_not_launch_an_assignment_marked_for_another_student(
     monkeypatch,
 ):

--- a/tests/test_git_workflow_assignment.py
+++ b/tests/test_git_workflow_assignment.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 import senpai_agent.git_workflow as git_workflow
+from senpai_agent.git_assignment import require_remote_assignment_history
 from senpai_agent.git_workflow import (
     GitWorkflowPreconditionError,
     create_assignment_branch,
@@ -108,3 +109,97 @@ def test_create_assignment_branch_rejects_a_base_that_moves_during_fetch(
         )
 
     assert git(remote, "branch", "--list", "student-one/lower-lr") == ""
+
+
+def test_require_remote_assignment_history_accepts_work_after_an_older_base(
+    tmp_path: Path,
+):
+    workspace, remote, base_sha = advisor_repository(tmp_path)
+    git(workspace, "checkout", "-b", "student-one/lower-lr")
+    head_sha = commit_file(workspace, "candidate.py", "candidate = True\n", "candidate")
+    git(workspace, "push", "origin", "student-one/lower-lr")
+    advanced_base = detached_commit(workspace, base_sha, "advance base")
+    git(workspace, "push", str(remote), f"{advanced_base}:refs/heads/schmidhuber")
+
+    require_remote_assignment_history(
+        workspace,
+        branch="student-one/lower-lr",
+        expected_head_sha=head_sha,
+        base_branch="schmidhuber",
+        expected_base_sha=base_sha,
+    )
+
+
+def test_require_remote_assignment_history_rejects_an_unknown_head(tmp_path: Path):
+    workspace, _remote, base_sha = advisor_repository(tmp_path)
+    git(workspace, "checkout", "-b", "student-one/lower-lr")
+    commit_file(workspace, "candidate.py", "candidate = True\n", "candidate")
+    git(workspace, "push", "origin", "student-one/lower-lr")
+
+    with pytest.raises(GitWorkflowPreconditionError, match="fetched Git commits"):
+        require_remote_assignment_history(
+            workspace,
+            branch="student-one/lower-lr",
+            expected_head_sha="f" * 40,
+            base_branch="schmidhuber",
+            expected_base_sha=base_sha,
+        )
+
+
+def test_require_remote_assignment_history_rejects_foreign_history(tmp_path: Path):
+    workspace, _remote, base_sha = advisor_repository(tmp_path)
+    tree = git(workspace, "rev-parse", f"{base_sha}^{{tree}}")
+    unrelated = git(workspace, "commit-tree", tree, "-m", "unrelated root")
+    git(workspace, "checkout", "--detach", unrelated)
+    head_sha = commit_file(workspace, "candidate.py", "candidate = True\n", "candidate")
+    git(workspace, "push", "origin", f"{head_sha}:refs/heads/student-one/lower-lr")
+
+    with pytest.raises(GitWorkflowPreconditionError, match="does not share"):
+        require_remote_assignment_history(
+            workspace,
+            branch="student-one/lower-lr",
+            expected_head_sha=head_sha,
+            base_branch="schmidhuber",
+            expected_base_sha=base_sha,
+        )
+
+
+def test_require_remote_assignment_history_accepts_a_replayed_ancestor_head(
+    tmp_path: Path,
+):
+    workspace, _remote, base_sha = advisor_repository(tmp_path)
+    git(workspace, "checkout", "-b", "student-one/lower-lr")
+    expected_head = commit_file(
+        workspace, "candidate.py", "candidate = True\n", "candidate"
+    )
+    commit_file(workspace, "notes.md", "continued work\n", "continue")
+    git(workspace, "push", "origin", "student-one/lower-lr")
+
+    require_remote_assignment_history(
+        workspace,
+        branch="student-one/lower-lr",
+        expected_head_sha=expected_head,
+        base_branch="schmidhuber",
+        expected_base_sha=base_sha,
+    )
+
+
+def test_require_remote_assignment_history_rejects_an_older_ancestral_base(
+    tmp_path: Path,
+):
+    workspace, remote, old_base = advisor_repository(tmp_path)
+    current_base = detached_commit(workspace, old_base, "advance base")
+    git(workspace, "push", str(remote), f"{current_base}:refs/heads/schmidhuber")
+    git(workspace, "checkout", "--detach", current_base)
+    git(workspace, "checkout", "-b", "student-one/lower-lr")
+    head_sha = commit_file(workspace, "candidate.py", "candidate = True\n", "candidate")
+    git(workspace, "push", "origin", "student-one/lower-lr")
+
+    with pytest.raises(GitWorkflowPreconditionError, match="diverges at"):
+        require_remote_assignment_history(
+            workspace,
+            branch="student-one/lower-lr",
+            expected_head_sha=head_sha,
+            base_branch="schmidhuber",
+            expected_base_sha=old_base,
+        )

--- a/tests/test_github_operator.py
+++ b/tests/test_github_operator.py
@@ -1,0 +1,261 @@
+import io
+import json
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from senpai_agent.github import operator
+from senpai_agent.github.tools import (
+    AdoptAssignmentAction,
+    CreateAssignmentAction,
+    GitHubMutationObservation,
+)
+from senpai_agent.github.workflow import MutationResult
+
+
+ENVIRONMENT = {
+    "GH_REPO": "acme/widgets",
+    "GITHUB_TOKEN": "operator-secret",
+    "SENPAI_GITHUB_ACTOR": "senpai-bot",
+}
+
+
+def command(workspace: Path, operation: str, source: str) -> list[str]:
+    return [
+        "--workspace",
+        str(workspace),
+        "--advisor-branch",
+        "advisor-branch",
+        "--student-names",
+        "student-one,student-two",
+        operation,
+        source,
+    ]
+
+
+def create_action() -> CreateAssignmentAction:
+    return CreateAssignmentAction(
+        assignment_id="assignment-18",
+        revision_id="revision-1",
+        student="student-one",
+        expected_base_sha="b" * 40,
+        head_branch="student-one/lower-lr",
+        title="Try a lower learning rate",
+        body="Run one bounded comparison.",
+    )
+
+
+def adopt_action() -> AdoptAssignmentAction:
+    return AdoptAssignmentAction(
+        pr_number=17,
+        assignment_id="assignment-17",
+        revision_id="revision-1",
+        student="student-two",
+        expected_base_sha="b" * 40,
+        head_branch="student-two/existing-experiment",
+        expected_pr_head_sha="c" * 40,
+    )
+
+
+def install_recorders(monkeypatch: pytest.MonkeyPatch):
+    calls = []
+
+    class Workflow:
+        def __init__(self, repo, token, **kwargs):
+            self.repo = repo
+            calls.append(("workflow", repo, token, kwargs))
+
+    def executor(name):
+        class RecordingExecutor:
+            def __init__(self, runtime):
+                self.runtime = runtime
+
+            def __call__(self, action):
+                calls.append((name, self.runtime, action))
+                return GitHubMutationObservation(
+                    changed=True,
+                    resource_url="https://github.test/acme/widgets/pull/17",
+                    state=name,
+                    version="c" * 40,
+                )
+
+        return RecordingExecutor
+
+    monkeypatch.setattr(operator, "GitHubWorkflow", Workflow)
+    monkeypatch.setattr(
+        operator, "CreateAssignmentExecutor", executor("assignment_created")
+    )
+    monkeypatch.setattr(
+        operator, "AdoptAssignmentExecutor", executor("assignment_adopted")
+    )
+    return calls
+
+
+def test_create_assignment_reads_json_file_and_uses_the_typed_executor(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    calls = install_recorders(monkeypatch)
+    source = tmp_path / "action.json"
+    source.write_text(create_action().model_dump_json(), encoding="utf-8")
+    output = io.StringIO()
+
+    assert operator.operator_main(
+        command(tmp_path, "create-assignment", str(source)),
+        environment=ENVIRONMENT,
+        stdout=output,
+    ) == 0
+
+    _, repo, token, workflow_options = calls[0]
+    name, runtime, action = calls[1]
+    assert repo == "acme/widgets"
+    assert token.get_secret_value() == "operator-secret"
+    assert workflow_options == {"role": "advisor", "trusted_actor": "senpai-bot"}
+    assert name == "assignment_created"
+    assert runtime.workspace == tmp_path.resolve()
+    assert runtime.advisor_branch == "advisor-branch"
+    assert runtime.student_names == frozenset({"student-one", "student-two"})
+    assert action == create_action()
+    assert json.loads(output.getvalue()) == {
+        "changed": True,
+        "resource_url": "https://github.test/acme/widgets/pull/17",
+        "state": "assignment_created",
+        "version": "c" * 40,
+    }
+    assert "operator-secret" not in output.getvalue()
+
+
+def test_adopt_assignment_reads_stdin_and_uses_the_typed_executor(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    calls = install_recorders(monkeypatch)
+    output = io.StringIO()
+
+    assert operator.operator_main(
+        command(tmp_path, "adopt-assignment", "-"),
+        environment={"GH_REPO": "acme/widgets", "GH_TOKEN": "fallback-secret"},
+        stdin=io.StringIO(adopt_action().model_dump_json()),
+        stdout=output,
+    ) == 0
+
+    _, _, token, workflow_options = calls[0]
+    name, runtime, action = calls[1]
+    assert token.get_secret_value() == "fallback-secret"
+    assert workflow_options == {"role": "advisor", "trusted_actor": None}
+    assert name == "assignment_adopted"
+    assert runtime.git_token is token
+    assert action == adopt_action()
+    assert "fallback-secret" not in output.getvalue()
+
+
+def test_operator_adoption_runs_the_real_guarded_executor(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    calls = []
+
+    class Workflow:
+        repo = "acme/widgets"
+
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        @contextmanager
+        def serialized_assignment_mutation(self):
+            calls.append("lock_enter")
+            yield
+            calls.append("lock_exit")
+
+        def adopt_assignment(self, number, *, assignment):
+            calls.append(("adopt", number, assignment))
+            return MutationResult(
+                changed=True,
+                resource_url=f"https://github.test/pull/{number}",
+                state="assignment_adopted",
+                version=assignment.head_sha,
+            )
+
+    monkeypatch.setattr(operator, "GitHubWorkflow", Workflow)
+    monkeypatch.setattr(
+        "senpai_agent.github.tools.advisor.git_assignment.require_remote_assignment_history",
+        lambda *_args, **kwargs: calls.append(("history", kwargs)),
+    )
+
+    assert operator.operator_main(
+        command(tmp_path, "adopt-assignment", "-"),
+        environment=ENVIRONMENT,
+        stdin=io.StringIO(adopt_action().model_dump_json()),
+        stdout=io.StringIO(),
+    ) == 0
+
+    assert calls[0] == "lock_enter"
+    assert calls[1][0] == "history"
+    assert calls[2][0] == "adopt"
+    assert calls[2][2].assignment_id == "assignment-17"
+    assert calls[3][0] == "history"
+    assert calls[4] == "lock_exit"
+
+
+@pytest.mark.parametrize(
+    ("environment", "message"),
+    [
+        ({"GITHUB_TOKEN": "secret"}, "GH_REPO must use owner/name form"),
+        ({"GH_REPO": "acme/widgets"}, "GITHUB_TOKEN or GH_TOKEN is required"),
+    ],
+)
+def test_operator_requires_environment_only_github_authority(
+    environment: dict[str, str],
+    message: str,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+):
+    with pytest.raises(SystemExit) as raised:
+        operator.operator_main(
+            command(tmp_path, "create-assignment", "-"),
+            environment=environment,
+            stdin=io.StringIO(create_action().model_dump_json()),
+        )
+
+    assert raised.value.code == 2
+    assert message in capsys.readouterr().err
+
+
+def test_operator_rejects_a_student_outside_its_allowlist_before_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+):
+    class Workflow:
+        repo = "acme/widgets"
+
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def serialized_assignment_mutation(self):
+            pytest.fail("mutation lock reached")
+
+    monkeypatch.setattr(operator, "GitHubWorkflow", Workflow)
+    action = create_action().model_copy(update={"student": "other-student"})
+
+    with pytest.raises(SystemExit) as raised:
+        operator.operator_main(
+            command(tmp_path, "create-assignment", "-"),
+            environment=ENVIRONMENT,
+            stdin=io.StringIO(action.model_dump_json()),
+        )
+
+    assert raised.value.code == 2
+    error = capsys.readouterr().err
+    assert "outside this launch" in error
+    assert "operator-secret" not in error
+
+
+def test_operator_has_no_credential_argument():
+    help_text = operator.build_parser().format_help()
+
+    assert "--token" not in help_text
+    with pytest.raises(SystemExit):
+        operator.build_parser().parse_args(["--token", "secret"])

--- a/tests/test_github_workflow_assignments.py
+++ b/tests/test_github_workflow_assignments.py
@@ -11,6 +11,7 @@ from senpai_agent.github.workflow import (
 from senpai_agent.models import render_assignment_marker, render_result_comment
 from github_workflow_support import (
     ASSIGNMENT_ID,
+    AmbiguousMutationGitHub,
     BASE_SHA,
     HEAD_SHA,
     FakeGitHub,
@@ -136,6 +137,225 @@ def test_create_assignment_allows_a_review_ready_pull_for_the_student():
     assert result.changed is True
     assert {"student:student-one", "status:wip"}.issubset(fake.pr["labels"])
     assert "status:review" not in fake.pr["labels"]
+
+
+def test_adopt_assignment_adds_one_marker_and_replays_without_rewriting():
+    assignment = assignment_record()
+    visible_body = "Run the bounded learning-rate experiment."
+    fake = FakeGitHub(
+        pull_request(
+            labels={"schmidhuber", "student:student-one", "status:wip", "keep"},
+            draft=True,
+            body=visible_body,
+        )
+    )
+    client = workflow(fake)
+
+    first = client.adopt_assignment(7, assignment)
+    mutations_after_first = list(fake.mutations)
+    second = client.adopt_assignment(7, assignment)
+
+    assert first.changed is True
+    assert second.changed is False
+    assert first.state == "assignment_adopted"
+    assert fake.pr["body"] == (
+        f"{render_assignment_marker(assignment)}\n\n{visible_body}"
+    )
+    assert fake.pr["title"] == "Try lower learning rate"
+    assert fake.pr["labels"] == {
+        "schmidhuber",
+        "student:student-one",
+        "status:wip",
+        "keep",
+    }
+    assert fake.pr["draft"] is True
+    assert fake.mutations == mutations_after_first
+
+
+def test_adopt_assignment_recovers_an_ambiguous_successful_patch():
+    fake = AmbiguousMutationGitHub(
+        pull_request(
+            labels={"schmidhuber", "student:student-one", "status:wip"},
+            draft=True,
+            body="Run the bounded learning-rate experiment.",
+        ),
+        fail_method="PATCH",
+        fail_path="/repos/acme/widgets/pulls/7",
+    )
+
+    result = workflow(fake).adopt_assignment(7, assignment_record())
+
+    assert result.changed is True
+    assert fake.pr["body"].startswith(render_assignment_marker(assignment_record()))
+
+
+def test_adopt_assignment_replay_survives_student_head_progress():
+    assignment = assignment_record()
+    fake = FakeGitHub(
+        pull_request(
+            labels={"schmidhuber", "student:student-one", "status:wip"},
+            draft=True,
+            body=f"{render_assignment_marker(assignment)}\n\nRun the experiment.",
+        )
+    )
+    fake.pr["head_sha"] = "d" * 40
+
+    result = workflow(fake).adopt_assignment(7, assignment)
+
+    assert result.changed is False
+    assert result.version == "d" * 40
+    assert fake.mutations == []
+
+
+def test_adopt_assignment_accepts_head_progress_after_marker_patch():
+    class AdvancingPatchGitHub(FakeGitHub):
+        def request(self, method, url, *, headers, json_body=None):
+            response = super().request(
+                method,
+                url,
+                headers=headers,
+                json_body=json_body,
+            )
+            if method == "PATCH" and url.endswith("/pulls/7"):
+                self.pr["head_sha"] = "d" * 40
+            return response
+
+    fake = AdvancingPatchGitHub(
+        pull_request(
+            labels={"schmidhuber", "student:student-one", "status:wip"},
+            draft=True,
+            body="Run the experiment.",
+        )
+    )
+
+    result = workflow(fake).adopt_assignment(7, assignment_record())
+
+    assert result.changed is True
+    assert result.version == "d" * 40
+
+
+@pytest.mark.parametrize(
+    ("changes", "error"),
+    [
+        ({"draft": False}, "draft"),
+        ({"labels": {"schmidhuber", "student:student-one", "status:review"}}, "status:wip"),
+        ({"labels": {"schmidhuber", "student:student-one", "student:other", "status:wip"}}, "student label"),
+        ({"labels": {"student:student-one", "status:wip"}}, "base label"),
+        ({"author": "other-user"}, "authenticated actor"),
+    ],
+)
+def test_adopt_assignment_rejects_ambiguous_pr_state_without_writing(
+    changes,
+    error,
+):
+    pr = pull_request(
+        labels={"schmidhuber", "student:student-one", "status:wip"},
+        draft=True,
+        body="Run the bounded learning-rate experiment.",
+    )
+    pr.update(changes)
+    fake = FakeGitHub(pr)
+
+    with pytest.raises(WorkflowPreconditionError, match=error):
+        workflow(fake).adopt_assignment(7, assignment_record())
+
+    assert fake.mutations == []
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        render_assignment_marker(
+            assignment_record(assignment_id="someone-elses-assignment")
+        ),
+        "<!-- senpai-assignment:v1 not-json -->",
+    ],
+)
+def test_adopt_assignment_rejects_existing_assignment_identity_without_writing(body):
+    fake = FakeGitHub(
+        pull_request(
+            labels={"schmidhuber", "student:student-one", "status:wip"},
+            draft=True,
+            body=body,
+        )
+    )
+
+    with pytest.raises(WorkflowPreconditionError, match="assignment marker"):
+        workflow(fake).adopt_assignment(7, assignment_record())
+
+    assert fake.mutations == []
+
+
+@pytest.mark.parametrize(
+    ("body", "comments", "error"),
+    [
+        (
+            "<!-- senpai-feedback:v1 {} -->\n\nRun the experiment.",
+            [],
+            "other Senpai markers",
+        ),
+        (
+            "Run the experiment.",
+            [comment(1, render_result_comment(experiment_result()))],
+            "terminal Senpai evidence",
+        ),
+    ],
+)
+def test_adopt_assignment_rejects_existing_protocol_state_without_writing(
+    body,
+    comments,
+    error,
+):
+    fake = FakeGitHub(
+        pull_request(
+            labels={"schmidhuber", "student:student-one", "status:wip"},
+            draft=True,
+            body=body,
+        ),
+        comments=comments,
+    )
+
+    with pytest.raises(WorkflowPreconditionError, match=error):
+        workflow(fake).adopt_assignment(7, assignment_record())
+
+    assert fake.mutations == []
+
+
+def test_untrusted_comment_cannot_block_assignment_adoption():
+    fake = FakeGitHub(
+        pull_request(
+            labels={"schmidhuber", "student:student-one", "status:wip"},
+            draft=True,
+            body="Run the experiment.",
+        ),
+        comments=[
+            comment(
+                1,
+                render_result_comment(experiment_result()),
+                author="outside-user",
+                association="NONE",
+            )
+        ],
+    )
+
+    result = workflow(fake).adopt_assignment(7, assignment_record())
+
+    assert result.changed is True
+
+
+def test_student_workflow_cannot_adopt_assignment_identity():
+    fake = FakeGitHub(
+        pull_request(
+            labels={"schmidhuber", "student:student-one", "status:wip"},
+            draft=True,
+            body="Run the experiment.",
+        )
+    )
+
+    with pytest.raises(WorkflowPreconditionError, match="only an advisor"):
+        workflow(fake, role="student").adopt_assignment(7, assignment_record())
+
+    assert fake.mutations == []
 
 
 def test_create_and_revision_transitions_cannot_overlap(monkeypatch):

--- a/tests/test_github_workflow_contracts.py
+++ b/tests/test_github_workflow_contracts.py
@@ -56,6 +56,7 @@ def test_pull_request_returns_an_immutable_typed_snapshot():
         head_sha=HEAD_SHA,
         base_ref="schmidhuber",
         head_ref="student-one/lower-lr",
+        author="senpai-bot",
         title="Try lower learning rate",
         body=cast(str, fake.pr["body"]),
         labels=("status:wip", "student:one"),

--- a/tests/test_openhands_tools_and_agents.py
+++ b/tests/test_openhands_tools_and_agents.py
@@ -434,6 +434,7 @@ def test_file_agent_definitions_keep_bounded_tools_and_no_github_mutations(
         "senpai_github",
         "get_prs",
         "create_assignment",
+        "adopt_assignment",
         "publish_advisor_branch",
         "repair_assignment_routing",
         "send_assignment_feedback",

--- a/tests/test_tools_github_access.py
+++ b/tests/test_tools_github_access.py
@@ -27,6 +27,7 @@ ADVISOR_GITHUB_TOOLS = {
     "get_prs",
     "respond_to_human_issue",
     "create_assignment",
+    "adopt_assignment",
     "publish_advisor_branch",
     "repair_assignment_routing",
     "send_assignment_feedback",

--- a/tests/test_tools_github_schema.py
+++ b/tests/test_tools_github_schema.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError
 
 from senpai_agent.github.tools import (
     AcceptResultOnCurrentBaseTool,
+    AdoptAssignmentTool,
     CloseExperimentTool,
     CreateAssignmentTool,
     GitHubToolRuntime,
@@ -30,6 +31,15 @@ EXPECTED_FIELDS = {
         "head_branch",
         "title",
         "body",
+    },
+    "adopt_assignment": {
+        "pr_number",
+        "assignment_id",
+        "revision_id",
+        "student",
+        "expected_base_sha",
+        "head_branch",
+        "expected_pr_head_sha",
     },
     "publish_advisor_branch": {
         "remote_branch_sha_before_push",
@@ -80,6 +90,7 @@ def github_tools(tmp_path: Path):
     )
     tool_types = (
         CreateAssignmentTool,
+        AdoptAssignmentTool,
         PublishAdvisorBranchTool,
         RepairAssignmentRoutingTool,
         SendAssignmentFeedbackTool,

--- a/tests/test_tools_github_transitions.py
+++ b/tests/test_tools_github_transitions.py
@@ -7,6 +7,8 @@ from senpai_agent.git_workflow import PushResult
 from senpai_agent.github.tools import (
     AcceptResultOnCurrentBaseAction,
     AcceptResultOnCurrentBaseTool,
+    AdoptAssignmentAction,
+    AdoptAssignmentTool,
     AssignmentVersion,
     CloseExperimentAction,
     CloseExperimentTool,
@@ -155,6 +157,101 @@ def test_create_assignment_rejects_students_outside_the_launch_before_mutation(
 
     with pytest.raises(PermissionError, match="outside this launch"):
         tool(action)
+
+    assert workflow.calls == []
+
+
+def test_adopt_assignment_verifies_remote_history_before_attaching_identity(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    workflow = RecordingWorkflow()
+    history_calls = []
+
+    def require_history(workspace, **kwargs):
+        workflow.calls.append(("require_history", None, {}))
+        history_calls.append((workspace, kwargs))
+
+    monkeypatch.setattr(
+        "senpai_agent.github.tools.advisor.git_assignment.require_remote_assignment_history",
+        require_history,
+    )
+    tool = AdoptAssignmentTool.create(runtime(workflow, tmp_path))[0]
+    action = AdoptAssignmentAction(
+        pr_number=17,
+        assignment_id="assignment-18",
+        revision_id="revision-1",
+        student="student-one",
+        expected_base_sha="b" * 40,
+        head_branch="student-one/lower-lr",
+        expected_pr_head_sha="c" * 40,
+    )
+
+    observation = tool(action)
+
+    assert observation.state == "adopt_assignment"
+    assert history_calls == [
+        (
+            tmp_path,
+            {
+                "branch": "student-one/lower-lr",
+                "expected_head_sha": "c" * 40,
+                "base_branch": "advisor-branch",
+                "expected_base_sha": "b" * 40,
+                "token": None,
+            },
+        ),
+        (
+            tmp_path,
+            {
+                "branch": "student-one/lower-lr",
+                "expected_head_sha": "c" * 40,
+                "base_branch": "advisor-branch",
+                "expected_base_sha": "b" * 40,
+                "token": None,
+            },
+        ),
+    ]
+    assert [call[0] for call in workflow.calls] == [
+        "lock_enter",
+        "require_history",
+        "adopt_assignment",
+        "require_history",
+        "lock_exit",
+    ]
+    _, number, fields = workflow.calls[2]
+    adopted = fields["assignment"]
+    assert number == 17
+    assert adopted.repo == "acme/widgets"
+    assert adopted.base_ref == "advisor-branch"
+    assert adopted.base_sha == "b" * 40
+    assert adopted.head_ref == "student-one/lower-lr"
+    assert adopted.head_sha == "c" * 40
+
+
+def test_adopt_assignment_rejects_unconfigured_student_before_git_or_github(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    workflow = RecordingWorkflow()
+    monkeypatch.setattr(
+        "senpai_agent.github.tools.advisor.git_assignment.require_remote_assignment_history",
+        lambda *_args, **_kwargs: pytest.fail("git verification reached"),
+    )
+    tool = AdoptAssignmentTool.create(runtime(workflow, tmp_path))[0]
+
+    with pytest.raises(PermissionError, match="outside this launch"):
+        tool(
+            AdoptAssignmentAction(
+                pr_number=17,
+                assignment_id="assignment-18",
+                revision_id="revision-1",
+                student="student-outside-launch",
+                expected_base_sha="b" * 40,
+                head_branch="student-outside-launch/lower-lr",
+                expected_pr_head_sha="c" * 40,
+            )
+        )
 
     assert workflow.calls == []
 


### PR DESCRIPTION
## Summary

- add an explicit advisor/operator-only `adopt_assignment` transition for an existing markerless assignment PR
- verify the authenticated PR author, configured routing, exact branch point, remote head ancestry, and absence of conflicting protocol state before and after adoption
- make successful adoption idempotent when a student legitimately advances the branch
- emit `malformed_assignment` to advisors and count only marker-valid assignments as active or duplicate work
- expose `create-assignment` and `adopt-assignment` through one operator CLI that calls the same typed executors as OpenHands
- clarify that `repair_assignment_routing` repairs labels and draft state only; it cannot create assignment identity

## Root cause

An operator-created PR could receive the normal student and WIP labels while bypassing `create_assignment`, leaving it without the canonical assignment marker. Students detected the invalid state, but advisors neither received that failure nor had a safe operation to adopt the PR. Raw labels also made the malformed PR appear to occupy a healthy student slot.

This change keeps the harness boundary narrow: it validates identity and routing, reports invalid state, and offers one explicit repair operation. It does not infer assignments from prose or automatically mutate malformed PRs.

## Safety and recovery behavior

- adoption is advisor-only and restricted to configured students and the configured advisor base
- the PR must be authored by the authenticated actor, open, draft, WIP, uniquely routed, and markerless
- the supplied base must be the exact merge base of the advisor and assignment branches, not merely an older ancestor
- the expected head may be an ancestor only when reconciling a replay after legitimate student progress; the first marker write still requires the exact current PR head
- remote Git history is checked both before and after the marker transition
- terminal result/disposition state and conflicting markers fail closed
- the existing human-readable PR body and unrelated labels are preserved
- GitHub PR body writes have no lease in this client, so concurrent body edits remain explicitly unsupported and documented

## Validation

- `uv run --extra dev pytest -q --maxfail=1` — 926 passed, 6 skipped
- `git diff --check`
- `python -m compileall -q senpai_agent`

This PR is intentionally not rolled out to any live advisor or student deployment. It also does not perform the one-time repair for the existing Maple PRs.
